### PR TITLE
chore: remove effort field, fix stale refs, add 9 new skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 __pycache__/
 .bak/
+.pi/state/

--- a/.pi/agents/pipelines.yaml
+++ b/.pi/agents/pipelines.yaml
@@ -1,0 +1,17 @@
+repo-foundation-v1:
+  description: "Explore repo context, design focused Pi setup, and pressure-test before apply"
+  steps:
+    - agent: planner
+      prompt: "Investigate repository workflow context and propose a focused Pi foundation for: $INPUT"
+    - agent: reviewer
+      prompt: "Stress-test this foundation design for risks, blind spots, and maintainability: \n\n$INPUT"
+
+repo-delivery-v1:
+  description: "Plan -> implement -> review loop for day-to-day engineering work"
+  steps:
+    - agent: planner
+      prompt: "Plan the implementation for: $INPUT"
+    - agent: worker
+      prompt: "Implement with focused scope and run relevant checks (repo checks):\n\n$INPUT"
+    - agent: reviewer
+      prompt: "Review for correctness, quality gates, and maintainability:\n\n$INPUT"

--- a/.pi/agents/planner.md
+++ b/.pi/agents/planner.md
@@ -1,0 +1,22 @@
+---
+name: planner
+description: agent-skills planning specialist grounded in repo-native constraints and delivery goals
+tools: read, grep, find, ls, bash
+---
+
+Role: repo-local planner.
+Objective: convert intent into a focused implementation design that matches this repository's workflow reality.
+Latitude: explore context broadly, then compress into a minimal executable plan.
+Use `.pi/persona.md` as the base local persona contract.
+
+Success criteria:
+- align with package manager: unknown
+- align with stack hints: none
+- align with quality scripts: none
+
+Output contract:
+1. Goal
+2. Proposed approach
+3. Files and deltas
+4. Verification plan
+5. Risks and tradeoffs

--- a/.pi/agents/reviewer.md
+++ b/.pi/agents/reviewer.md
@@ -1,0 +1,20 @@
+---
+name: reviewer
+description: agent-skills review specialist for correctness, quality gates, and long-term maintainability
+tools: read, grep, find, ls, bash
+---
+
+Role: final reviewer.
+Objective: detect correctness, risk, and maintainability issues before shipping.
+Latitude: be concise, specific, and severity-driven.
+Use `.pi/persona.md` as the base local persona contract.
+
+Review focus:
+- stack hints: none
+- quality scripts: none
+
+Output contract:
+1. ✅ What is solid
+2. ⚠️ Findings (severity + path)
+3. 🔧 Required fixes
+4. 🚀 Ready / not-ready verdict

--- a/.pi/agents/teams.yaml
+++ b/.pi/agents/teams.yaml
@@ -1,0 +1,9 @@
+foundation:
+  - planner
+  - worker
+  - reviewer
+
+delivery:
+  - planner
+  - worker
+  - reviewer

--- a/.pi/agents/worker.md
+++ b/.pi/agents/worker.md
@@ -1,0 +1,20 @@
+---
+name: worker
+description: agent-skills implementation specialist for high-signal, low-bloat execution
+tools: read, grep, find, ls, bash, edit, write
+---
+
+Role: repo-local implementer.
+Objective: execute approved scope with precision, explicit verification, and minimal collateral change.
+Latitude: use engineering judgment, but keep diffs auditable and focused.
+Use `.pi/persona.md` as the base local persona contract.
+
+Success criteria:
+- uses local tooling (unknown) and quality scripts when relevant
+- no speculative refactors
+- clear changed-file summary and residual risk callout
+
+Output contract:
+1. What changed
+2. Verification run
+3. Risks / follow-ups

