### PR TITLE
feat: codify llm-semantic-match as reference skill

### DIFF
--- a/core/llm-semantic-match/SKILL.md
+++ b/core/llm-semantic-match/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: llm-semantic-match
-description: Use LLM sub-calls to resolve user intent to one item from a finite set. Replace all fuzzy/substring string matching in agent tools with this pattern.
+user-invocable: false
+description: |
+  Use LLM sub-calls to resolve user intent to one item from a finite set.
+  Replace all fuzzy/substring string matching in agent tools with this pattern.
+  Keywords: semantic matching, intent resolution, fuzzy match, tool lookup, entity resolution.
 ---
 
 # LLM-as-Semantic-Matcher


### PR DESCRIPTION
## Summary

A loose `llm-semantic-match.md` was sitting at the repo root — valid content, wrong location. This moves it into the proper skill structure as a reference skill (auto-loads as ambient context, no budget cost).

No issue — housekeeping found during a skill audit session.

## Changes

- `llm-semantic-match.md` (root) → `core/llm-semantic-match/SKILL.md`
- Added `user-invocable: false` to frontmatter (reference mode, not a slash command)
- Expanded `description` with keywords for model-side discovery

## Acceptance Criteria

- [x] Skill lives in `core/llm-semantic-match/SKILL.md`
- [x] Frontmatter has `user-invocable: false`
- [x] Stale root-level file removed
- [x] Synced to `~/.claude/skills/` (84 skills)

## Manual QA

```bash
ls core/llm-semantic-match/SKILL.md          # exists
head -5 core/llm-semantic-match/SKILL.md     # shows correct frontmatter
ls ~/.claude/skills/llm-semantic-match       # symlink present
# root file gone:
ls llm-semantic-match.md 2>&1               # No such file
```

## What Changed

```mermaid
graph TD
  A["llm-semantic-match.md (repo root)"] -->|moved + frontmatter updated| B["core/llm-semantic-match/SKILL.md"]
  B --> C["~/.claude/skills/llm-semantic-match (symlink)"]
```

## Before / After

**Before:** `llm-semantic-match.md` at repo root — valid pattern doc but invisible to the skill system, not auto-loaded, consuming no budget but also providing no value.

**After:** Proper reference skill. Auto-loads into Claude's context when building agent tools, surfacing the LLM-as-resolver pattern (exact match → LLM fallback → create new) and its dependency-injection approach for testability.

## Test Coverage

No tests — documentation-only repo. Visual verification via `ls` commands above.