--- a/.pi/bootstrap-report.md
+++ b/.pi/bootstrap-report.md
@@ -1,0 +1,276 @@
+# Pi Bootstrap Report
+
+- Domain: agent-skills
+- Repo: /Users/phaedrus/Development/agent-skills
+- Generated: 2026-03-02T15:52:10.837Z
+- Package manager: unknown
+- Stack hints: none
+
+## Notes
+- Fallback plan used because synthesis was unavailable or invalid.
+
+## Repository Context Digest
+contextSnippets:
+[CLAUDE.md]
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repo Is
+
+A unified skills monorepo (~74 skills) for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first (with helper scripts) — no application code, no tests, no CI. Skills are distributed to agent harnesses via symlinks.
+
+## Repo Structure
+
+```
+agent-skills/
+├── core/           # ~74 skills, synced to ~/.claude/skills/
+│   ├── groom/
+│   ├── autopilot/
+│   ├── build/
+│   └── ...
+├── packs/          # Domain packs, loaded per-project on demand
+├── scripts/
+│   └── sync.sh
+└── CLAUDE.md
+```
+
+## Key Commands
+
+```bash
+# Sync core skills to agent harnesses
+./scripts/sync.sh claude            # → ~/.claude/skills/
+./scripts/sync.sh codex             # → ~/.codex/skills/ (skips .system)
+./scripts/sync.sh gemini            # → ~/.gemini/skills/
+./scripts/sync.sh all               # All harnesses
+./scripts/sync.sh claude --dry-run  # Preview without changes
+
+# Prune stale symlinks (for deleted skills)
+./scripts/sync.sh --prune claude
+./scripts/sync.sh --prune all
+
+# Load a domain pack into a project
+./scripts/sync.sh pack marketing ~/Development/myproject
+./scripts/sync.sh pack marketing --global
+```
+
+No build, lint, or test commands — this repo is documentation only.
+
+## Skill Directory Convention
+
+Every skill lives in `core/{skill-name}/` with a required `SKILL.md`:
+
+```
+core/{skill-name}/
+├── SKILL.md          # Required. Frontmat
+
+.claude inventory:
+(none)
+
+.codex inventory:
+(none)
+
+.pi inventory:
+.pi/state/session-handoff.json, .pi/state/session-handoff.ndjson
+
+scripts inventory:
+scripts/sync.sh
+
+## Single Highest-Leverage Addition
+- Idea: Establish a minimal planner -> worker -> reviewer local workflow loop that compounds repo familiarity through memory-first context reuse.
+- Source lane: ambition-pass
+- Why now: This creates immediate throughput gains with low maintenance while preserving room for optional advanced overlays.
+- 72h validation experiment: Run this bootstrap on two active tasks, then compare plan-to-merge latency and rework churn against the prior baseline.
+- Kill criteria: If cycle time or defect/rework metrics worsen by more than 15%, roll back to prior local config and revisit assumptions.
+
+## Lane Evidence
+## repo-scout
+- model: openai-codex/gpt-5.3-codex
+- thinking: xhigh
+- status: ok
+- elapsed: 11s
+
+(no output)
+
+---
+
+## context-bridge
+- model: openrouter/anthropic/claude-sonnet-4.6
+- thinking: high
+- status: ok
+- elapsed: 72s
+
+Now I have a complete picture. Here's the analysis:
+
+---
+
+## Existing Context Signals
+
+### CLAUDE.md (primary context file)
+- Authoritative repo orientation: ~74 skills, Markdown-first, no code/tests/CI
+- Documents 3 invocation modes + budget model (critical architecture constraint)
+- Core delivery pipeline: `groom → shape → autopilot → pr-fix → pr-polish → merge`
+- Skill directory convention (`SKILL.md` frontmatter, no `README.md`)
+- Sync workflow: `./scripts/sync.sh {claude|codex|gemini|pi|all}`
+- Principles: deep modules, compose-don't-duplicate, budget-aware, agent-agnostic
+
+### `scripts/sync.sh`
+- Pi target is **already wired**: `do_pi()` syncs 4 shared skills (`agent-browser`, `dogfood`, `skill-creator`, `design`) to `~/Development/pi-agent-config/skills`
+- That Pi path (`pi-agent-config`) is a separate repo — this repo feeds into it, not directly into `~/.pi/`
+- Prune logic for all harnesses (Pi not included in prune, only sync)
+
+### `.pi/` state
+- Only `state/session-handoff.json` + `.ndjson` — session just started, no notes/prior tools
+- No `AGENTS.md`, no Pi-specific config, no commands, no extensions
+
+### `core/` skill inventory
+- 83 total skills, 48 DMI, 14 reference (auto-load), ~21 model+user
+- Pi-native skills already live here: `agentic-bootstrap`, `organic-reflection`, `skill-builder`, `skill-creator`
+- `thinktank`, `delegate`, `agent-browser`, `dogfood`, `llm-communication` — high Pi relevance
+- `llm-semantic-match.md` at repo root — a reference doc/pattern, not a skill
+
+### What's absent
+- No `AGENTS.md` at repo root (contrast: CLAUDE.md exists)
+- No `.pi/AGENTS.md` or `.pi/config`
+- Pi harness path points to an external repo, not `~/.pi/agent/skills/`
+- `packs/` is empty — documented feature with no current content
+
+---
+
+## Adopt / Bridge / Ignore Decisions
+
+| Signal | Decision | Rationale |
+|--------|----------|-----------|
+| **CLAUDE.md content** | **Adopt → AGENTS.md** | The repo orientation, skill conventions, budget model, and pipeline are…
+
+---
+
+## docs-research
+- model: openrouter/google/gemini-3.1-pro
+- thinking: high
+- status: ok
+- elapsed: 130s
+
+## High-Value References
+
+- **Anthropic Prompt Engineering Guide**  
+  **URL**: [https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview)  
+  **Why it matters**: Claude is a primary harness for this monorepo. Anthropic emphasizes using XML tags and treating the model as a collaborator rather than using overly defensive, brittle negative constraints (e.g., "Do NOT do X").
+
+- **Agent Skills Specification**  
+  **URL**: [https://agentskills.io/specification](https://agentskills.io/specification)  
+  **Why it matters**: Pi explicitly implements this standard. To ensure progressive disclosure works (where only the description sits in context and the file is `read` lazily), `SKILL.md` frontmatter must strictly adhere to naming (lowercase, ≤64 chars) and description limits (≤1024 chars).
+
+- **Google Gemini Prompting Strategies**  
+  **URL**: [https://ai.google.dev/gemini-api/docs/prompting-strategies](https://ai.google.dev/gemini-api/docs/prompting-strategies)  
+  **Why it matters**: Because skills mirror across multi-model harnesses (Claude, Codex, Gemini, Pi), prompting must focus on objective-based output contracts over model-specific step-by-step scripting to gracefully degrade across underlying reasoning engines.
+
+- **OpenAI Structured Outputs Guide**  
+  **URL**: [https://developers.openai.com/api/docs/guides/structured-outputs](https://developers.openai.com/api/docs/guides/structured-outputs)  
+  **Why it matters**: Instructs how to design deterministic format contracts that prevent "prompt drift" and eliminate the need for multi-pass retry logic on synthesis tasks.
+
+## Practical Implications for Agentic Workflow
+
+1. **Adopt "Role + Objective + Latitude" over Micromanagement**  
+   Replace massive procedural checklists with a clear objective and explicit latitude. Instead of writing 50 steps of how to perform an audit, state: *"You're a senior SRE. Find root c…
+
+---
+
+## workflow-critic
+- model: openrouter/anthropic/claude-sonnet-4.6
+- thinking: high
+- status: ok
+- elapsed: 235s
+
+---
+
+## Critical Failure Modes
+
+### 1. Budget cliff — silent skill drops at 96.5% capacity
+**Evidence:** 77 skills currently synced to `~/.claude/skills` consume ~15,451 of 16,000 description chars (96.5%). The README claims 12 DEFAULT (budget-consuming) skills; actual count is **21**. The 8 skills not yet synced to Claude (`agentic-bootstrap`, `github-cli-hygiene`, etc.) are DEFAULT mode — adding them would almost certainly overflow the budget and cause Claude to silently drop skills with no warning. This is the exact failure the repo was designed to prevent, and the design has already drifted past its own safety margin.
+
+### 2. Pi skills are copies, not symlinks — silent divergence in production
+**Evidence:** 10 of 17 pi-agent-config skills are filesystem copies (`COPY: agentic-bootstrap`, `COPY: pr-polish`, `COPY: skill-builder`, etc.). `sync.sh do_pi()` only manages 4 of the 17. Three are already demonstrably diverged:
+- `agentic-bootstrap`: pi copy still has the old `.pi/persona.md` pattern; core/ has the updated AGENTS.md-first architecture — the two emit **contradictory instructions** to operators.
+- `pr-polish`: pi copy has a different description, different title, different framing.
+- `skill-builder`: pi copy has `effort: high` frontmatter field and different invocation language.
+
+Pi agents are running stale, partially-overwritten skill contracts. Fixes applied in this repo don't reach Pi.
+
+### 3. `deploy` uses a non-standard frontmatter key — escapes DMI classification
+**Evidence:** `core/deploy/SKILL.md` line 9: `model-invocable: false`. The valid key is `disable-model-invocation: true`. No harness recognizes `model-invocable: false` — it's silently ignored, making `deploy` a **DEFAULT (budget-consuming) skill** when the author intended DMI. This miscounts the budget and can cause Claude to autonomously invoke deploy workflows.
+
+### 4. Stale sync is undetectable — no freshness enforcement
+**Evidence:** `sync.sh` has no `--check` or `--diff` mode. The 8 s…
+
+---
+
+## ambition-pass
+- model: openrouter/google/gemini-3-flash-preview
+- thinking: high
+- status: ok
+- elapsed: 33s
+
+## Foundation Workflow Pattern
+
+The `agent-skills` repository is unique because its product is **agent capability itself**. The foundation must treat "Instructions as Code" with the same rigors as a software library: validation, optimization, and distribution.
+
+1.  **Instruction-as-Code Audit:** Instead of manual counting, use a meta-skill to audit the "Instruction Budget" (Claude's 16k char limit).
+2.  **Density Optimization:** Systematically move verbose, non-essential instructions from "Model+User" (always loaded) to "DMI" (user-invoked) to maximize the "intelligence density" of the active context.
+3.  **Cross-Harness Validation:** Ensure a skill written for Claude doesn't break formatting or expectations for Gemini or Codex.
+
+## Prompt + Pipeline Ideas
+
+*   **The Skill Distiller Pipeline:** `Collect Execution Log` -> `Identify Redundancy` -> `Shrink SKILL.md`. Uses the `distill` philosophy to shorten skills while preserving their performance.
+*   **The "Budget Sentry" Hook:** A pre-commit or post-sync check that calculates the total character count of all `user-invocable: true` and `reference` skills, failing if it exceeds 14k chars (leaving buffer).
+*   **Skill Performance Heatmap:** A simple tracker of which skills are actually used during a session, suggesting the "archival" (DMI-ification) of unused skills to save budget.
+
+## Minimal Viable Bootstrap vs Optional Upgrades
+
+| Feature | Status | Description |
+| :--- | :--- | :--- |
+| **Repo Persona (`.pi/persona.md`)** | **Must-Have** | Defines the "Skill Architect" role: objective is max utility per character. |
+| **Budget Auditor (`/audit-budget`)** | **Must-Have** | Quantifies the 16k char constraint. Essential for monorepo health. |
+| **Sync Script (`scripts/sync.sh`)** | **Existing** | Handles distribution. Works well, keep as-is. |
+| **Synthetic Test Lab** | Optional | Simulates agent runs with a skill to "verify" logic without real code. |
+| **Multi-Agent Simulation** | Optional | Checks if Claude handl…
+
+---
+
+## implementation-critic
+- model: openrouter/anthropic/claude-sonnet-4.6
+- thinking: xhigh
+- status: ok
+- elapsed: 191s
+
+Now I have enough signal. Here's the full pressure-test report:
+
+---
+
+## Durability Risks
+
+### 1. Count/budget claims are stale and wrong
+README and CLAUDE.md both state "12 model-invocable + 14 references + 48 DMI = 74 total. Budget usage: 45%." Actual counts: **21 model+user + 14 ref + 48 DMI = 83 total**. Budget-consuming descriptions total ~8,885 chars (~56% of 16K), not 45%. Both documents will become increasingly wrong as skills are added. There is no automated check to keep these numbers honest.
+
+### 2. `observability` skill references a ghost dependency (`sentry-observability`)
+Eight lines in `core/observability/SKILL.md` call `~/.claude/skills/sentry-observability/scripts/*.sh`. The skill `sentry-observability` does not exist in this repo, so those scripts are absent at any harness unless independently installed. An operator following the skill's instructions will get `No such file or directory` with no diagnostic. The `sentry.md` reference doc exists; the scripts do not.
+
+### 3. `og-hero-image` depends on a non-existent skill (`gemini-imagegen`)
+Two script invocations in `og-hero-image/SKILL.md` target `~/.claude/skills/gemini-imagegen/scripts/`. That skill is not in this monorepo. No fallback or warning is in the skill body. The skill will silently fail for any user who doesn't happen to have that skill from elsewhere.
+
+### 4. Hardcoded `phrazzld` GitHub handle in three delivery skills
+`build/SKILL.md`, `pr/SKILL.md`, and `autopilot/SKILL.md` all hardcode `--assignee phrazzld` in GitHub CLI commands. Any operator who isn't `phrazzld` will silently mis-assign or fail if the handle doesn't exist in their org.
+
+### 5. `ousterhout` agent is invoked but undefined
+`autopilot/SKILL.md` and `build/SKILL.md` both call `ousterhout agent for module depth review`. There is no `ousterhout` skill in `core/`, no `~/.codex/agents/` reference documented here, and no fallback. This will confuse operators or silently no-op.
+
+### 6. `do_pi` sync is a hardcoded four-skill li…
+
+## Quality Gate Scorecard
+- Gate pass: yes
+- Ambition score: 85/100 (pass)
+  - novelty: 5/5
+  - feasibility: 4/5
+  - evidence: 5/5
+  - rollbackability: 3/5
+- Consensus score: 96/100 (pass)

--- a/.pi/persona.md
+++ b/.pi/persona.md
@@ -1,0 +1,22 @@
+# Local Persona
+
+Name: agent-skills-operator
+
+## Mission
+Operate as the most effective AI engineer for this repository (agent-skills) with strong local-context fit.
+
+## Behavioral posture
+- Be decisive, practical, and explicit about tradeoffs.
+- Prefer root-cause fixes and strategic simplification over patches.
+- Keep changes auditable and scoped.
+
+## Context anchors
+- Domain: agent-skills
+- Stack hints: general software
+- Package manager: unknown
+- Quality scripts: none
+
+## Delivery contract
+- Plan before non-trivial changes.
+- Verify with relevant local checks.
+- Report residual risk and follow-ups.

--- a/.pi/prompts/deliver.md
+++ b/.pi/prompts/deliver.md
@@ -1,0 +1,10 @@
+---
+description: Execute a scoped change using planner -> worker -> reviewer flow
+---
+Task: $@
+
+Preferred path:
+- If `/pipeline` is available, run `/pipeline repo-delivery-v1 $@`.
+- Otherwise execute the same flow manually using `.pi/agents/planner.md`, `.pi/agents/worker.md`, and `.pi/agents/reviewer.md`.
+
+Keep the patch focused, verify with relevant repo checks, and report residual risk.

--- a/.pi/prompts/design.md
+++ b/.pi/prompts/design.md
@@ -1,0 +1,13 @@
+---
+description: Design a focused implementation plan with explicit verification
+---
+Use `.pi/agents/planner.md` as your operating overlay.
+
+Task: $@
+
+Memory-first context warmup:
+- If `memory_context` is available, fetch a scoped context pack before finalizing the design.
+- Prefer local memory evidence first, then blend global analogs for edge-case awareness.
+
+Deliver a concise design and verification plan tailored to this repository.
+Avoid over-prescriptive checklists; prioritize clarity, tradeoffs, and execution readiness.

--- a/.pi/prompts/discover.md
+++ b/.pi/prompts/discover.md
@@ -1,0 +1,15 @@
+---
+description: Explore this repository and map high-leverage work options
+---
+Use `.pi/agents/planner.md` as your operating overlay.
+
+Task: $@
+
+Memory-first context warmup:
+- If `memory_context` is available, run it early with scope `both` and a focused query for this task.
+- Prioritize local hits; use global hits only as fallback context.
+
+Goal:
+- Investigate the codebase and workflow context deeply.
+- Surface an adopt/bridge/ignore view for existing local machinery.
+- Return only high-signal options and a recommended next move.

--- a/.pi/prompts/review.md
+++ b/.pi/prompts/review.md
@@ -1,0 +1,8 @@
+---
+description: Review current changes for correctness, risk, and merge readiness
+---
+Use `.pi/agents/reviewer.md` as your operating overlay.
+
+Review target: $@
+
+Provide severity-tagged findings, required fixes, and a clear ready/not-ready verdict.

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,19 @@
+{
+  "packages": [],
+  "extensions": [
+    "+/Users/phaedrus/.pi/agent/extensions/organic-workflows",
+    "+/Users/phaedrus/.pi/agent/extensions/profiles",
+    "+/Users/phaedrus/.pi/agent/extensions/subagent",
+    "+/Users/phaedrus/.pi/agent/extensions/orchestration",
+    "+/Users/phaedrus/.pi/agent/extensions/web-search"
+  ],
+  "skills": [],
+  "prompts": [
+    "+prompts/discover.md",
+    "+prompts/design.md",
+    "+prompts/deliver.md",
+    "+prompts/review.md"
+  ],
+  "themes": [],
+  "enableSkillCommands": false
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,11 +1,11 @@
 {
   "packages": [],
   "extensions": [
-    "+/Users/phaedrus/.pi/agent/extensions/organic-workflows",
-    "+/Users/phaedrus/.pi/agent/extensions/profiles",
-    "+/Users/phaedrus/.pi/agent/extensions/subagent",
-    "+/Users/phaedrus/.pi/agent/extensions/orchestration",
-    "+/Users/phaedrus/.pi/agent/extensions/web-search"
+    "+~/.pi/agent/extensions/organic-workflows",
+    "+~/.pi/agent/extensions/profiles",
+    "+~/.pi/agent/extensions/subagent",
+    "+~/.pi/agent/extensions/orchestration",
+    "+~/.pi/agent/extensions/web-search"
   ],
   "skills": [],
   "prompts": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+# AGENTS.md — agent-skills\n\n## Scope\n- agent-skills repository-specific Pi foundation.\n- Optimized for .\n\n## Engineering doctrine\n- Root-cause remediation over symptom patching.\n- Favor convention over configuration.\n\n## Quality bar\n- Ensure local tests pass before merge.\n- Meaningful test coverage over line-count gaming.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,13 @@
-# AGENTS.md — agent-skills\n\n## Scope\n- agent-skills repository-specific Pi foundation.\n- Optimized for .\n\n## Engineering doctrine\n- Root-cause remediation over symptom patching.\n- Favor convention over configuration.\n\n## Quality bar\n- Ensure local tests pass before merge.\n- Meaningful test coverage over line-count gaming.
+# AGENTS.md — agent-skills
+
+## Scope
+- agent-skills repository-specific Pi foundation.
+- Optimized for local agent workflows.
+
+## Engineering doctrine
+- Root-cause remediation over symptom patching.
+- Favor convention over configuration.
+
+## Quality bar
+- Ensure local tests pass before merge.
+- Meaningful test coverage over line-count gaming.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Repo Is
 
-A unified skills monorepo (~74 skills) for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first (with helper scripts) — no application code, no tests, no CI. Skills are distributed to agent harnesses via symlinks.
+A unified skills monorepo (~74 skills) for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first, with some TypeScript helper scripts and tests (e.g., `core/web-search/`). Skills are distributed to agent harnesses via symlinks.
 
 ## Repo Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Repo Is
 
-A unified skills monorepo (~74 skills) for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Pure Markdown — no application code, no tests, no CI. Skills are distributed to agent harnesses via symlinks.
+A unified skills monorepo (~74 skills) for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first (with helper scripts) — no application code, no tests, no CI. Skills are distributed to agent harnesses via symlinks.
 
 ## Repo Structure
 
@@ -62,7 +62,6 @@ No README.md in skill dirs (prohibited).
 name: skill-name
 description: |
   [What it does] + [When to use it / trigger phrases] + [Key capabilities]
-effort: low | medium | high | max
 user-invocable: false                  # Optional. Reference skills only.
 disable-model-invocation: true         # Optional. User-only workflows (free — no budget cost).
 argument-hint: "[optional example]"    # Optional. Shown in /menu.
@@ -104,10 +103,9 @@ Domain checklists live in `audit/references/`, `fix/references/`.
 ## Adding a Skill
 
 1. Create `core/{name}/SKILL.md` with frontmatter
-2. Match effort level to reasoning cost (low=lookup, medium=scaffold, high=implement, max=architecture)
-3. Choose invocation mode: default (model+user), DMI (user-only), or reference (auto-load)
-4. Follow patterns from existing skills in the same category
-5. Run `./scripts/sync.sh all` to distribute
+2. Choose invocation mode: default (model+user), DMI (user-only), or reference (auto-load)
+3. Follow patterns from existing skills in the same category
+4. Run `./scripts/sync.sh all` to distribute
 
 ## Principles
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 74 deep skills for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
 
-Skills are pure Markdown — no application code, no dependencies. They teach agents *how to work*: debugging methodology, PR workflows, design systems, incident response, and dozens of domain-specific playbooks.
+Skills are Markdown-first with a handful of Python helper scripts. No application code, no dependencies. They teach agents *how to work*: debugging methodology, PR workflows, design systems, incident response, and dozens of domain-specific playbooks.
 
 ## Why
 
@@ -60,6 +60,7 @@ Skills are symlinked, not copied. Edit once, every harness sees the change.
 | `/check-quality` | DMI | Audit quality gates: tests, CI, hooks |
 | `/debug` | Model+User | Four-phase systematic debugging |
 | `/test-coverage` | DMI | TDD workflow, Vitest config, coverage audit |
+| `/distill` | Model+User | Repo knowledge distillation and session codification |
 | `/done` | DMI | Session retrospective and codification |
 | `/triage` | Model+User | Incident response → postmortem → verification |
 
@@ -113,7 +114,7 @@ Domains: bitcoin, btcpay, bun, docs, landing, lightning, observability, onboardi
 
 ### References (auto-loaded)
 
-`git-mastery` · `naming-conventions` · `external-integration-patterns` · `ui-skills` · `business-model-preferences` · `toolchain-preferences` · `distill` · `next-patterns` · `database` · `delegate` · `cli-reference` · `ralph-patterns` · `skill-builder` · `agentic-ui-contract`
+`git-mastery` · `naming-conventions` · `external-integration-patterns` · `ui-skills` · `business-model-preferences` · `toolchain-preferences` · `next-patterns` · `database` · `delegate` · `cli-reference` · `ralph-patterns` · `skill-builder` · `agentic-ui-contract` · `webapp-testing`
 
 ### Domain Tools (DMI)
 
@@ -138,7 +139,6 @@ description: |
   Investigate local development issues: test failures, type errors,
   runtime bugs, build problems. Use when something is broken and you
   need to find the root cause. Not for production incidents (use /triage).
-effort: high
 ---
 ```
 
@@ -146,8 +146,7 @@ effort: high
 
 1. Create `core/{name}/SKILL.md` with frontmatter
 2. Choose mode: default (model+user), `disable-model-invocation: true` (DMI), or `user-invocable: false` (reference)
-3. Set effort: `low` (lookup) · `medium` (scaffold) · `high` (implement) · `max` (architecture)
-4. Run `./scripts/sync.sh all`
+3. Run `./scripts/sync.sh all`
 
 ## Principles
 

--- a/core/agentic-bootstrap/SKILL.md
+++ b/core/agentic-bootstrap/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: agentic-bootstrap
+description: Design repo-local Pi foundations using autonomous exploration lanes, model-job routing, synthesis-first artifact generation, and lean success criteria. Use when bootstrapping or overhauling `.pi/` in a repository.
+---
+
+# Agentic Bootstrap Engineering
+
+Use this skill when creating or redesigning a repository's local Pi foundation.
+
+## Core posture
+
+- Treat models as capable collaborators, not scripts.
+- Maximize exploration quality, then synthesize.
+- Keep output focused and auditable.
+- Bias toward repo-specific fit over generic templates.
+- **Always generate a repo-local persona character in the root `AGENTS.md`.**
+
+## Workflow
+
+1. **Explore broadly & deeply**
+   - Inspect local policy/context (`AGENTS.md`, `CLAUDE.md`, README/docs, scripts).
+   - Mine existing automation/context layers (`.claude/`, `.codex/`, existing `.pi/`).
+   - Analyze the **git history** (`git log --oneline -n 30`, `git log --stat`, major refactors) to understand where the project came from.
+   - Review the **backlog, issues, and retrospectives** (e.g., `TODO`s, `.groom/retro.md`) to understand where it's going.
+   - Run parallel lanes when useful (scout, docs, critic, context-bridge).
+
+2. **Route models by job**
+   - Scout/context/synthesis lanes: deeper reasoning models.
+   - Research lanes: retrieval-strong models.
+   - Critic lanes: adversarial/review-strong models.
+
+3. **Synthesize with strict output contract**
+   - Emit concrete artifacts (settings, overlays, prompts, pipelines, local workflow doc, and **AGENTS.md**).
+   - **Design a personified character (`AGENTS.md`)**: The persona must be a *person* or *character* (e.g., an archivist, a chronomancer) deeply tied to the domain, complete with a Name, Title, Quote, Voice, and Belief System.
+   - **Inject context front-and-center**: Do not bury capabilities or the persona in `.pi/persona.md`. The character identity, core domain rules, and essential capabilities must go directly into the repo-root `AGENTS.md` so the Pi runtime automatically loads them on every turn.
+   - Require explicit opt-ins in settings.
+   - Keep role overlays goal-oriented (role + objective + success criteria + output contract).
+
+4. **Pressure test before finalize**
+   - Surface failure modes and maintenance burden.
+   - Remove brittle over-prescriptive instructions.
+   - Keep only high-leverage local artifacts.
+
+## Success criteria
+
+- Foundation is clearly repo-specific.
+- Local config is explicit and narrow.
+- **The persona is a full character with Voice and Beliefs.**
+- **The persona and core rules/capabilities are loaded automatically via the root `AGENTS.md`.**
+- Workflow supports explore -> design -> implement -> review.
+- Instructions are high-signal and not procedurally bloated.
+- Artifacts are understandable by a new operator in one read.
+
+## Output contract
+
+```markdown
+## Repo Signals & Git History (Where we came from/Where we are going)
+## Adopt / Bridge / Ignore Decisions
+## Proposed Local Pi Foundation (including the Character Persona in AGENTS.md)
+## Risks and Safeguards
+## Why this is the minimal high-leverage setup
+```
+
+## References
+
+- `references/best-practices.md`

--- a/core/agentic-bootstrap/references/best-practices.md
+++ b/core/agentic-bootstrap/references/best-practices.md
@@ -1,0 +1,14 @@
+# Agentic Bootstrap Best-Practice References
+
+Core prompt/context engineering:
+- OpenAI Prompt Engineering Guide: https://developers.openai.com/api/docs/guides/prompt-engineering
+- OpenAI Structured Outputs: https://developers.openai.com/api/docs/guides/structured-outputs
+- GPT-5 Prompting Guide (Cookbook): https://developers.openai.com/cookbook/examples/gpt-5/gpt-5_prompting_guide
+- Gemini Prompting Strategies: https://ai.google.dev/gemini-api/docs/prompting-strategies
+- Claude XML tags and control patterns: https://docs.claude.com/en/docs/use-xml-tags
+
+Agentic engineering design patterns:
+- Anthropic multi-agent research context: https://www.anthropic.com/research/building-effective-agents
+- OpenAI agents guides/cookbook index: https://platform.openai.com/docs/guides/agents
+
+Use these references to improve lane prompts, output contracts, and model-job routing over time.

--- a/core/agentic-bootstrap/references/best-practices.md
+++ b/core/agentic-bootstrap/references/best-practices.md
@@ -1,11 +1,11 @@
 # Agentic Bootstrap Best-Practice References
 
 Core prompt/context engineering:
-- OpenAI Prompt Engineering Guide: https://developers.openai.com/api/docs/guides/prompt-engineering
-- OpenAI Structured Outputs: https://developers.openai.com/api/docs/guides/structured-outputs
-- GPT-5 Prompting Guide (Cookbook): https://developers.openai.com/cookbook/examples/gpt-5/gpt-5_prompting_guide
+- OpenAI Prompt Engineering Guide: https://platform.openai.com/docs/guides/prompting
+- OpenAI Structured Outputs: https://platform.openai.com/docs/guides/structured-outputs
+- GPT-5 Prompting Guide (Cookbook): https://cookbook.openai.com/examples/gpt-5/gpt-5.1_prompting_guide/
 - Gemini Prompting Strategies: https://ai.google.dev/gemini-api/docs/prompting-strategies
-- Claude XML tags and control patterns: https://docs.claude.com/en/docs/use-xml-tags
+- Claude XML tags and control patterns: https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/use-xml-tags
 
 Agentic engineering design patterns:
 - Anthropic multi-agent research context: https://www.anthropic.com/research/building-effective-agents

--- a/core/agentic-ui-contract/SKILL.md
+++ b/core/agentic-ui-contract/SKILL.md
@@ -7,7 +7,6 @@ description: |
   how it is rendered. Use for chat-first apps, tool-calling agents,
   generative UI systems, and planner/tool architecture decisions.
   Keywords: agentic UX, tool calling, planner, generative UI, function tools.
-effort: high
 ---
 
 # Agentic UI Contract

--- a/core/ai-media/SKILL.md
+++ b/core/ai-media/SKILL.md
@@ -7,7 +7,6 @@ description: |
   All via inference.sh CLI.
 disable-model-invocation: true
 argument-hint: "[type: image|video|remotion|demo|voiceover|asset] [prompt or description]"
-effort: high
 allowed-tools: Bash(infsh *)
 ---
 

--- a/core/app-screenshots/SKILL.md
+++ b/core/app-screenshots/SKILL.md
@@ -8,7 +8,6 @@ description: |
   Uses fastlane (free) not SaaS. Keywords: app store, play store, screenshot,
   device frame, fastlane, snapshot, frameit, localization.
 argument-hint: "[app path] [platforms: ios, android] [locales: en, es]"
-effort: high
 ---
 
 ## What This Does

--- a/core/audit-website/SKILL.md
+++ b/core/audit-website/SKILL.md
@@ -2,11 +2,6 @@
 name: audit-website
 disable-model-invocation: true
 description: Audit websites for SEO, performance, security, technical, content, and 15 other issue cateories with 230+ rules using the squirrelscan CLI. Returns LLM-optimized reports with health scores, broken links, meta tag analysis, and actionable recommendations. Use to discover and asses website or webapp issues and health.
-license: See LICENSE file in repository root
-compatibility: Requires squirrel CLI installed and accessible in PATH
-metadata:
-  author: squirrelscan
-  version: "1.22"
 allowed-tools: Bash(squirrel:*) Read Edit Grep Glob
 ---
 

--- a/core/audit/SKILL.md
+++ b/core/audit/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Run /audit <domain> for structured P0-P3 findings report. /audit --all for everything.
   Invoke for: domain audit, compliance check, launch readiness, gap analysis.
 argument-hint: "<domain|--all>"
-effort: high
 disable-model-invocation: true
 ---
 

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: shipping an issue end-to-end, autonomous delivery, sprint execution.
   Trigger: /autopilot, "ship this issue", "build and ship", "sprint execute".
 argument-hint: "[issue-id]"
-effort: high
 ---
 
 # /autopilot
@@ -51,7 +50,7 @@ and a clean dogfood QA pass.
 5. **Design** — Invoke `/shape --design-only` if no `## Technical Design` section
 6. **Build** — Invoke `/build` (branching, implementation, commits)
 7. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa --fix`. Fix P0/P1 before proceeding.
-8. **Refine** — `/refactor`, `/update-docs`, then `ousterhout` agent for module depth review
+8. **Refine** — `/pr-fix --refactor`, update docs inline, then `ousterhout` agent for module depth review
 9. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
    Iterate until no P0/P1 issues remain. **Do not open a PR until QA passes.**
 10. **Commit** — Create semantic commits for all remaining changes:
@@ -142,7 +141,7 @@ After `/build` completes, parallelize the refinement phase:
 |----------|------|
 | **Simplifier** | Run code-simplifier agent, commit |
 | **Depth reviewer** | Run ousterhout agent, commit |
-| **Doc updater** | Run /update-docs, commit |
+| **Doc updater** | Update docs (README, ADRs, API docs), commit |
 
 Lead sequences commits after all teammates finish. Then dogfood QA, then `/pr`.
 

--- a/core/bitcoin/SKILL.md
+++ b/core/bitcoin/SKILL.md
@@ -8,7 +8,6 @@ description: |
   Auto-invoke when: files contain bitcoin/btc/utxo/satoshi, imports bitcoin
   packages, references BITCOIN_* or BTC_* env vars, wallet handlers modified.
 argument-hint: "[focus area, e.g. 'wallet' or 'testnet config']"
-effort: high
 ---
 
 # /bitcoin

--- a/core/brand/SKILL.md
+++ b/core/brand/SKILL.md
@@ -173,8 +173,35 @@ For projects not yet on brand.yaml:
 
 ## Phase 6: Logo Generation
 
-1. **Context**: read brand.yaml for identity, palette, voice
-2. **Generate 4 SVG candidates** with constrained prompts:
+### Phase 6a: Icon-library-first path (preferred)
+
+Check if project uses an icon library (Phosphor, Lucide, Heroicons, Tabler):
+1. Scan `package.json` for icon libraries
+2. If found: search for domain-relevant icons (e.g. "Heartbeat" for monitoring)
+3. Present candidates with fill/bold weights — fill works best at 16px favicon
+4. If user picks one:
+   - Extract SVG path from package (`dist/defs/` or core assets)
+   - Color with brand palette primary
+   - Create `public/logo.svg` (256 viewBox, brand-colored fill)
+   - Generate all favicon sizes via sharp:
+```javascript
+const sizes = [16, 32, 180, 192, 512];
+for (const size of sizes) {
+  await sharp(svg, { density: 300 }).resize(size).png().toFile(`favicon-${size}.png`);
+}
+```
+   - Generate `favicon.ico` (ICO header + 32px PNG)
+   - Skip AI generation entirely
+
+### Phase 6b: AI generation (fallback)
+
+When icon-library path is declined or no library exists:
+
+1. **QuiverAI** (quiver.ai) — vector-native SVG generation
+   - Free tier: 20 SVGs/week
+   - API: `POST https://api.quiver.ai/v1/generate`
+   - Prompt constraints: simple icon, max 3 shapes, brand colors only
+2. **Constrained prompt fallback**: Generate 4 SVG candidates
    - Viewbox: 64x64, max 3 shapes (geometric primitives)
    - Colors: only primary + foreground hex
    - No text, no gradients, no filters, no embedded images
@@ -183,15 +210,18 @@ For projects not yet on brand.yaml:
 5. **Optimize + variants**:
 ```bash
 npx svgo logo.svg -o logo-optimized.svg
-# Generate favicon variants at 16, 32, 48, 180, 192, 512px
 ```
 6. **Update brand.yaml** with logo paths
+
+### Wordmark generation
+- Use project's display font (from brand.yaml typography.display)
+- Nano Banana 2 for high-quality text rendering if needed
 
 Output:
 ```
 assets/
   logo.svg, logo-mark.svg
-  favicon-{16,32,48,180,192,512}.png
+  favicon-{16,32,180,192,512}.png
   favicon.ico
 ```
 

--- a/core/brand/SKILL.md
+++ b/core/brand/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Creates brand.yaml, compiles to CSS/Tailwind/TypeScript tokens, generates
   OG cards, social images, logos, and branded video. One command from zero to
   full brand system. Use when establishing or updating brand identity.
-effort: high
 disable-model-invocation: true
 ---
 

--- a/core/build/SKILL.md
+++ b/core/build/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: building a feature, implementing an issue, writing code, shipping.
   Trigger: /build, /implement, "build this", "implement this", "start coding".
 argument-hint: <issue-id>
-effort: high
 ---
 
 # /build

--- a/core/bun/SKILL.md
+++ b/core/bun/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Complete Bun lifecycle management. Audits current state, plans migration,
   executes changes, verifies success. Full orchestrator for Bun adoption.
   Invoke for: migrate to bun, adopt bun, bun migration, switch to bun.
-effort: high
 ---
 
 # /bun

--- a/core/business-model-preferences/SKILL.md
+++ b/core/business-model-preferences/SKILL.md
@@ -4,7 +4,6 @@ description: |
   Pricing philosophy and business model constraints.
   Auto-invoke when: evaluating pricing, checkout flows, subscription logic, tier structures.
 user-invocable: false
-effort: low
 ---
 
 # Business Model Preferences

--- a/core/changelog/SKILL.md
+++ b/core/changelog/SKILL.md
@@ -6,7 +6,6 @@ description: |
   commitlint, GitHub Actions, LLM synthesis, public changelog page, and RSS.
 disable-model-invocation: true
 argument-hint: "[focus area, e.g. 'LLM synthesis' or 'public page' or 'setup']"
-effort: medium
 ---
 
 # /changelog

--- a/core/check-quality/SKILL.md
+++ b/core/check-quality/SKILL.md
@@ -5,7 +5,6 @@ description: |
   linting, security. Outputs prioritized findings (P0-P3) and can fix gaps.
   Invoke for: "quality audit", "set up CI", "add hooks", "coverage gaps",
   "quality gates", "is this project production-ready?"
-effort: high
 disable-model-invocation: true
 ---
 

--- a/core/cli-reference/SKILL.md
+++ b/core/cli-reference/SKILL.md
@@ -7,7 +7,6 @@ description: |
   - Before suggesting any dashboard action
   - Setting environment variables across platforms
   Keywords: env var, configure, dashboard, settings, production, deploy, CLI
-effort: low
 ---
 
 # CLI Reference

--- a/core/commit/SKILL.md
+++ b/core/commit/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: ready to commit, cleaning workspace, pushing changes.
   Trigger: /commit, "commit this", "push changes", "clean and commit".
 disable-model-invocation: true
-effort: medium
 ---
 
 # /commit

--- a/core/content/SKILL.md
+++ b/core/content/SKILL.md
@@ -5,7 +5,6 @@ description: |
   launch announcements, email sequences, and AI-writing cleanup. Covers the
   full content lifecycle from first draft to polished, on-brand output.
   Use when writing, editing, or publishing any marketing or product content.
-effort: high
 disable-model-invocation: true
 ---
 

--- a/core/crypto-gains/SKILL.md
+++ b/core/crypto-gains/SKILL.md
@@ -4,7 +4,6 @@ disable-model-invocation: true
 description: |
   Calculate capital gains with FIFO, wash sale detection, term classification, and Form 8949 outputs.
 user-invocable: true
-effort: high
 ---
 
 # /crypto-gains

--- a/core/database/SKILL.md
+++ b/core/database/SKILL.md
@@ -5,7 +5,6 @@ description: |
   migrations, query optimization, transactions, connection pooling, and Convex-specific
   best practices. Reference skill for all database work.
 user-invocable: false
-effort: high
 ---
 
 # Database

--- a/core/debug/SKILL.md
+++ b/core/debug/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use for: any bug, test failure, production incident, unexpected behavior,
   "investigate", "why is this broken", "debug this", "what went wrong".
 argument-hint: <symptoms - error message, unexpected behavior, what's broken>
-effort: max
 ---
 
 # /debug

--- a/core/delegate/SKILL.md
+++ b/core/delegate/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Multi-AI orchestration primitive. Delegate to specialized AI tools, collect outputs, synthesize.
   Use when: analysis, review, audit, investigation tasks need multiple expert perspectives.
   Keywords: orchestrate, delegate, multi-ai, parallel, synthesis, consensus, dag, swarm
-effort: high
 ---
 
 # /delegate
@@ -237,6 +236,6 @@ use the Task tool with `subagent_type: "general-purpose"`.
 ## Related
 
 - `/llm-communication` — Prompt writing principles
-- `/review-branch` — Example implementation
+- `/pr-fix` — Example implementation
 - `/thinktank` — Multi-model synthesis
 - `/codex-coworker` — Codex delegation patterns

--- a/core/deploy/SKILL.md
+++ b/core/deploy/SKILL.md
@@ -6,7 +6,7 @@ description: |
   Use when: deploying, shipping to production, releasing.
   Trigger: /deploy cloud, /deploy web, /deploy oss, /deploy all.
 argument-hint: <cloud|web|oss|all>
-model-invocable: false
+disable-model-invocation: true
 ---
 
 # /deploy

--- a/core/deploy/SKILL.md
+++ b/core/deploy/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: deploy
+description: |
+  Deploy cerberus targets: cloud (Fly.io), web (Vercel), oss (GitHub release).
+  Pre-flight checks, deploy, health verify, rollback guidance.
+  Use when: deploying, shipping to production, releasing.
+  Trigger: /deploy cloud, /deploy web, /deploy oss, /deploy all.
+argument-hint: <cloud|web|oss|all>
+model-invocable: false
+---
+
+# /deploy
+
+Deploy with confidence. Pre-flight → deploy → verify → report.
+
+## Targets
+
+| Target | Platform | Deploy From | Command | Verify |
+|--------|----------|-------------|---------|--------|
+| `cloud` | Fly.io | `cerberus-cloud/` | `fly deploy` | `curl -sf https://cerberus-cloud.fly.dev/api/health` |
+| `web` | Vercel | `cerberus-web/` | `vercel --prod` | HTTP 200 on production URL |
+| `oss` | GitHub Actions | `cerberus/` | `gh workflow run release.yml --ref master` | `gh release list --limit 1` |
+
+Parse `$ARGUMENTS` to determine target(s). If `all`, deploy in order: `oss` → `cloud` → `web`.
+If no argument, ask the user which target.
+
+## Pre-flight (ALL targets)
+
+1. **CLI tool exists** — `fly version` / `vercel --version` / `gh --version`
+2. **Git status clean** — `git status --porcelain` must be empty (uncommitted changes = abort)
+
+## Pre-flight: `cloud`
+
+3. **Submodule initialized** — `git submodule status cerberus` must NOT show `-` prefix (uninitialized)
+4. **No local submodule modifications** — `git submodule status cerberus` must NOT show `+` prefix
+5. **Tests pass** — `bun test`
+6. **Working directory** — must be `cerberus-cloud/` (or cd into it)
+
+If submodule is uninitialized:
+```
+Submodule not initialized. Run:
+  git submodule update --init cerberus
+```
+
+## Pre-flight: `web`
+
+3. **Build succeeds** — `bun run build` from `cerberus-web/`
+
+## Pre-flight: `oss`
+
+3. **On master** — `git branch --show-current` must be `master`
+4. **Confirm HEAD** — show `git log --oneline -3` and ask user to confirm this is the right commit
+
+## Deploy
+
+Run the deploy command. Stream output (don't suppress).
+
+## Verify
+
+After deploy completes, verify with retries (3 attempts, 5s apart):
+
+- **cloud**: `curl -sf https://cerberus-cloud.fly.dev/api/health`
+- **web**: `curl -sf <production-url>` (resolve from vercel output)
+- **oss**: `gh release list --limit 1` (confirm new release appears)
+
+## Report
+
+On success:
+```
+✅ <target> deployed successfully
+   Version: <commit-sha-short>
+   URL: <url>
+```
+
+On failure:
+```
+❌ <target> deploy failed
+   Error: <error-summary>
+
+   Rollback (cloud): fly releases → fly deploy --image <previous-ref>
+   Rollback (web):   vercel rollback
+   Rollback (oss):   gh release delete <tag> --yes
+```
+
+## Fly.io Details
+
+- **App**: `cerberus-cloud`
+- **Region**: `iad`
+- **Health**: `/api/health`
+- **Required secrets**: `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `OPENROUTER_API_KEY`, `GITHUB_WEBHOOK_SECRET`, `GITHUB_MARKETPLACE_WEBHOOK_SECRET`
+- **Volume**: `cerberus_data` mounted at `/app/data` (SQLite persistence)
+- **Rollback**: `fly releases` → find previous image → `fly deploy --image <ref>`

--- a/core/design/SKILL.md
+++ b/core/design/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Two modes: Explore (greenfield, 6 directions) or Extend (refinement).
   Composes design tokens, aesthetic system, taste constraints, and visual QA.
   Use when designing UI systems, exploring directions, or establishing brand visuals.
-effort: high
 ---
 
 # DESIGN

--- a/core/distill/SKILL.md
+++ b/core/distill/SKILL.md
@@ -3,7 +3,6 @@ name: distill
 description: |
   Distill repo knowledge into CLAUDE.md and codify session learnings into durable improvements.
   Invoke at end of sessions or when onboarding a repo.
-effort: high
 ---
 
 # DISTILL

--- a/core/done/SKILL.md
+++ b/core/done/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Extracts learnings, updates docs, captures retro signals for future grooming.
   Invoke for: "done", "wrap up", "what did we learn", "retro", "session end",
   finishing multi-step work, after debugging hard problems.
-effort: medium
 disable-model-invocation: true
 argument-hint: "[--skip-commit] [--focus area] [append --issue N]"
 ---

--- a/core/external-integration-patterns/SKILL.md
+++ b/core/external-integration-patterns/SKILL.md
@@ -2,7 +2,6 @@
 name: external-integration-patterns
 user-invocable: false
 description: "Patterns for reliable external service integration: env validation, health checks, error handling, observability. Invoke when integrating Stripe, Clerk, Sendgrid, or any external API."
-effort: high
 ---
 
 # External Integration Patterns

--- a/core/finances-ingest/SKILL.md
+++ b/core/finances-ingest/SKILL.md
@@ -10,7 +10,6 @@ description: |
   financial records from bank/broker/crypto exports. Keywords: ingest, import, parse,
   new transactions, add transactions, financial data, export, csv import, bank statement.
 user-invocable: true
-effort: medium
 ---
 
 # finances-ingest

--- a/core/finances-report/SKILL.md
+++ b/core/finances-report/SKILL.md
@@ -11,7 +11,6 @@ description: |
   net worth, spending, cash flow, debt, liabilities, bitcoin, how am I doing financially,
   finances summary, show me my finances, portfolio.
 user-invocable: true
-effort: low
 ---
 
 # finances-report

--- a/core/finances-snapshot/SKILL.md
+++ b/core/finances-snapshot/SKILL.md
@@ -9,7 +9,6 @@ description: |
   monthly financial check-ins, tracking net worth. Keywords: net worth, balance sheet,
   snapshot, financial update, update finances, capture finances, record net worth.
 user-invocable: true
-effort: medium
 ---
 
 # finances-snapshot

--- a/core/fix/SKILL.md
+++ b/core/fix/SKILL.md
@@ -6,7 +6,6 @@ description: |
   bun, virality. One fix per invocation. Run again for next issue.
   Use for: bug fixes, domain issues, error resolution, compliance fixes.
 argument-hint: "<domain|error>"
-effort: high
 ---
 
 # /fix

--- a/core/flywheel-qa/SKILL.md
+++ b/core/flywheel-qa/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: PR passes CI but needs runtime verification before merge.
 disable-model-invocation: true
 argument-hint: "<PR-number>"
-effort: high
 ---
 
 # /flywheel-qa

--- a/core/git-mastery/SKILL.md
+++ b/core/git-mastery/SKILL.md
@@ -11,7 +11,6 @@ description: |
   - Optimizing large repository performance
   Keywords: git, commit, branch, merge, rebase, PR, pull request, trunk-based,
   conventional commits, atomic commits, git hooks, CODEOWNERS
-effort: high
 ---
 
 # Git Mastery

--- a/core/github-app-scaffold/SKILL.md
+++ b/core/github-app-scaffold/SKILL.md
@@ -2,7 +2,6 @@
 name: github-app-scaffold
 disable-model-invocation: true
 description: "Scaffold and implement GitHub Apps from existing automation ideas using Probot + @octokit/app. Use when turning scripts, bots, or manual GitHub workflows into a proper GitHub App."
-effort: high
 ---
 
 # GitHub App Scaffold

--- a/core/github-cli-hygiene/SKILL.md
+++ b/core/github-cli-hygiene/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: github-cli-hygiene
+description: Safe, well-formatted GitHub CLI writes for PRs/issues/reviews using body files and post-write validation.
+---
+
+# GitHub CLI Hygiene Skill
+
+Use this skill whenever writing content to GitHub via CLI:
+- PR title/body creation or edits
+- PR comments
+- issue comments
+- review submissions/replies
+
+## Invocation intent for PR work
+
+If the user asks to "open/create/make/update the PR" (or invokes a PR prompt/skill), execute the write action — do not stop at drafting content.
+- No existing PR for branch: run `gh pr create ... --body-file <path>`
+- Existing PR: run `gh pr edit ... --body-file <path>`
+- Only skip write when user explicitly requests draft-only output
+
+## Core policy (non-negotiable)
+
+1. Never use inline `--body/-b` for markdown content.
+2. Always write markdown to a temp file first.
+3. Use `--body-file/-F <path>` for write commands.
+4. Fetch back the posted content and verify formatting quality.
+
+## Canonical write flow
+
+1. Draft content in file
+   - `/tmp/pr-body.md`, `/tmp/pr-comment.md`, `/tmp/review-reply.md`
+2. Execute GitHub command with body file
+3. Re-fetch and lint output quality
+   - no escaped `\n`
+   - no ANSI artifacts or pasted logs
+   - no empty bullets
+4. If malformed, immediately edit and re-post via body file
+
+## Safe command patterns
+
+### Create draft PR
+```bash
+gh pr create --draft --title "<title>" --body-file /tmp/pr-body.md
+```
+
+### Edit PR body
+```bash
+gh pr edit <number> --body-file /tmp/pr-body.md
+```
+
+### PR comment
+```bash
+gh pr comment <number> --body-file /tmp/pr-comment.md
+```
+
+### Issue comment
+```bash
+gh issue comment <number> --body-file /tmp/issue-comment.md
+```
+
+### PR review
+```bash
+gh pr review <number> --comment --body-file /tmp/review.md
+```
+
+## Quality checklist before submit
+
+- Title is specific and <= 72 chars
+- Body has clear sections and concise bullets
+- Verification includes commands + pass/fail summaries only
+- Includes `Closes #N` when applicable
+- No raw stdout/stderr pasted

--- a/core/github-cli-hygiene/SKILL.md
+++ b/core/github-cli-hygiene/SKILL.md
@@ -20,8 +20,8 @@ If the user asks to "open/create/make/update the PR" (or invokes a PR prompt/ski
 
 ## Core policy (non-negotiable)
 
-1. Never use inline `--body/-b` for markdown content.
-2. Always write markdown to a temp file first.
+1. Never use inline `--body/-b` for Markdown content.
+2. Always write Markdown to a temp file first.
 3. Use `--body-file/-F <path>` for write commands.
 4. Fetch back the posted content and verify formatting quality.
 

--- a/core/groom/SKILL.md
+++ b/core/groom/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: backlog session, issue grooming, sprint planning, backlog cleanup.
   Trigger: /groom, /backlog, /tidy, "groom the backlog", "clean up issues".
 disable-model-invocation: true
-effort: high
 ---
 
 # /groom

--- a/core/groom/references/project-md-format.md
+++ b/core/groom/references/project-md-format.md
@@ -88,7 +88,7 @@ Things we've tried that didn't work. Distilled from `.groom/retro.md`.
 
 - `/groom` Phase 1 — load for session context
 - `/autopilot` — load before starting any issue
-- `/spec` and `/architect` — load for product context
+- `/shape` — load for product context
 - `/issue enrich` — embed vision one-liner in Context section
 
 ## Update Frequency

--- a/core/growth/SKILL.md
+++ b/core/growth/SKILL.md
@@ -5,7 +5,6 @@ description: |
   launches, referrals, competitor analysis, and pSEO generation. Covers
   the full growth stack from baseline SEO to scaled paid acquisition.
   Use when optimizing conversions, running campaigns, or planning launches.
-effort: high
 disable-model-invocation: true
 ---
 

--- a/core/guardrail/SKILL.md
+++ b/core/guardrail/SKILL.md
@@ -6,7 +6,6 @@ description: |
   ESLint local plugins (JS/TS) or ast-grep YAML rules (Python/Go/Rust/any).
   Invoke when: codifying an import boundary, enforcing API conventions,
   blocking deprecated patterns, or any "always/never" constraint.
-effort: high
 argument-hint: '"description of pattern to enforce" [--engine eslint|ast-grep]'
 ---
 

--- a/core/issue/SKILL.md
+++ b/core/issue/SKILL.md
@@ -7,7 +7,6 @@ description: |
   `/issue enrich [#N]` — Fill gaps with sub-agent research.
   `/issue decompose [#N]` — Split oversized issues into atomic sub-issues.
 argument-hint: "lint|enrich|decompose [#N|--all] [--fix]"
-effort: medium
 ---
 
 # /issue

--- a/core/lightning/SKILL.md
+++ b/core/lightning/SKILL.md
@@ -8,7 +8,6 @@ description: |
   Auto-invoke when: files contain lightning/lnd/bolt11/invoice, imports
   lightning packages, references LND_* env vars, channel handlers modified.
 argument-hint: "[focus area, e.g. 'channels' or 'liquidity']"
-effort: high
 ---
 
 # /lightning

--- a/core/llm-communication/SKILL.md
+++ b/core/llm-communication/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: llm-communication
+description: "Write effective LLM prompts, commands, and agent instructions. Goal-oriented over step-prescriptive. Role + Objective + Latitude pattern. Use when writing prompts, designing agents, building Pi commands, or reviewing LLM instructions."
+effort: high
+---
+
+# Talking to LLMs
+
+This skill helps you write effective prompts, commands, and agent instructions.
+
+## Core Principle
+
+LLMs are intelligent agents, not script executors. Talk to them like senior engineers.
+
+## Anti-Patterns
+
+### Over-Prescriptive Instructions
+
+Bad:
+```
+Step 1: Run X
+Step 2: Parse Y
+Step 3: For each result, do Z
+...700 more lines
+```
+
+This is brittle and removes model adaptability.
+
+### Excessive Hand-Holding
+
+Bad:
+```
+If user says X do Y.
+If user says Z do W.
+```
+
+You cannot enumerate every case. Trust generalization.
+
+### Defensive Over-Specification
+
+Bad:
+```
+IMPORTANT: Do NOT do X.
+WARNING: Never do Y.
+CRITICAL: Always remember Z.
+```
+
+If you need many warnings, the instruction is likely poorly framed.
+
+## Good Patterns
+
+### State the Goal, Not the Steps
+
+Good:
+```
+Investigate production errors across available observability.
+Correlate with recent changes. Find root cause. Propose fix.
+```
+
+### Provide Context, Not Micromanagement
+
+Good:
+```
+You're a senior SRE investigating an incident.
+User reports breakage around 14:57.
+```
+
+### Trust Recovery
+
+Good:
+```
+Use judgment. If one approach fails, try another.
+```
+
+### Role + Objective + Latitude
+
+1. **Role**
+2. **Objective**
+3. **Latitude**
+
+Example:
+```
+You're a senior engineer reviewing this PR.
+Find bugs, security issues, and code smells.
+Be direct. If it's fine, say so briefly.
+```
+
+## The Test
+
+Before finalizing instructions, ask:
+
+> “Would I give these instructions to a senior engineer?”
+
+If not, simplify and raise abstraction.

--- a/core/llm-communication/SKILL.md
+++ b/core/llm-communication/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: llm-communication
 description: "Write effective LLM prompts, commands, and agent instructions. Goal-oriented over step-prescriptive. Role + Objective + Latitude pattern. Use when writing prompts, designing agents, building Pi commands, or reviewing LLM instructions."
-effort: high
 ---
 
 # Talking to LLMs

--- a/core/llm-infrastructure/SKILL.md
+++ b/core/llm-infrastructure/SKILL.md
@@ -5,7 +5,6 @@ description: |
   gateway routing, observability, CI/CD. Ensures all AI features follow best practices.
   CRITICAL: Training data lags months. ALWAYS web search before LLM decisions.
 argument-hint: "[focus area, e.g. 'models' or 'evals' or 'prompts' or 'routing']"
-effort: high
 ---
 
 # /llm-infrastructure

--- a/core/log-issues/SKILL.md
+++ b/core/log-issues/SKILL.md
@@ -6,7 +6,6 @@ description: |
   production, product-standards, bun, virality. Deduplicates against open issues.
   Invoke for: backlog creation from audit, issue triage, gap tracking.
 argument-hint: "<domain|--all>"
-effort: medium
 disable-model-invocation: true
 ---
 

--- a/core/mobile-migrate/SKILL.md
+++ b/core/mobile-migrate/SKILL.md
@@ -2,7 +2,6 @@
 name: mobile-migrate
 disable-model-invocation: true
 description: "Add an Expo + EAS React Native mobile app to an existing web project, sharing logic, design tokens, auth, and backend integrations. Use when migrating a web codebase into a web+mobile monorepo."
-effort: high
 ---
 
 # Mobile Migrate

--- a/core/moneta-ingest/SKILL.md
+++ b/core/moneta-ingest/SKILL.md
@@ -4,7 +4,6 @@ disable-model-invocation: true
 description: |
   Parse new financial documents into Moneta. Detect type, run parser, validate output, summarize reconciliation.
 user-invocable: true
-effort: high
 ---
 
 # /moneta-ingest

--- a/core/moneta-reconcile/SKILL.md
+++ b/core/moneta-reconcile/SKILL.md
@@ -4,7 +4,6 @@ disable-model-invocation: true
 description: |
   Verify accounting integrity. Compare totals to source docs, check lots vs holdings, detect duplicates, report gaps.
 user-invocable: true
-effort: high
 ---
 
 # /moneta-reconcile

--- a/core/monorepo-scaffold/SKILL.md
+++ b/core/monorepo-scaffold/SKILL.md
@@ -2,7 +2,6 @@
 name: monorepo-scaffold
 disable-model-invocation: true
 description: "Convert single-app repos into a Turborepo monorepo using pnpm workspaces. Use when splitting apps into apps/ and shared code into packages/ with cached pipelines."
-effort: high
 ---
 
 # Monorepo Scaffold

--- a/core/naming-conventions/SKILL.md
+++ b/core/naming-conventions/SKILL.md
@@ -5,7 +5,6 @@ description: "Apply universal naming principles: avoid Manager/Helper/Util, use 
 allowed-tools:
   - Read
   - Grep
-effort: low
 ---
 
 # Naming Conventions

--- a/core/next-patterns/SKILL.md
+++ b/core/next-patterns/SKILL.md
@@ -7,7 +7,6 @@ description: |
   Keywords: Next.js, App Router, RSC, use cache, PPR, cacheLife, cacheTag, metadata,
   route handlers, middleware, Suspense, hydration
 user-invocable: false
-effort: high
 ---
 
 # Next.js Patterns

--- a/core/observability/SKILL.md
+++ b/core/observability/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Complete observability infrastructure. Error tracking, alerting, logging, health checks.
   Optimized for indie dev: minimal services, CLI-manageable, AI agent integration.
 argument-hint: "[focus area, e.g. 'alerts' or 'health checks']"
-effort: high
 ---
 
 # /observability

--- a/core/og-hero-image/SKILL.md
+++ b/core/og-hero-image/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: creating social sharing images, website headers, marketing collateral.
   Keywords: og image, open graph, hero image, social header, brand image
 argument-hint: "[brand name or project path]"
-effort: high
 ---
 
 # /og-hero-image

--- a/core/organic-reflection/SKILL.md
+++ b/core/organic-reflection/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: organic-reflection
+description: Reflect on recent work and propose lean, high-leverage Pi/process improvements with tradeoff analysis. Use when evolving prompts/skills/extensions/tools organically instead of bulk migration.
+---
+
+# Organic Reflection Skill
+
+Use this skill when the user wants Pi/process/tooling to evolve from real usage signals.
+
+## Core principles
+
+- No bulk migration.
+- No command/catalog bloat.
+- Minimize configuration, maximize opinionated defaults.
+- Prefer reversible changes.
+- Codify only repeated, high-value behavior.
+
+## Default scope
+
+Always evaluate both:
+1. Repo-local improvements
+2. Global Pi workflow/config improvements
+
+## Inputs to gather
+
+1. **Recent execution evidence**
+   - Git history (recent commits and changed files)
+   - Recent issue/PR context
+   - Notable friction points and repeated manual work
+
+2. **Memory evidence (local-first)**
+   - Session JSONL (`~/.pi/agent/sessions/...`)
+   - Runtime logs (`~/.pi/agent/logs/...`)
+   - If available, run `memory_ingest` + `memory_search` (or `memory_context`) before broad research
+   - Use `scope=both` and explicitly prioritize local findings over global fallback
+
+3. **Config source context**
+   - Existing repo assets (`prompts/`, `skills/`, `extensions/`, `docs/`)
+   - Legacy sources (`~/.claude/skills`, `~/.codex/commands`, `~/.codex/agents`)
+
+4. **Pi capability constraints**
+   - Prompt templates, skills, extensions, packages
+   - Session storage/branching/compaction behavior
+   - SDK + extension examples relevant to orchestration and memory
+
+5. **External best practices**
+   - Web/doc research with citations
+
+## Swarm-first research (recommended)
+
+If a `subagent` tool is available, propose a parallel swarm plan first.
+Reference lane templates: `references/swarm-lanes.md`.
+
+Important:
+- Swarm is recommended, not mandatory.
+- User chooses whether to launch swarm, number of agents, and lane focus.
+
+If no subagent support is available, run lanes sequentially.
+
+## Mandatory workflow
+
+1. **Replay reality**
+   - Describe what actually happened recently (not planned work).
+   - Extract repeated tasks and decision bottlenecks.
+
+2. **Identify codification targets**
+   - Convert repeated patterns into candidate artifacts across these classes:
+     - Process-only improvement
+     - Global Pi config update (prompt/skill/extension/package)
+     - Repo-local config update
+     - External tool adoption or internal tool build
+
+3. **Run rubric scoring**
+   - Load and apply: `references/evaluation-rubric.md`
+
+4. **Memory strategy analysis**
+   - Compare options:
+     - Session/log indexing only
+     - Local semantic index (e.g., QMD-backed)
+     - External memory layer
+   - Prefer local-first until evidence says otherwise.
+
+5. **Ask clarifying questions**
+   - Ask focused questions before locking recommendations.
+   - Resolve scope, maintenance, and reversibility tradeoffs.
+
+6. **Recommend in phases**
+   - Toe-dip: smallest experiment today
+   - Pilot: short validation run
+   - Scale: only after evidence
+
+## Memory analysis checklist
+
+- Verify what survives in session JSONL
+- Explain compaction tradeoff (summary is lossy, full history remains in session file)
+- Check current logs and retention behavior
+- Prefer storing raw transcript excerpts + derived summaries/metadata
+- Propose external memory integration only if local-first is insufficient
+
+## Output contract
+
+```markdown
+## Reflection Findings
+
+## Repeated Patterns Worth Codifying
+
+## Candidate Artifacts (scored)
+| Idea | Type | Scope | Score | Why now/next/later |
+
+## Memory Strategy Notes
+
+## Clarifying Questions
+
+## Recommendation
+- Now:
+- Next:
+- Later:
+```

--- a/core/organic-reflection/SKILL.md
+++ b/core/organic-reflection/SKILL.md
@@ -106,6 +106,7 @@ If no subagent support is available, run lanes sequentially.
 
 ## Candidate Artifacts (scored)
 | Idea | Type | Scope | Score | Why now/next/later |
+|---|---|---|---|---|
 
 ## Memory Strategy Notes
 

--- a/core/organic-reflection/references/evaluation-rubric.md
+++ b/core/organic-reflection/references/evaluation-rubric.md
@@ -1,0 +1,41 @@
+# Organic Reflection Evaluation Rubric
+
+Score each candidate artifact from 1 (low) to 5 (high) on each dimension.
+Evaluate scope fit explicitly: global Pi config, repo-local config, process-only, or external/internal tool.
+
+## Dimensions
+
+1. **Impact**
+   - How much repeated pain does this remove?
+
+2. **Evidence strength**
+   - How clearly has this need appeared in real work (not speculation)?
+
+3. **Implementation effort**
+   - Lower effort gets higher score (quick to test).
+
+4. **Maintenance burden**
+   - Lower ongoing maintenance gets higher score.
+
+5. **Bloat risk**
+   - Lower risk of command/catalog sprawl gets higher score.
+
+6. **Reversibility**
+   - How easy is it to remove if it underperforms?
+
+7. **Opinionated default fit**
+   - Higher score for low-config, sensible-default workflows.
+
+## Recommendation bands
+
+- **28-35**: `now` (high-confidence candidate)
+- **20-27**: `next` (promising, validate in small pilot)
+- **<=19**: `later` (insufficient signal or too expensive)
+
+## Tie-breakers
+
+Prefer candidates that:
+1. Reduce repeated manual orchestration
+2. Improve safety/quality signal early (before PR)
+3. Stay composable and avoid one-off command proliferation
+4. Reduce required user configuration via opinionated defaults

--- a/core/organic-reflection/references/swarm-lanes.md
+++ b/core/organic-reflection/references/swarm-lanes.md
@@ -1,0 +1,46 @@
+# Reflection Swarm Lanes (Optional)
+
+Use these lane prompts if a `subagent` tool is available.
+
+## Lane A — Work Memory Miner
+
+Goal: extract repeated friction and high-value wins from recent work.
+
+Prompt:
+- Inspect recent sessions/logs/commits/PRs.
+- Return:
+  1. repeated manual tasks
+  2. recurring decision bottlenecks
+  3. candidate codification targets
+
+## Lane B — Legacy Config Synthesizer
+
+Goal: identify reusable patterns from Claude/Codex without migrating bloat.
+
+Prompt:
+- Scan `~/.claude/skills`, `~/.codex/commands`, `~/.codex/agents` for only relevant patterns.
+- Return keep/drop/later recommendations with reasons.
+
+## Lane C — Pi Capability Mapper
+
+Goal: map native Pi extension points for the reflected needs.
+
+Prompt:
+- Inspect Pi docs/examples for prompt templates, skills, extensions, sessions, compaction, SDK.
+- Return implementation paths and constraints.
+
+## Lane D — External Research Scout
+
+Goal: gather current best practices and candidate tools.
+
+Prompt:
+- Research memory/orchestration best practices and candidate tools.
+- Include citation URLs for factual claims.
+
+## Synthesizer
+
+Combine lanes A-D into one recommendation:
+- 1-2 `now` experiments
+- 2-3 `next` candidates
+- clear `later` deferrals
+- explicit bloat-risk notes

--- a/core/posthog/SKILL.md
+++ b/core/posthog/SKILL.md
@@ -9,7 +9,6 @@ description: |
   package, references POSTHOG_* env vars, event tracking code modified, user
   mentions "analytics not working" or "events not sending".
 argument-hint: "[focus area, e.g. 'events' or 'feature-flags' or 'debugging']"
-effort: high
 ---
 
 # /posthog

--- a/core/pr-feedback/SKILL.md
+++ b/core/pr-feedback/SKILL.md
@@ -31,7 +31,7 @@ If an `Auto PR Feedback Digest` message is present in context, use it as the ini
    - Inline reply for review comments when possible
    - PR-level comment for outside-diff/general feedback
 9. Record trend signal:
-   - Run `/pr-trends` after merge/fix loop to watch repeated issue classes.
+   - Note repeated issue classes in commit message or PR comment for later pattern analysis.
 
 ## Reviewer response format
 

--- a/core/pr-feedback/SKILL.md
+++ b/core/pr-feedback/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: pr-feedback
+description: Triage and address GitHub PR feedback directly from the current branch, then commit and post reviewer replies.
+---
+
+# PR Feedback Skill
+
+Use this skill when asked to respond to review comments, "review input", or "address PR feedback".
+
+## Required execution pattern
+
+If an `Auto PR Feedback Digest` message is present in context, use it as the initial triage seed. Still refresh GitHub data before posting final replies.
+
+1. Detect the PR for the current branch (`gh pr status`).
+2. Fetch feedback via GH CLI APIs:
+   - `pulls/<pr>/comments`
+   - `pulls/<pr>/reviews`
+   - `issues/<pr>/comments`
+3. For each actionable comment:
+   - Classify: `bug | risk | style | question`
+   - Assign severity: `critical | high | medium | low`
+   - Decide: `fix now | defer | reject` with reason
+4. Apply severity policy:
+   - `critical/high`: **fix now by default**
+   - `medium`: fix now or track with follow-up issue + rationale
+   - `low`: optional
+5. Implement approved fixes.
+6. Run verification relevant to the changed files (or note N/A).
+7. Commit changes.
+8. Post GitHub responses:
+   - Inline reply for review comments when possible
+   - PR-level comment for outside-diff/general feedback
+9. Record trend signal:
+   - Run `/pr-trends` after merge/fix loop to watch repeated issue classes.
+
+## Reviewer response format
+
+Use this exact structure in replies:
+
+- `Classification: <bug|risk|style|question>`
+- `Severity: <critical|high|medium|low>`
+- `Decision: <fix now|defer|reject>. <reason>`
+- `Change: <what changed>`
+- `Verification: <tests/checks run or N/A>`
+
+## Guardrails
+
+- Do not claim a fix without a real file change and commit.
+- Do not wait for manually pasted comments when GH CLI can fetch them.
+- Skip duplicate/thanks-only bot comments.
+- Do not defer critical/high findings without explicit blocker rationale.

--- a/core/pr-fix/SKILL.md
+++ b/core/pr-fix/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: PR blocked, CI red, unaddressed reviews, code review needed, refactoring.
   Trigger: /pr-fix, /fix-ci, /review-branch, /review-and-fix, /respond, /address-review, /refactor.
 argument-hint: "[PR-number]"
-effort: high
 ---
 
 # /pr-fix

--- a/core/pr-polish/SKILL.md
+++ b/core/pr-polish/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Use when: PR works but could be better, pre-merge quality pass, retrospective review.
   Trigger: /pr-polish, "polish this PR", "elevate quality", "hindsight review".
 argument-hint: "[PR-number]"
-effort: high
 ---
 
 # /pr-polish
@@ -86,7 +85,7 @@ Write missing tests. Each test should justify its existence — no coverage-padd
 
 ### 5. Documentation
 
-Invoke `/update-docs` for anything the PR affects:
+Update docs for anything the PR affects:
 
 - ADRs for architectural decisions made during implementation
 - README updates for new features or changed behavior

--- a/core/pr/SKILL.md
+++ b/core/pr/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: opening a pull request, shipping to review, creating PR.
   Trigger: /pr, "open PR", "create pull request", "ship to review".
 disable-model-invocation: true
-effort: medium
 ---
 
 # /pr

--- a/core/prompt-context-engineering/SKILL.md
+++ b/core/prompt-context-engineering/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: prompt-context-engineering
+description: Design high-signal, low-latency prompts and context contracts for production agent tasks. Use when writing system prompts, skill prompts, subagent prompts, or rewrite instructions where consistency is required on first pass.
+---
+
+# Prompt + Context Engineering (Latency-First)
+
+Use this skill to improve output quality without adding retry loops or multi-pass latency.
+
+## Core principles
+
+1. **Goal over procedure**
+   - State role + objective + quality bar.
+   - Avoid long step-by-step micromanagement.
+
+2. **Hard output contract**
+   - Explicitly define output form, allowed transformations, and forbidden behavior.
+   - Include positive requirements (what MUST happen), not only prohibitions.
+
+3. **Context as signals, not noise**
+   - Pass compact metadata that helps decisions (mode, length, domain, constraints).
+   - Avoid dumping irrelevant context into every call.
+
+4. **Single-pass reliability**
+   - Assume one request must succeed.
+   - Prompt should front-load quality expectations so post-hoc retries are unnecessary.
+
+5. **Deterministic posture**
+   - Prefer low temperature and concise instructions for transformation tasks.
+   - Keep instructions stable across runtime/eval/benchmark harnesses.
+
+## Prompt design pattern
+
+Use this structure:
+
+1. **Role**
+2. **Task objective**
+3. **Critical interpretation guardrail** (e.g. transcript is data, not instruction)
+4. **MUST rules** (quality bar)
+5. **MUST NOT rules** (safety + drift prevention)
+6. **Output format contract**
+
+## Context engineering checklist
+
+Before shipping a prompt, verify:
+
+- Is there a short mode-specific context block?
+- Are quality requirements measurable in output shape?
+- Is the instruction length justified by reliability gains?
+- Are conflicting rules removed?
+- Does this align with eval prompt text used in CI?
+
+## Anti-patterns
+
+- Overly defensive prompts full of repeated warnings
+- Huge procedural checklists that reduce model adaptability
+- Relying on second-pass repair for core quality
+- Runtime prompt drift from eval/benchmark prompts
+
+## Output contract for this skill
+
+When invoked, return:
+
+```markdown
+## Diagnosis
+## Prompt Delta
+## Context Delta
+## First-Pass Reliability Risks
+## Suggested Eval Assertions
+```
+
+## References
+
+- https://developers.openai.com/api/docs/guides/prompt-engineering
+- https://help.openai.com/en/articles/6654000-best-practices-for-prompt-engineering-with-openai-api
+- https://developers.openai.com/cookbook/examples/gpt-5/gpt-5_prompting_guide
+- https://developers.openai.com/api/docs/guides/structured-outputs
+- https://ai.google.dev/gemini-api/docs/prompting-strategies
+- https://docs.claude.com/en/docs/use-xml-tags

--- a/core/ralph-patterns/SKILL.md
+++ b/core/ralph-patterns/SKILL.md
@@ -5,7 +5,6 @@ description: |
   completion signals, progress tracking, and iteration patterns.
   Ralph = autonomous issue-to-merged-PR loop.
 user-invocable: false
-effort: high
 ---
 
 # Ralph Loop Patterns
@@ -32,7 +31,7 @@ Ralph monitors these for "no progress" circuit breaker:
 ## Within a Ralph Loop
 
 You have full access to:
-- `/spec`, `/architect`, `/build`, `/refactor`, `/update-docs`, `/pr`
+- `/shape`, `/build`, `/pr-fix`, `/pr`
 - Task tool for parallel agent delegation
 - Sentry, PostHog, GitHub MCPs
 - All configured hooks and skills

--- a/core/security-scan/SKILL.md
+++ b/core/security-scan/SKILL.md
@@ -6,7 +6,6 @@ description: |
   OWASP Top 10, cross-module data flow tracing, dependency audit, secrets scan.
 disable-model-invocation: true
 argument-hint: "[optional: specific focus area, e.g. 'auth' or 'api routes']"
-effort: max
 ---
 
 # /security-scan
@@ -140,5 +139,5 @@ git ls-files --cached | grep -i "\.env$" | head -5
 ## Related
 
 - `/check-quality` — Includes lightweight security scan
-- `/review-branch` — security-sentinel is mandatory reviewer
+- `/pr-fix` — security-sentinel is mandatory reviewer
 - `/billing-security` — Payment-specific security patterns

--- a/core/shape/SKILL.md
+++ b/core/shape/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: planning a feature, shaping an idea, writing specs, designing architecture.
   Trigger: /shape, /spec, /architect, /brainstorm, /breadboard, /shaping, /critique.
 disable-model-invocation: true
-effort: high
 argument-hint: <issue-id-or-idea>
 ---
 

--- a/core/skill-builder/SKILL.md
+++ b/core/skill-builder/SKILL.md
@@ -9,7 +9,6 @@ description: |
   - Noticing repeated patterns across sessions
   AUTONOMOUS: Create skills proactively, then inform user what was created.
 user-invocable: false
-effort: high
 ---
 
 # Skill Builder

--- a/core/skill-creator/SKILL.md
+++ b/core/skill-creator/SKILL.md
@@ -2,7 +2,6 @@
 name: skill-creator
 description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
 disable-model-invocation: true
-license: Complete terms in LICENSE.txt
 ---
 
 # Skill Creator

--- a/core/slack-app-scaffold/SKILL.md
+++ b/core/slack-app-scaffold/SKILL.md
@@ -2,7 +2,6 @@
 name: slack-app-scaffold
 disable-model-invocation: true
 description: "Scaffold Slack apps from existing functionality using Bolt for JavaScript and the Slack CLI. Use when turning a service, script, or workflow into a Slack app with events, commands, modals, or automations."
-effort: high
 ---
 
 # Slack App Scaffold

--- a/core/stripe/SKILL.md
+++ b/core/stripe/SKILL.md
@@ -6,7 +6,6 @@ description: |
   local dev, reconciliation, and security. One skill for all Stripe work.
 disable-model-invocation: true
 argument-hint: "[focus area, e.g. 'webhooks' or 'subscription UX' or 'local dev']"
-effort: high
 ---
 
 # /stripe

--- a/core/sysadmin-ops/SKILL.md
+++ b/core/sysadmin-ops/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: sysadmin-ops
+description: Investigate host stability incidents (memory/process pressure), triage likely culprits, and drive safe recovery + hardening for multi-workspace Pi operations.
+---
+
+# Sysadmin Ops Skill
+
+Use when the user asks to investigate crashes, runaway memory, machine instability,
+or to design autonomous reliability guardrails for Pi workflows.
+
+## Primary goals
+
+1. Stabilize the host quickly.
+2. Preserve evidence for root-cause analysis.
+3. Restore interrupted workflows with minimal context loss.
+4. Prevent recurrence with layered guardrails.
+
+## Incident triage workflow
+
+1. **Confirm event window**
+   - capture local timestamp range
+   - list active/affected workspaces
+
+2. **Collect host forensics (macOS)**
+   - inspect `/Library/Logs/DiagnosticReports/JetsamEvent-*.ips`
+   - summarize top process families by aggregate RSS and process count
+   - extract evidence of process storms (count, age distribution, coalition hints)
+
+3. **Collect Pi execution forensics**
+   - parse `~/.pi/agent/sessions/**` for bash commands around event window
+   - identify high-risk commands (tests/builds/nested CLI/orchestration)
+   - detect unfinished commands and crash-correlated sessions
+
+4. **Containment recommendations**
+   - immediate limits (session count, concurrency, timeouts)
+   - command-level guardrails for sharp edges
+   - optional emergency stop procedure
+
+5. **Recovery plan**
+   - regenerate per-workspace handoff state
+   - enumerate next-resume checklist per workspace
+
+6. **Preventive hardening**
+   - extension guardrails
+   - slice policy changes
+   - watchdog automation and alerts
+
+## Key sharp edges to check
+
+- nested non-interactive `pi` invocations inside agents
+- unbounded test/build commands without explicit timeout
+- test runners without worker caps
+- team/pipeline recursion loops
+- many simultaneous workspaces with heavy runners
+
+## Output contract
+
+```markdown
+## Incident Summary
+
+## Forensic Evidence
+- host
+- session timeline
+
+## Likely Root Causes (ranked)
+
+## Immediate Containment
+
+## Recovery Plan
+
+## Hardening Plan
+- now
+- next
+- later
+```

--- a/core/sysadmin/SKILL.md
+++ b/core/sysadmin/SKILL.md
@@ -5,7 +5,6 @@ description: |
   memory pressure, Docker, Homebrew, stuck processes. Quick health checks and
   safe maintenance actions.
 disable-model-invocation: true
-effort: low
 ---
 
 # /sysadmin

--- a/core/tax-check/SKILL.md
+++ b/core/tax-check/SKILL.md
@@ -4,7 +4,6 @@ disable-model-invocation: true
 description: |
   Validate tax calculations: bracket math, deduction eligibility, Form 8949 format, audit-risk flags.
 user-invocable: true
-effort: high
 ---
 
 # /tax-check

--- a/core/test-coverage/SKILL.md
+++ b/core/test-coverage/SKILL.md
@@ -5,7 +5,6 @@ description: |
   Runs coverage, identifies gaps, enforces test-first workflow.
   Use for: "run test audit", "coverage gaps", "write tests", "TDD",
   "testing philosophy", "vitest setup", "test quality review".
-effort: high
 disable-model-invocation: true
 ---
 

--- a/core/thinktank/SKILL.md
+++ b/core/thinktank/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Runs multiple AI models in parallel for diverse perspectives.
   Use when: architecture decisions, code review, security audit, need consensus.
 argument-hint: '"<query>" [file...]'
-effort: high
 ---
 
 # /thinktank

--- a/core/toolchain-preferences/SKILL.md
+++ b/core/toolchain-preferences/SKILL.md
@@ -2,7 +2,6 @@
 name: toolchain-preferences
 description: "Apply preferred toolchain and technology stack defaults: pnpm, Next.js, TypeScript, Convex, Vercel, Tailwind, shadcn/ui, Zustand, TanStack, Vitest. Use when setting up new projects, choosing dependencies, discussing stack decisions, or evaluating alternatives."
 user-invocable: false
-effort: low
 ---
 
 # Toolchain Preferences

--- a/core/triage/SKILL.md
+++ b/core/triage/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use for: production down, error spikes, CI failures, incident response,
   "postmortem", "verify fix", "is production ok", user reports.
 argument-hint: "[action: status | investigate ISSUE-ID | investigate-ci RUN-ID | fix | verify | postmortem ISSUE-ID]"
-effort: max
 ---
 
 # /triage

--- a/core/tune-repo/SKILL.md
+++ b/core/tune-repo/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Runs Glance (bottom-up directory summaries) + Cartographer (top-down architecture map),
   then synthesizes into CLAUDE.md, AGENTS.md, ADRs, and memory.
   Use when: onboarding to a new repo, improving agent effectiveness, repo setup, agent tuning.
-effort: high
 ---
 
 # /tune-repo

--- a/core/visual-qa/SKILL.md
+++ b/core/visual-qa/SKILL.md
@@ -6,7 +6,6 @@ description: |
   Use when: frontend changes are code-complete, before commit or PR.
   Composes: agent-browser for automation, taste-skill for anti-slop analysis.
 allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
-effort: medium
 ---
 
 # /visual-qa
@@ -38,7 +37,7 @@ This skill is a **primitive** invoked by other skills. It also runs standalone v
 | `/build` | After quality gates pass, if diff touches `app/`, `components/`, or `*.css` |
 | `/autopilot` | After Build, before Refine phase |
 | `/frontend-design` | After code generation, as validation loop |
-| `/review-and-fix` | After fixes applied, before `/pr` |
+| `/pr-fix` | After fixes applied, before `/pr` |
 | `/pr` | Generates before/after screenshots for PR body |
 | `/commit` | Optional — if `--qa` flag or diff touches frontend files |
 | standalone | `/visual-qa [url]` |

--- a/core/visualize/SKILL.md
+++ b/core/visualize/SKILL.md
@@ -2,11 +2,6 @@
 name: visual-explainer
 disable-model-invocation: true
 description: Generate beautiful, self-contained HTML pages that visually explain systems, code changes, plans, and data. Use when the user asks for a diagram, architecture overview, diff review, plan review, project recap, comparison table, or any visual explanation of technical concepts. Also use proactively when you are about to render a complex ASCII table (4+ rows or 3+ columns) — present it as a styled HTML page instead.
-license: MIT
-compatibility: Requires a browser to view generated HTML files. Optional gemini-imagegen for AI image generation.
-metadata:
-  author: nicobailon
-  version: "0.1.1"
 ---
 
 # Visual Explainer

--- a/core/visualize/prompts/architect-diagram.md
+++ b/core/visualize/prompts/architect-diagram.md
@@ -1,6 +1,6 @@
 ---
-description: Render /architect output as a visual architecture diagram with component graph, data flow, file impact map, and tradeoffs
-source_skill: /architect
+description: Render /shape --design-only output as a visual architecture diagram with component graph, data flow, file impact map, and tradeoffs
+source_skill: /shape
 ---
 
 # Architect Diagram

--- a/core/visualize/prompts/review-findings.md
+++ b/core/visualize/prompts/review-findings.md
@@ -1,6 +1,6 @@
 ---
-description: Render /review-branch output as a visual code review report with severity-organized findings, file heatmap, and reviewer breakdown
-source_skill: /review-branch
+description: Render /pr-fix review output as a visual code review report with severity-organized findings, file heatmap, and reviewer breakdown
+source_skill: /pr-fix
 ---
 
 # Review Findings

--- a/core/visualize/prompts/spec-overview.md
+++ b/core/visualize/prompts/spec-overview.md
@@ -1,6 +1,6 @@
 ---
-description: Render /spec output as a visual feature specification with user journey, approach comparison, and success metrics
-source_skill: /spec
+description: Render /shape --spec-only output as a visual feature specification with user journey, approach comparison, and success metrics
+source_skill: /shape
 ---
 
 # Spec Overview

--- a/core/web-search/SKILL.md
+++ b/core/web-search/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: web-search
+description: Retrieval-first web research with citations and recency controls. Use for web, docs, and news lookups via /web, /web-deep, /web-news, and /web-docs.
+---
+
+# Web Search Skill
+
+Provides retrieval-first web research with citations and recency controls.
+
+## Commands
+- `/web <query>`: fast top links
+- `/web-deep <query>`: fetch and summarize with citations
+- `/web-news <query>`: recency-biased search results
+- `/web-docs <query>`: library/docs-focused retrieval
+
+## Behavior Contract
+- Return structured result envelope (see schema below)
+- Include citation URL for every claim
+- Prefer Context7 for docs/library lookups
+- Prefer Exa as primary general provider
+- Fallback to Brave on provider failure
+- Optional Perplexity pass allowed only for synthesis, never source of truth
+
+## Output Schema
+```json
+{
+  "results": [
+    {
+      "title": "string",
+      "url": "string",
+      "snippet": "string",
+      "published_at": "ISO-8601 or null",
+      "score": 0.0,
+      "source_provider": "context7|exa|brave|perplexity"
+    }
+  ],
+  "meta": {
+    "query": "string",
+    "command": "web|web-deep|web-news|web-docs",
+    "provider_chain": ["context7", "exa", "brave"],
+    "provider_used": "context7|exa|brave|null",
+    "cache_hit": false,
+    "time_sensitive": false,
+    "recency_days": null,
+    "confidence": "high|medium|low",
+    "uncertainty": "string|null"
+  },
+  "synthesis": {
+    "summary": "string",
+    "citations": ["https://..."]
+  }
+}
+```
+
+## Safety and Quality
+- Never fabricate URLs
+- Mark uncertain facts as uncertain
+- Apply recency filters for time-sensitive queries
+
+## Runtime Notes
+- Pi extension entrypoint: `extensions/web-search/index.ts`
+- CLI entrypoint (optional debug): `skills/web-search/cli.ts`
+- Cache: `cache/web-search-cache.json` (TTL via `WEB_SEARCH_TTL_MS`)
+- Logs: `logs/web-search.ndjson` (size-rotated)
+- `PI_WEB_SEARCH_LOG_MAX_BYTES` / `PI_WEB_SEARCH_LOG_MAX_BACKUPS` / `PI_WEB_SEARCH_LOG_ROTATE_CHECK_MS`
+- Cost controls:
+  - `WEB_SEARCH_MAX_RESULTS` caps results per query
+  - Cache dedupe prevents repeated provider calls for same normalized query

--- a/core/web-search/SKILL.md
+++ b/core/web-search/SKILL.md
@@ -58,8 +58,8 @@ Provides retrieval-first web research with citations and recency controls.
 - Apply recency filters for time-sensitive queries
 
 ## Runtime Notes
-- Pi extension entrypoint: `extensions/web-search/index.ts`
-- CLI entrypoint (optional debug): `skills/web-search/cli.ts`
+- Pi extension entrypoint: `~/.pi/agent/extensions/web-search/` (loaded via settings.json)
+- CLI entrypoint (optional debug): `core/web-search/cli.ts`
 - Cache: `cache/web-search-cache.json` (TTL via `WEB_SEARCH_TTL_MS`)
 - Logs: `logs/web-search.ndjson` (size-rotated)
 - `PI_WEB_SEARCH_LOG_MAX_BYTES` / `PI_WEB_SEARCH_LOG_MAX_BACKUPS` / `PI_WEB_SEARCH_LOG_ROTATE_CHECK_MS`

--- a/core/web-search/__tests__/confidence.test.ts
+++ b/core/web-search/__tests__/confidence.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import { assessConfidence } from "../confidence";
+import type { SearchRequest, SearchResult } from "../provider-adapter";
+
+const BASE_REQUEST: SearchRequest = {
+  query: "latest ai news",
+  command: "web-news",
+};
+
+const nowIso = new Date().toISOString();
+const staleIso = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+
+function result(url: string, published_at: string | null): SearchResult {
+  return {
+    title: url,
+    url,
+    snippet: "",
+    published_at,
+    score: 1,
+    source_provider: "exa",
+  };
+}
+
+describe("assessConfidence", () => {
+  test("returns low confidence when no results", () => {
+    const output = assessConfidence(BASE_REQUEST, []);
+    expect(output.confidence).toBe("low");
+    expect(output.uncertainty).toContain("No sources");
+  });
+
+  test("returns low confidence for time-sensitive query without recent sources", () => {
+    const output = assessConfidence(BASE_REQUEST, [
+      result("https://a.example", staleIso),
+      result("https://b.example", staleIso),
+    ]);
+    expect(output.confidence).toBe("low");
+    expect(output.uncertainty).toContain("No clearly recent");
+  });
+
+  test("returns high confidence for multiple recent sources", () => {
+    const output = assessConfidence(BASE_REQUEST, [
+      result("https://a.example", nowIso),
+      result("https://b.example", nowIso),
+      result("https://c.example", nowIso),
+    ]);
+    expect(output.confidence).toBe("high");
+    expect(output.uncertainty).toBeNull();
+  });
+
+  test("returns medium confidence for non-time-sensitive low source count", () => {
+    const request: SearchRequest = { query: "typescript utility types", command: "web" };
+    const output = assessConfidence(request, [
+      result("https://a.example", null),
+      result("https://b.example", null),
+    ]);
+    expect(output.confidence).toBe("medium");
+  });
+});

--- a/core/web-search/__tests__/query-utils.test.ts
+++ b/core/web-search/__tests__/query-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  canonicalizeUrl,
+  dedupeByCanonicalUrl,
+  inferRecencyDays,
+  isDocsLookup,
+  isTimeSensitiveQuery,
+  normalizeQuery,
+} from "../query-utils";
+import type { SearchResult } from "../provider-adapter";
+
+describe("query-utils", () => {
+  test("normalizeQuery trims, lowers, and collapses spaces", () => {
+    expect(normalizeQuery("  Latest   Next.js   docs  ")).toBe("latest next.js docs");
+  });
+
+  test("isDocsLookup detects docs-like queries and explicit docs mode", () => {
+    expect(isDocsLookup("react router docs", "web")).toBe(true);
+    expect(isDocsLookup("weather in sf", "web-docs")).toBe(true);
+    expect(isDocsLookup("weather in sf", "web")).toBe(false);
+  });
+
+  test("isTimeSensitiveQuery detects recency intents", () => {
+    expect(isTimeSensitiveQuery("latest openai api updates", "web")).toBe(true);
+    expect(isTimeSensitiveQuery("postgres indexing guide", "web-news")).toBe(true);
+    expect(isTimeSensitiveQuery("postgres indexing guide", "web")).toBe(false);
+  });
+
+  test("inferRecencyDays applies explicit value and defaults", () => {
+    expect(inferRecencyDays({ query: "latest ai news", command: "web" })).toBe(30);
+    expect(inferRecencyDays({ query: "new release", command: "web-news" })).toBe(7);
+    expect(inferRecencyDays({ query: "evergreen topic", command: "web" })).toBeNull();
+    expect(
+      inferRecencyDays({
+        query: "x",
+        command: "web",
+        recencyDays: 99999,
+      })
+    ).toBe(3650);
+  });
+
+  test("canonicalizeUrl strips tracking params and dedupes", () => {
+    const inputs: SearchResult[] = [
+      {
+        title: "A",
+        url: "https://example.com/docs?utm_source=test&id=1",
+        snippet: "",
+        published_at: null,
+        score: 1,
+        source_provider: "exa",
+      },
+      {
+        title: "B",
+        url: "https://example.com/docs?id=1&utm_medium=email",
+        snippet: "",
+        published_at: null,
+        score: 0.8,
+        source_provider: "brave",
+      },
+    ];
+
+    expect(canonicalizeUrl(inputs[0].url)).toBe("https://example.com/docs?id=1");
+    const deduped = dedupeByCanonicalUrl(inputs);
+    expect(deduped).toHaveLength(1);
+    expect(deduped[0].url).toBe("https://example.com/docs?id=1");
+  });
+});

--- a/core/web-search/cache.ts
+++ b/core/web-search/cache.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { SearchRequest } from "./provider-adapter";
+import { normalizeQuery } from "./query-utils";
+
+interface CacheEntry<T> {
+  expiresAt: number;
+  value: T;
+}
+
+type CacheStore<T> = Record<string, CacheEntry<T>>;
+
+export interface QueryCacheOptions {
+  filePath: string;
+  ttlMs: number;
+}
+
+export class QueryCache<T> {
+  private readonly filePath: string;
+  private readonly ttlMs: number;
+
+  constructor(options: QueryCacheOptions) {
+    this.filePath = options.filePath;
+    this.ttlMs = options.ttlMs;
+  }
+
+  async get(request: SearchRequest): Promise<T | null> {
+    const key = cacheKey(request);
+    const store = await this.load();
+    const entry = store[key];
+    if (!entry) {
+      return null;
+    }
+
+    if (Date.now() >= entry.expiresAt) {
+      delete store[key];
+      await this.save(store);
+      return null;
+    }
+
+    return entry.value;
+  }
+
+  async set(request: SearchRequest, value: T): Promise<void> {
+    const key = cacheKey(request);
+    const store = await this.load();
+    store[key] = {
+      expiresAt: Date.now() + this.ttlMs,
+      value,
+    };
+    await this.save(store);
+  }
+
+  private async load(): Promise<CacheStore<T>> {
+    try {
+      const raw = await readFile(this.filePath, "utf8");
+      return JSON.parse(raw) as CacheStore<T>;
+    } catch {
+      return {};
+    }
+  }
+
+  private async save(store: CacheStore<T>): Promise<void> {
+    await mkdir(path.dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  }
+}
+
+function cacheKey(request: SearchRequest): string {
+  const normalizedQuery = normalizeQuery(request.query);
+  const key = [
+    "v2",
+    request.command,
+    normalizedQuery,
+    request.limit ?? "",
+    request.recencyDays ?? "",
+  ].join(":");
+  return createHash("sha256").update(key).digest("hex");
+}

--- a/core/web-search/cli.ts
+++ b/core/web-search/cli.ts
@@ -25,8 +25,8 @@ interface CliInput {
 async function main(): Promise<void> {
   const input = parseArgs(process.argv.slice(2));
   const configDir = process.env.PI_CONFIG_DIR ?? path.resolve(process.cwd(), "..", "..");
-  const cacheTtlMs = Number(process.env.WEB_SEARCH_TTL_MS ?? 30 * 60 * 1000);
-  const limit = Number(process.env.WEB_SEARCH_MAX_RESULTS ?? 5);
+  const cacheTtlMs = Number(process.env.WEB_SEARCH_TTL_MS) || 30 * 60 * 1000;
+  const limit = Number(process.env.WEB_SEARCH_MAX_RESULTS) || 5;
 
   const request = {
     query: input.query,

--- a/core/web-search/cli.ts
+++ b/core/web-search/cli.ts
@@ -1,0 +1,129 @@
+import path from "node:path";
+
+import { QueryCache } from "./cache";
+import { assessConfidence } from "./confidence";
+import { WebSearchOrchestrator } from "./orchestrator";
+import {
+  Context7Provider,
+  BraveProvider,
+  ExaProvider,
+  PerplexitySynthesisProvider,
+} from "./providers";
+import type { ProviderAdapter, SearchResponse, WebCommand } from "./provider-adapter";
+import {
+  inferRecencyDays,
+  isDocsLookup,
+  isTimeSensitiveQuery,
+  normalizeQuery,
+} from "./query-utils";
+
+interface CliInput {
+  command: WebCommand;
+  query: string;
+}
+
+async function main(): Promise<void> {
+  const input = parseArgs(process.argv.slice(2));
+  const configDir = process.env.PI_CONFIG_DIR ?? path.resolve(process.cwd(), "..", "..");
+  const cacheTtlMs = Number(process.env.WEB_SEARCH_TTL_MS ?? 30 * 60 * 1000);
+  const limit = Number(process.env.WEB_SEARCH_MAX_RESULTS ?? 5);
+
+  const request = {
+    query: input.query,
+    command: input.command,
+    limit,
+    recencyDays: inferRecencyDays({
+      query: input.query,
+      command: input.command,
+      limit,
+    }),
+  };
+
+  const providers: ProviderAdapter[] = [];
+  const useContext7 = Boolean(process.env.CONTEXT7_API_KEY) && isDocsLookup(input.query, input.command);
+  if (useContext7) {
+    providers.push(new Context7Provider(process.env.CONTEXT7_API_KEY!));
+  }
+  if (process.env.EXA_API_KEY) {
+    providers.push(new ExaProvider(process.env.EXA_API_KEY));
+  }
+  if (process.env.BRAVE_API_KEY) {
+    providers.push(new BraveProvider(process.env.BRAVE_API_KEY));
+  }
+
+  if (providers.length === 0) {
+    throw new Error(
+      "no retrieval providers configured; set CONTEXT7_API_KEY and/or EXA_API_KEY and/or BRAVE_API_KEY"
+    );
+  }
+
+  const cache = new QueryCache({
+    filePath: path.join(configDir, "cache", "web-search-cache.json"),
+    ttlMs: cacheTtlMs,
+  });
+
+  const orchestrator = new WebSearchOrchestrator(providers, {
+    cache,
+    logPath: path.join(configDir, "logs", "web-search.ndjson"),
+  });
+
+  const { results, meta } = await orchestrator.searchWithMeta(request);
+  const confidence = assessConfidence(request, results);
+
+  let synthesis: SearchResponse["synthesis"] = null;
+  if (input.command === "web-deep" && process.env.PERPLEXITY_API_KEY && results.length > 0) {
+    const synthesizer = new PerplexitySynthesisProvider(process.env.PERPLEXITY_API_KEY);
+    const generated = await synthesizer.synthesize(input.query, results);
+    synthesis = generated.citations.length > 0 ? generated : null;
+  }
+
+  const response: SearchResponse = {
+    results,
+    meta: {
+      query: input.query,
+      normalized_query: normalizeQuery(input.query),
+      command: input.command,
+      provider_chain: meta.providerChain,
+      provider_used: meta.providerUsed,
+      cache_hit: meta.cacheHit,
+      time_sensitive: isTimeSensitiveQuery(input.query, input.command),
+      recency_days: request.recencyDays ?? null,
+      confidence: confidence.confidence,
+      uncertainty: confidence.uncertainty,
+    },
+    synthesis,
+  };
+
+  process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+}
+
+function parseArgs(args: string[]): CliInput {
+  if (args.length < 2) {
+    throw new Error("usage: web-search <web|web-deep|web-news|web-docs> <query>");
+  }
+
+  const [command, ...queryParts] = args;
+  if (
+    command !== "web" &&
+    command !== "web-deep" &&
+    command !== "web-news" &&
+    command !== "web-docs"
+  ) {
+    throw new Error("command must be one of: web, web-deep, web-news, web-docs");
+  }
+
+  const query = queryParts.join(" ").trim();
+  if (!query) {
+    throw new Error("query must not be empty");
+  }
+
+  return {
+    command,
+    query,
+  };
+}
+
+main().catch((error) => {
+  process.stderr.write(`${String(error)}\n`);
+  process.exit(1);
+});

--- a/core/web-search/confidence.ts
+++ b/core/web-search/confidence.ts
@@ -1,0 +1,106 @@
+import type { SearchMeta, SearchRequest, SearchResult } from "./provider-adapter";
+import { inferRecencyDays, isTimeSensitiveQuery } from "./query-utils";
+
+export interface ConfidenceAssessment {
+  confidence: SearchMeta["confidence"];
+  uncertainty: string | null;
+}
+
+export function assessConfidence(
+  request: SearchRequest,
+  results: SearchResult[]
+): ConfidenceAssessment {
+  if (results.length === 0) {
+    return {
+      confidence: "low",
+      uncertainty: "No sources returned from configured providers.",
+    };
+  }
+
+  if (results.length === 1) {
+    return {
+      confidence: "medium",
+      uncertainty: "Only one source found. Cross-check before relying on it.",
+    };
+  }
+
+  const timeSensitive = isTimeSensitiveQuery(request.query, request.command);
+  if (!timeSensitive) {
+    return {
+      confidence: results.length >= 4 ? "high" : "medium",
+      uncertainty: results.length >= 4 ? null : "Limited source count.",
+    };
+  }
+
+  const recencyDays = inferRecencyDays(request) ?? 30;
+  const recentCount = results.filter((result) =>
+    isRecentEnough(result.published_at, recencyDays)
+  ).length;
+
+  if (recentCount === 0) {
+    return {
+      confidence: "low",
+      uncertainty: `No clearly recent sources found within ~${recencyDays} days.`,
+    };
+  }
+
+  if (recentCount < 2) {
+    return {
+      confidence: "medium",
+      uncertainty: `Only ${recentCount} recent source found within ~${recencyDays} days.`,
+    };
+  }
+
+  return {
+    confidence: "high",
+    uncertainty: null,
+  };
+}
+
+function isRecentEnough(publishedAt: string | null, recencyDays: number): boolean {
+  const publishedMs = parsePublishedAtToMs(publishedAt);
+  if (publishedMs === null) {
+    return false;
+  }
+
+  const maxAgeMs = recencyDays * 24 * 60 * 60 * 1000;
+  return Date.now() - publishedMs <= maxAgeMs;
+}
+
+function parsePublishedAtToMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const direct = Date.parse(value);
+  if (Number.isFinite(direct)) {
+    return direct;
+  }
+
+  const trimmed = value.trim().toLowerCase();
+  if (trimmed === "yesterday") {
+    return Date.now() - 24 * 60 * 60 * 1000;
+  }
+
+  const agoMatch = trimmed.match(/(\d+)\s+(minute|hour|day|week|month|year)s?\s+ago/);
+  if (!agoMatch) {
+    return null;
+  }
+
+  const valueNum = Number(agoMatch[1]);
+  const unit = agoMatch[2];
+  const unitMs =
+    unit === "minute"
+      ? 60 * 1000
+      : unit === "hour"
+      ? 60 * 60 * 1000
+      : unit === "day"
+      ? 24 * 60 * 60 * 1000
+      : unit === "week"
+      ? 7 * 24 * 60 * 60 * 1000
+      : unit === "month"
+      ? 30 * 24 * 60 * 60 * 1000
+      : 365 * 24 * 60 * 60 * 1000;
+
+  return Date.now() - valueNum * unitMs;
+}

--- a/core/web-search/orchestrator.ts
+++ b/core/web-search/orchestrator.ts
@@ -1,0 +1,176 @@
+import type { SearchRequest, SearchResult, ProviderAdapter } from "./provider-adapter";
+import type { QueryCache } from "./cache";
+import { dedupeByCanonicalUrl, normalizeQuery } from "./query-utils";
+import { appendLineWithRotation } from "../../extensions/shared/log-rotation";
+
+export interface OrchestratorOptions {
+  cache?: QueryCache<SearchResult[]>;
+  logPath?: string;
+}
+
+export interface SearchRunMeta {
+  cacheHit: boolean;
+  providerUsed: ProviderAdapter["name"] | null;
+  providerChain: ProviderAdapter["name"][];
+}
+
+const WEB_SEARCH_LOG_MAX_BYTES = clampInt(
+  Number(process.env.PI_WEB_SEARCH_LOG_MAX_BYTES ?? 10 * 1024 * 1024),
+  128 * 1024,
+  512 * 1024 * 1024,
+);
+const WEB_SEARCH_LOG_MAX_BACKUPS = clampInt(
+  Number(process.env.PI_WEB_SEARCH_LOG_MAX_BACKUPS ?? 5),
+  1,
+  20,
+);
+const WEB_SEARCH_LOG_ROTATE_CHECK_MS = clampInt(
+  Number(process.env.PI_WEB_SEARCH_LOG_ROTATE_CHECK_MS ?? 30_000),
+  1_000,
+  10 * 60 * 1000,
+);
+
+interface LogEvent {
+  ts: string;
+  event: string;
+  query: string;
+  command: SearchRequest["command"];
+  provider?: ProviderAdapter["name"];
+  count?: number;
+  detail?: string;
+}
+
+export class WebSearchOrchestrator {
+  private readonly providers: ProviderAdapter[];
+  private readonly cache?: QueryCache<SearchResult[]>;
+  private readonly logPath?: string;
+
+  constructor(providers: ProviderAdapter[], options: OrchestratorOptions = {}) {
+    if (providers.length === 0) {
+      throw new Error("providers must not be empty");
+    }
+    this.providers = providers;
+    this.cache = options.cache;
+    this.logPath = options.logPath;
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult[]> {
+    const { results } = await this.searchWithMeta(request);
+    return results;
+  }
+
+  async searchWithMeta(
+    request: SearchRequest
+  ): Promise<{ results: SearchResult[]; meta: SearchRunMeta }> {
+    const providerChain = this.providers.map((provider) => provider.name);
+
+    if (this.cache) {
+      const cached = await this.cache.get(request);
+      if (cached) {
+        await this.log({ event: "cache_hit", request, count: cached.length });
+        return {
+          results: cached,
+          meta: {
+            cacheHit: true,
+            providerUsed: cached[0]?.source_provider ?? null,
+            providerChain,
+          },
+        };
+      }
+    }
+
+    let lastError: unknown = null;
+    await this.log({ event: "cache_miss", request });
+
+    for (const provider of this.providers) {
+      try {
+        const results = await provider.search(request);
+        if (results.length === 0) {
+          await this.log({ event: "provider_empty", request, provider });
+          continue;
+        }
+
+        const deduped = dedupeByCanonicalUrl(results);
+        if (this.cache) {
+          await this.cache.set(request, deduped);
+        }
+
+        await this.log({
+          event: "provider_success",
+          request,
+          provider,
+          count: deduped.length,
+        });
+        return {
+          results: deduped,
+          meta: {
+            cacheHit: false,
+            providerUsed: provider.name,
+            providerChain,
+          },
+        };
+      } catch (error) {
+        lastError = error;
+        await this.log({
+          event: "provider_error",
+          request,
+          provider,
+          detail: String(error),
+        });
+      }
+    }
+
+    await this.log({
+      event: "all_providers_failed",
+      request,
+      detail: lastError ? String(lastError) : "no results",
+    });
+
+    if (lastError) {
+      throw lastError;
+    }
+    return {
+      results: [],
+      meta: {
+        cacheHit: false,
+        providerUsed: null,
+        providerChain,
+      },
+    };
+  }
+
+  private async log(input: {
+    event: string;
+    request: SearchRequest;
+    provider?: ProviderAdapter;
+    count?: number;
+    detail?: string;
+  }): Promise<void> {
+    if (!this.logPath) {
+      return;
+    }
+
+    const payload: LogEvent = {
+      ts: new Date().toISOString(),
+      event: input.event,
+      query: normalizeQuery(input.request.query),
+      command: input.request.command,
+      provider: input.provider?.name,
+      count: input.count,
+      detail: input.detail,
+    };
+
+    await appendLineWithRotation(this.logPath, `${JSON.stringify(payload)}\n`, {
+      maxBytes: WEB_SEARCH_LOG_MAX_BYTES,
+      maxBackups: WEB_SEARCH_LOG_MAX_BACKUPS,
+      checkIntervalMs: WEB_SEARCH_LOG_ROTATE_CHECK_MS,
+    });
+  }
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}

--- a/core/web-search/orchestrator.ts
+++ b/core/web-search/orchestrator.ts
@@ -1,7 +1,38 @@
+import * as fs from "node:fs";
+import * as nodePath from "node:path";
 import type { SearchRequest, SearchResult, ProviderAdapter } from "./provider-adapter";
 import type { QueryCache } from "./cache";
 import { dedupeByCanonicalUrl, normalizeQuery } from "./query-utils";
-import { appendLineWithRotation } from "../../extensions/shared/log-rotation";
+
+// Log rotation — inlined to avoid external dependency
+interface RotationOptions {
+  maxBytes: number;
+  maxBackups: number;
+  checkIntervalMs: number;
+}
+const _lastRotationCheck: Map<string, number> = new Map();
+async function appendLineWithRotation(
+  filePath: string,
+  line: string,
+  opts: RotationOptions,
+): Promise<void> {
+  await fs.promises.mkdir(nodePath.dirname(filePath), { recursive: true });
+  const now = Date.now();
+  const lastCheck = _lastRotationCheck.get(filePath) ?? 0;
+  if (now - lastCheck >= opts.checkIntervalMs) {
+    _lastRotationCheck.set(filePath, now);
+    try {
+      const stat = await fs.promises.stat(filePath);
+      if (stat.size >= opts.maxBytes) {
+        for (let i = opts.maxBackups - 1; i >= 1; i--) {
+          try { await fs.promises.rename(`${filePath}.${i}`, `${filePath}.${i + 1}`); } catch { /* skip */ }
+        }
+        try { await fs.promises.rename(filePath, `${filePath}.1`); } catch { /* skip */ }
+      }
+    } catch { /* file doesn't exist yet */ }
+  }
+  await fs.promises.appendFile(filePath, line, "utf8");
+}
 
 export interface OrchestratorOptions {
   cache?: QueryCache<SearchResult[]>;

--- a/core/web-search/provider-adapter.ts
+++ b/core/web-search/provider-adapter.ts
@@ -1,0 +1,48 @@
+export type WebCommand = "web" | "web-deep" | "web-news" | "web-docs";
+
+export type SearchProviderName = "context7" | "exa" | "brave" | "perplexity";
+
+export type ConfidenceLevel = "high" | "medium" | "low";
+
+export interface SearchRequest {
+  query: string;
+  command: WebCommand;
+  limit?: number;
+  recencyDays?: number;
+}
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+  published_at: string | null;
+  score: number;
+  source_provider: SearchProviderName;
+}
+
+export interface SearchMeta {
+  query: string;
+  normalized_query: string;
+  command: WebCommand;
+  provider_chain: SearchProviderName[];
+  provider_used: SearchProviderName | null;
+  cache_hit: boolean;
+  time_sensitive: boolean;
+  recency_days: number | null;
+  confidence: ConfidenceLevel;
+  uncertainty: string | null;
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+  meta: SearchMeta;
+  synthesis: {
+    summary: string;
+    citations: string[];
+  } | null;
+}
+
+export interface ProviderAdapter {
+  readonly name: SearchProviderName;
+  search(request: SearchRequest): Promise<SearchResult[]>;
+}

--- a/core/web-search/providers.ts
+++ b/core/web-search/providers.ts
@@ -1,0 +1,388 @@
+import type { ProviderAdapter, SearchRequest, SearchResult } from "./provider-adapter";
+import { isoTimestampDaysAgo } from "./query-utils";
+
+const DEFAULT_LIMIT = 5;
+const CONTEXT7_BASE_URL = process.env.CONTEXT7_BASE_URL ?? "https://context7.com/api/v1";
+const PERPLEXITY_MODEL = process.env.PERPLEXITY_MODEL ?? "sonar";
+
+type Context7SearchItem = {
+  id?: string;
+  title?: string;
+  name?: string;
+  url?: string;
+  description?: string;
+  snippets?: string[];
+  score?: number;
+};
+
+export class Context7Provider implements ProviderAdapter {
+  readonly name = "context7" as const;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult[]> {
+    const payload = await this.searchPayload(request.query);
+
+    const items = (payload.results ?? payload.data ?? []).slice(0, request.limit ?? DEFAULT_LIMIT);
+    if (items.length === 0) {
+      return [];
+    }
+
+    const mapped = items.map((item, index) => {
+      const fallbackUrl = item.id ? `https://context7.com/${item.id}` : "";
+      return {
+        title: item.title ?? item.name ?? (fallbackUrl || "Context7 result"),
+        url: item.url ?? fallbackUrl,
+        snippet: item.description ?? firstSnippet(item.snippets),
+        published_at: null,
+        score: scoreFromRank(index),
+        source_provider: "context7" as const,
+      };
+    });
+
+    // For explicit docs mode, enrich the first result with actual documentation text.
+    if (request.command === "web-docs" && items[0]?.id) {
+      const docsSnippet = await this.fetchDocSnippet(items[0].id);
+      if (docsSnippet) {
+        mapped[0] = {
+          ...mapped[0],
+          snippet: docsSnippet,
+        };
+      }
+    }
+
+    return mapped.filter((item) => Boolean(item.url));
+  }
+
+  private async searchPayload(
+    query: string
+  ): Promise<{ results?: Context7SearchItem[]; data?: Context7SearchItem[] }> {
+    const postResponse = await fetch(`${CONTEXT7_BASE_URL}/search`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        query,
+      }),
+    });
+
+    if (postResponse.ok) {
+      return (await postResponse.json()) as { results?: Context7SearchItem[]; data?: Context7SearchItem[] };
+    }
+
+    // Context7 deployments differ; some only support GET.
+    if (postResponse.status === 405) {
+      const params = new URLSearchParams({ query });
+      const getResponse = await fetch(`${CONTEXT7_BASE_URL}/search?${params}`, {
+        method: "GET",
+        headers: {
+          authorization: `Bearer ${this.apiKey}`,
+        },
+      });
+      if (getResponse.ok) {
+        return (await getResponse.json()) as {
+          results?: Context7SearchItem[];
+          data?: Context7SearchItem[];
+        };
+      }
+      throw new Error(`context7 search failed: ${getResponse.status}`);
+    }
+
+    throw new Error(`context7 search failed: ${postResponse.status}`);
+  }
+
+  private async fetchDocSnippet(context7Id: string): Promise<string | null> {
+    try {
+      const response = await fetch(`${CONTEXT7_BASE_URL}/${context7Id}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify({
+          tokens: 1800,
+        }),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const payload = (await response.json()) as Record<string, unknown>;
+      return extractBestDocSnippet(payload);
+    } catch {
+      return null;
+    }
+  }
+}
+
+export class ExaProvider implements ProviderAdapter {
+  readonly name = "exa" as const;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult[]> {
+    const recencyStart =
+      typeof request.recencyDays === "number" ? isoTimestampDaysAgo(request.recencyDays) : null;
+
+    const response = await fetch("https://api.exa.ai/search", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": this.apiKey,
+      },
+      body: JSON.stringify({
+        query: request.query,
+        numResults: request.limit ?? DEFAULT_LIMIT,
+        ...(recencyStart ? { startPublishedDate: recencyStart } : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`exa search failed: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      results?: Array<{
+        title?: string;
+        url?: string;
+        text?: string;
+        publishedDate?: string;
+        score?: number;
+      }>;
+    };
+
+    return (payload.results ?? [])
+      .filter((item) => Boolean(item.url))
+      .map((item) => ({
+        title: item.title ?? item.url ?? "Untitled",
+        url: item.url!,
+        snippet: item.text ?? "",
+        published_at: item.publishedDate ?? null,
+        score: item.score ?? 0,
+        source_provider: "exa" as const,
+      }));
+  }
+}
+
+export class BraveProvider implements ProviderAdapter {
+  readonly name = "brave" as const;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult[]> {
+    const query = new URLSearchParams({
+      q: request.query,
+      count: String(request.limit ?? DEFAULT_LIMIT),
+    });
+
+    const freshness = freshnessFromRecencyDays(request.recencyDays);
+    if (freshness) {
+      query.set("freshness", freshness);
+    }
+
+    const response = await fetch(`https://api.search.brave.com/res/v1/web/search?${query}`, {
+      headers: {
+        Accept: "application/json",
+        "X-Subscription-Token": this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`brave search failed: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      web?: {
+        results?: Array<{
+          title?: string;
+          url?: string;
+          description?: string;
+          age?: string;
+        }>;
+      };
+    };
+
+    return (payload.web?.results ?? [])
+      .filter((item) => Boolean(item.url))
+      .map((item, index) => ({
+        title: item.title ?? item.url ?? "Untitled",
+        url: item.url!,
+        snippet: item.description ?? "",
+        published_at: item.age ?? null,
+        score: scoreFromRank(index),
+        source_provider: "brave" as const,
+      }));
+  }
+}
+
+export class PerplexitySynthesisProvider implements ProviderAdapter {
+  readonly name = "perplexity" as const;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  async search(request: SearchRequest): Promise<SearchResult[]> {
+    const synthesis = await this.synthesize(request.query, []);
+    return synthesis.citations.map((url, index) => ({
+      title: "Perplexity citation",
+      url,
+      snippet: synthesis.summary,
+      published_at: null,
+      score: scoreFromRank(index),
+      source_provider: "perplexity" as const,
+    }));
+  }
+
+  async synthesize(
+    query: string,
+    sources: SearchResult[]
+  ): Promise<{ summary: string; citations: string[] }> {
+    const sourceLines = sources
+      .map((result, index) => `${index + 1}. ${result.title} :: ${result.url}`)
+      .join("\n");
+
+    const response = await fetch("https://api.perplexity.ai/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY_MODEL,
+        messages: [
+          {
+            role: "system",
+            content:
+              "Summarize using provided sources. Never invent URLs. Keep uncertainty explicit.",
+          },
+          {
+            role: "user",
+            content: [
+              `Query: ${query}`,
+              "Use these source URLs as ground truth:",
+              sourceLines || "(No explicit sources were provided.)",
+              "Return concise synthesis and include citations from sources.",
+            ].join("\n"),
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`perplexity synthesis failed: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      choices?: Array<{
+        message?: {
+          content?: string;
+        };
+      }>;
+      citations?: string[];
+      search_results?: Array<{ url?: string }>;
+    };
+
+    const modelSummary = payload.choices?.[0]?.message?.content?.trim() ?? "";
+    const citations = dedupeUrls([
+      ...(payload.citations ?? []),
+      ...((payload.search_results ?? []).map((item) => item.url).filter(Boolean) as string[]),
+    ]);
+
+    return {
+      summary: modelSummary,
+      citations,
+    };
+  }
+}
+
+function scoreFromRank(index: number): number {
+  const value = 1 - index * 0.05;
+  return value > 0 ? value : 0;
+}
+
+function freshnessFromRecencyDays(recencyDays: number | undefined): "pd" | "pw" | "pm" | "py" | null {
+  if (typeof recencyDays !== "number") {
+    return null;
+  }
+  if (recencyDays <= 1) {
+    return "pd";
+  }
+  if (recencyDays <= 7) {
+    return "pw";
+  }
+  if (recencyDays <= 31) {
+    return "pm";
+  }
+  return "py";
+}
+
+function firstSnippet(snippets: string[] | undefined): string {
+  if (!snippets || snippets.length === 0) {
+    return "";
+  }
+  return snippets[0];
+}
+
+function dedupeUrls(urls: string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const url of urls) {
+    const normalized = url.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    deduped.push(normalized);
+  }
+  return deduped;
+}
+
+function extractBestDocSnippet(payload: Record<string, unknown>): string | null {
+  const directText = payload.content;
+  if (typeof directText === "string" && directText.trim()) {
+    return truncateSnippet(directText);
+  }
+
+  const textField = payload.text;
+  if (typeof textField === "string" && textField.trim()) {
+    return truncateSnippet(textField);
+  }
+
+  const chunks = payload.chunks;
+  if (Array.isArray(chunks)) {
+    for (const chunk of chunks) {
+      if (typeof chunk === "string" && chunk.trim()) {
+        return truncateSnippet(chunk);
+      }
+      if (
+        typeof chunk === "object" &&
+        chunk &&
+        "content" in chunk &&
+        typeof (chunk as { content?: unknown }).content === "string"
+      ) {
+        return truncateSnippet((chunk as { content: string }).content);
+      }
+    }
+  }
+
+  return null;
+}
+
+function truncateSnippet(input: string): string {
+  const trimmed = input.trim().replace(/\s+/g, " ");
+  return trimmed.length > 480 ? `${trimmed.slice(0, 477)}...` : trimmed;
+}

--- a/core/web-search/query-utils.ts
+++ b/core/web-search/query-utils.ts
@@ -1,0 +1,106 @@
+import type { SearchRequest, SearchResult, WebCommand } from "./provider-adapter";
+
+const TIME_SENSITIVE_PATTERN =
+  /\b(latest|today|current|currently|now|recent|newest|breaking|this week|this month)\b/i;
+const DOCS_PATTERN = /\b(api|sdk|docs?|documentation|reference|library|framework|package)\b/i;
+const TRACKING_QUERY_KEYS = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "fbclid",
+  "gclid",
+  "ref",
+]);
+
+export function normalizeQuery(query: string): string {
+  return query.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function isDocsLookup(query: string, command: WebCommand): boolean {
+  if (command === "web-docs") {
+    return true;
+  }
+  return DOCS_PATTERN.test(query);
+}
+
+export function isTimeSensitiveQuery(query: string, command: WebCommand): boolean {
+  if (command === "web-news") {
+    return true;
+  }
+  return TIME_SENSITIVE_PATTERN.test(query);
+}
+
+export function inferRecencyDays(request: SearchRequest): number | null {
+  if (typeof request.recencyDays === "number") {
+    const bounded = Math.max(1, Math.min(3650, Math.floor(request.recencyDays)));
+    return bounded;
+  }
+
+  if (request.command === "web-news") {
+    return 7;
+  }
+
+  if (isTimeSensitiveQuery(request.query, request.command)) {
+    return 30;
+  }
+
+  return null;
+}
+
+export function isoTimestampDaysAgo(days: number): string {
+  const nowMs = Date.now();
+  const deltaMs = days * 24 * 60 * 60 * 1000;
+  return new Date(nowMs - deltaMs).toISOString();
+}
+
+export function canonicalizeUrl(rawUrl: string): string {
+  const input = rawUrl.trim();
+  if (!input) {
+    return input;
+  }
+
+  try {
+    const parsed = new URL(input);
+    parsed.hash = "";
+    const keep = new URLSearchParams();
+    for (const [key, value] of parsed.searchParams.entries()) {
+      if (!TRACKING_QUERY_KEYS.has(key.toLowerCase())) {
+        keep.append(key, value);
+      }
+    }
+
+    const sorted = [...keep.entries()].sort(([a], [b]) => a.localeCompare(b));
+    parsed.search = "";
+    for (const [key, value] of sorted) {
+      parsed.searchParams.append(key, value);
+    }
+
+    if (parsed.pathname !== "/" && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    }
+    return parsed.toString();
+  } catch {
+    return input;
+  }
+}
+
+export function dedupeByCanonicalUrl(results: SearchResult[]): SearchResult[] {
+  const seen = new Set<string>();
+  const deduped: SearchResult[] = [];
+
+  for (const result of results) {
+    const normalizedUrl = canonicalizeUrl(result.url);
+    if (!normalizedUrl || seen.has(normalizedUrl)) {
+      continue;
+    }
+    seen.add(normalizedUrl);
+    deduped.push({
+      ...result,
+      url: normalizedUrl,
+    });
+  }
+
+  return deduped;
+}

--- a/core/webapp-testing/SKILL.md
+++ b/core/webapp-testing/SKILL.md
@@ -5,7 +5,6 @@ description: |
   frontend functionality, debugging UI behavior, capturing screenshots, and
   viewing browser logs. Reference skill for browser-based testing patterns.
 user-invocable: false
-license: Complete terms in LICENSE.txt
 ---
 
 # Web Application Testing

--- a/docs/pi-local-workflow.md
+++ b/docs/pi-local-workflow.md
@@ -1,0 +1,32 @@
+# Pi Local Workflow
+
+This repository is bootstrapped for agent-skills using repo-local Pi config under .pi/.
+
+## Recommended run pattern
+
+1. Use meta mode when evolving architecture/config primitives:
+   - `pictl meta`
+2. Use build mode for normal project delivery:
+   - `pictl build`
+3. Use local prompt workflows:
+   - `/discover`
+   - `/design`
+   - `/deliver`
+   - `/review`
+4. Prime and use local-first memory:
+   - `/memory-ingest --scope both --force` (first run, then periodic refresh)
+   - `/memory-search --scope local <topic>`
+   - `/memory-context --scope both <goal>`
+5. If orchestration is enabled, run local pipelines:
+   - `/pipeline repo-foundation-v1 <goal>`
+   - `/pipeline repo-delivery-v1 <goal>`
+
+## Local artifacts
+
+- `.pi/settings.json`
+- `.pi/persona.md`
+- `.pi/agents/*.md`
+- `.pi/agents/teams.yaml`
+- `.pi/agents/pipelines.yaml`
+- `.pi/prompts/*.md`
+- `.pi/bootstrap-report.md`


### PR DESCRIPTION
## Summary

Two cleanup streams plus net-new capabilities:

1. **Strip `effort:` frontmatter** — field was never consumed by any harness (Claude, Codex, Gemini, Pi). It added maintenance noise without routing signal. Removed from all 74 skills.
2. **Fix stale skill references** — several skills pointed to deleted commands (`/refactor`, `/review-branch`, `/update-docs`). Patched to current equivalents (`/pr-fix`, inline).
3. **Add 9 new skills** — fills gaps identified in recent sessions.

## Changes

- `CLAUDE.md` / `README.md`: remove effort field docs, update references list, add `/distill` to table
- `core/*/SKILL.md` (73 files): strip `effort:` line from frontmatter
- `core/autopilot`, `delegate`, `ralph-patterns`, `visual-qa`: fix stale skill refs
- New: `agentic-bootstrap`, `deploy`, `github-cli-hygiene`, `llm-communication`, `organic-reflection`, `pr-feedback`, `prompt-context-engineering`, `sysadmin-ops`, `web-search`
- New: `AGENTS.md` (repo-level agent guidance), `docs/pi-local-workflow.md`
- `core/web-search/`: TypeScript implementation with tests (orchestrator, providers, cache, confidence scoring)

## Acceptance Criteria

- [x] No `effort:` field in any `SKILL.md` frontmatter
- [x] All skill cross-references point to existing skills
- [x] 9 new skills have valid frontmatter and content
- [x] `CLAUDE.md` reflects updated Adding a Skill workflow (no effort step)

## Manual QA

```bash
# Verify no effort fields remain
grep -r "^effort:" core/ --include="*.md"  # should return nothing

# Verify new skills exist
ls core/{agentic-bootstrap,deploy,github-cli-hygiene,llm-communication,organic-reflection,pr-feedback,prompt-context-engineering,sysadmin-ops,web-search}/SKILL.md

# Verify stale refs are gone
grep -r "review-branch\|/refactor\|/update-docs" core/ --include="*.md"  # should return nothing
```

## What Changed

```graph TD
    A[74 skills with effort field] --> B[Remove effort field]
    B --> C[74 clean skills]
    D[Stale refs: /refactor /review-branch /update-docs] --> E[Fix to current equivalents]
    F[Gap analysis: 9 missing skills] --> G[Add 9 new skills]
    C --> H[83 total skills]
    E --> H
    G --> H
```

## Before / After

**Before:** All skills had `effort: low|medium|high|max` in frontmatter. Several skills referenced deleted commands (`/refactor`, `/review-branch`, `/update-docs`). 9 capability gaps existed with no skill coverage.

**After:** `effort:` removed from all skills. Stale refs patched. 9 new skills cover: deploy orchestration, PR feedback, web search, prompt engineering, sysadmin ops, agentic bootstrap, LLM communication patterns, organic reflection, and GitHub CLI hygiene.

## Test Coverage

- `core/web-search/__tests__/confidence.test.ts` — confidence scoring logic
- `core/web-search/__tests__/query-utils.test.ts` — query normalization
- Other skills are documentation-only (no runnable tests by design)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Web search with multi-provider support, confidence scoring, caching, and a CLI entrypoint.
  - Agent-based pipelines and team roles for repository planning, delivery, and review.
  - New deployment and sysadmin skills and several operational skills.

* **Documentation**
  - Comprehensive agentic bootstrap, persona, prompts, and local workflow guides added.
  - Expanded skill library, best-practices, references, and reporting/feedback docs.

* **Tests**
  - Added test coverage for web-search confidence and query utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->