### PR TITLE
fix(sync): isolate generated audit references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 .bak/
 .pi/state/
+core/audit/generated-references/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,10 @@ overlays/<harness>/<skill>/...
 Overlay files are merged onto `core/<skill>/` at sync time. Special file:
 - `SKILL.append.md` appends harness-specific instructions to `SKILL.md`
 
-Pack loading symlinks skills into the project's `.claude/skills/` and links
-`audit-references/*.md` into `core/audit/references/` so audit/fix/log-issues
-orchestrators find them automatically.
+Pack loading symlinks skills into the project's `.claude/skills/` and syncs
+`audit-references/*.md` into ignored runtime state at
+`core/audit/generated-references/` so audit/fix/log-issues can discover them
+without mutating tracked source.
 
 No build, lint, or test commands — this repo is documentation only.
 
@@ -120,9 +121,10 @@ Three unified skills replace all domain-specific check-*/fix-*/log-* skills:
 ```
 
 Core domain checklists live in `core/audit/references/`. Pack checklists live in
-`packs/<pack>/audit-references/` and get symlinked into `core/audit/references/`
-when a pack is loaded via `sync.sh pack <name>`. Audit/fix/log-issues discover
-available domains dynamically by scanning `references/*-checklist.md`.
+`packs/<pack>/audit-references/` and get symlinked into ignored runtime state at
+`core/audit/generated-references/` when a pack is loaded via
+`sync.sh pack <name>`. Audit/fix/log-issues discover available domains
+dynamically by scanning both checklist directories.
 
 ## Adding or Modifying a Skill
 

--- a/core/audit/SKILL.md
+++ b/core/audit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: audit
 description: |
-  Audit any domain with a checklist in references/. Run /audit <domain> for
-  structured P0-P3 findings report. /audit --all for everything.
-  /audit --list to see available domains. Dynamic: pack checklists appear
-  when loaded via sync.sh.
+  Audit any domain with a checklist in core references or generated pack
+  references. Run /audit <domain> for structured P0-P3 findings report.
+  /audit --all for everything. /audit --list to see available domains.
+  Dynamic: pack checklists appear when loaded via sync.sh.
   Invoke for: domain audit, compliance check, launch readiness, gap analysis.
 argument-hint: "<domain|--all|--list>"
 disable-model-invocation: true
@@ -26,27 +26,30 @@ Structured domain audit. One skill, all domains.
 
 ## Available Domains
 
-**Dynamic.** Domains are discovered by scanning `references/*-checklist.md`.
+**Dynamic.** Domains are discovered by scanning `references/*-checklist.md` and
+`generated-references/*-checklist.md`.
 
 Core domains ship with this skill. Pack domains (payments, growth, scaffold)
 appear after loading a pack via `sync.sh pack <name> <project>`, which
-symlinks pack checklists into `references/`.
+symlinks pack checklists into `generated-references/`.
 
 To list available domains:
 ```bash
-ls audit/references/*-checklist.md | sed 's|.*references/||;s|-checklist.md||'
+find audit/references audit/generated-references -maxdepth 1 -name '*-checklist.md' 2>/dev/null | sed 's|.*audit/[^/]*/||;s|-checklist.md||' | sort -u
 ```
 
 ## Process
 
 ### 1. Load Domain Checklist
 
-Read `references/{domain}-checklist.md` for the requested domain.
+Read `references/{domain}-checklist.md`, or `generated-references/{domain}-checklist.md`
+if the domain came from a loaded pack.
 
-If `--list`, scan `references/*-checklist.md` and list available domain names.
+If `--list`, scan both checklist directories and list unique domain names.
 
-If `--all`, load all checklist files. Auto-detect applicable domains from project
-(check package.json deps, config files, directory structure) and skip N/A domains.
+If `--all`, load all checklist files from both directories. Auto-detect
+applicable domains from project (check package.json deps, config files,
+directory structure) and skip N/A domains.
 
 ### 2. Execute Checks
 

--- a/core/fix/SKILL.md
+++ b/core/fix/SKILL.md
@@ -2,8 +2,9 @@
 name: fix
 description: |
   Audit a domain then fix the highest priority issue. Domains discovered
-  dynamically from audit/references/*-checklist.md. One fix per invocation.
-  Run again for next issue. Use for: bug fixes, domain issues, error resolution.
+  dynamically from audit core refs plus generated pack refs. One fix per
+  invocation. Run again for next issue. Use for: bug fixes, domain issues,
+  error resolution.
 argument-hint: "<domain|error>"
 ---
 
@@ -22,14 +23,17 @@ Audit. Fix. Verify. One issue at a time.
 
 ## Domains
 
-**Dynamic.** Scan `audit/references/*-checklist.md` for available domains.
-Core domains always present; pack domains appear after `sync.sh pack <name>`.
+**Dynamic.** Scan `audit/references/*-checklist.md` and
+`audit/generated-references/*-checklist.md` for available domains. Core domains
+always present; pack domains appear after `sync.sh pack <name>`.
 
 ## Process
 
 ### Domain Fix (argument matches a domain)
 
-1. **Audit** -- Read `audit/references/{domain}-checklist.md`, run all checks
+1. **Audit** -- Read `audit/references/{domain}-checklist.md`, or
+   `audit/generated-references/{domain}-checklist.md` for pack-provided domains,
+   then run all checks
 2. **Prioritize** -- Identify highest priority (P0 first) failing check
 3. **Fix** -- Apply the fix for that one issue
 4. **Verify** -- Re-run the failing check to confirm resolution

--- a/core/log-issues/SKILL.md
+++ b/core/log-issues/SKILL.md
@@ -2,8 +2,9 @@
 name: log-issues
 description: |
   Audit a domain then create GitHub issues for all findings. Domains discovered
-  dynamically from audit/references/*-checklist.md. Deduplicates against open issues.
-  Invoke for: backlog creation from audit, issue triage, gap tracking.
+  dynamically from audit core refs plus generated pack refs. Deduplicates
+  against open issues. Invoke for: backlog creation from audit, issue triage,
+  gap tracking.
 argument-hint: "<domain|--all>"
 disable-model-invocation: true
 ---
@@ -22,14 +23,17 @@ Audit a domain, create GitHub issues for every finding.
 
 ## Domains
 
-**Dynamic.** Scan `audit/references/*-checklist.md` for available domains.
-Core domains always present; pack domains appear after `sync.sh pack <name>`.
+**Dynamic.** Scan `audit/references/*-checklist.md` and
+`audit/generated-references/*-checklist.md` for available domains. Core domains
+always present; pack domains appear after `sync.sh pack <name>`.
 
 ## Process
 
 ### 1. Audit
 
-Read `audit/references/{domain}-checklist.md` and run all checks.
+Read `audit/references/{domain}-checklist.md`, or
+`audit/generated-references/{domain}-checklist.md` for pack-provided domains,
+and run all checks.
 If `--all`, run all applicable domain checklists.
 
 ### 2. Deduplicate

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -5,6 +5,8 @@ REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 CORE_DIR="$REPO_DIR/core"
 PACKS_DIR="$REPO_DIR/packs"
 OVERLAYS_DIR="$REPO_DIR/overlays"
+AUDIT_CORE_REFS_DIR="$CORE_DIR/audit/references"
+AUDIT_GENERATED_REFS_DIR="$CORE_DIR/audit/generated-references"
 
 usage() {
   echo "Usage: sync.sh <command> [options]"
@@ -74,6 +76,115 @@ link_skill() {
   fi
 }
 
+link_reference() {
+  local src="$1" target_dir="$2"
+  local ref_name dst
+  ref_name="$(basename "$src")"
+  dst="$target_dir/$ref_name"
+
+  if [[ -L "$dst" ]]; then
+    local current
+    current="$(readlink "$dst")"
+    if [[ "$current" == "$src" ]]; then
+      return
+    fi
+    if dry; then
+      log "[dry] repoint $dst -> $src"
+    else
+      rm "$dst"
+    fi
+  elif [[ -e "$dst" ]]; then
+    if dry; then
+      log "[dry] replace generated ref $dst"
+    else
+      /usr/bin/trash "$dst" 2>/dev/null || rm -rf "$dst"
+    fi
+  fi
+
+  if dry; then
+    log "[dry] ln -s $src -> $dst"
+  else
+    ln -s "$src" "$dst"
+  fi
+}
+
+prune_legacy_pack_audit_references() {
+  [[ ! -d "$AUDIT_CORE_REFS_DIR" ]] && return
+
+  local count=0
+  local ref
+  for ref in "$AUDIT_CORE_REFS_DIR"/*.md; do
+    [[ ! -e "$ref" && ! -L "$ref" ]] && continue
+    [[ ! -L "$ref" ]] && continue
+
+    local target
+    target="$(readlink "$ref")"
+    [[ "$target" != "$PACKS_DIR/"* ]] && continue
+
+    if dry; then
+      log "[dry] remove legacy pack audit ref $ref"
+    else
+      rm "$ref"
+    fi
+    ((count+=1))
+  done
+
+  if [[ "$count" -gt 0 ]]; then
+    log "Pruned $count legacy pack audit refs from $AUDIT_CORE_REFS_DIR"
+  fi
+  return 0
+}
+
+prune_generated_audit_references() {
+  [[ ! -d "$AUDIT_GENERATED_REFS_DIR" ]] && return
+
+  local count=0
+  local ref
+  for ref in "$AUDIT_GENERATED_REFS_DIR"/*.md; do
+    [[ ! -e "$ref" && ! -L "$ref" ]] && continue
+    [[ ! -L "$ref" ]] && continue
+
+    local target
+    target="$(readlink "$ref")"
+    if [[ ! -f "$target" ]]; then
+      if dry; then
+        log "[dry] prune stale generated audit ref $ref"
+      else
+        rm "$ref"
+      fi
+      ((count+=1))
+    fi
+  done
+
+  if [[ "$count" -gt 0 ]]; then
+    log "Pruned $count stale generated audit refs from $AUDIT_GENERATED_REFS_DIR"
+  fi
+  return 0
+}
+
+sync_pack_audit_references() {
+  local source_dir="$1"
+  [[ ! -d "$source_dir" ]] && return
+
+  prune_legacy_pack_audit_references
+  if dry; then
+    log "[dry] mkdir -p $AUDIT_GENERATED_REFS_DIR"
+  else
+    mkdir -p "$AUDIT_GENERATED_REFS_DIR"
+  fi
+  prune_generated_audit_references
+
+  local count=0
+  local ref_file
+  for ref_file in "$source_dir"/*.md; do
+    [[ ! -f "$ref_file" ]] && continue
+    link_reference "$ref_file" "$AUDIT_GENERATED_REFS_DIR"
+    ((count+=1))
+  done
+
+  log "Pack audit-references: $count refs synced to $AUDIT_GENERATED_REFS_DIR"
+}
+
 # Build a merged skill directory from base + harness overlay.
 # base dir always copied first, overlay files then override.
 # Special overlay file SKILL.append.md is appended to SKILL.md.
@@ -140,7 +251,7 @@ prune_harness() {
         else
           rm "$entry"
         fi
-        ((symlink_count++))
+        ((symlink_count+=1))
       fi
       continue
     fi
@@ -169,7 +280,7 @@ prune_harness() {
       else
         /usr/bin/trash "$entry" 2>/dev/null || rm -rf "$entry"
       fi
-      ((managed_dir_count++))
+      ((managed_dir_count+=1))
     fi
   done
   log "$target_dir: pruned $symlink_count stale symlinks, $managed_dir_count stale managed dirs"
@@ -208,7 +319,7 @@ sync_harness() {
     else
       link_skill "$base_skill" "$target_dir"
     fi
-    ((count++))
+    ((count+=1))
   done
 
   log "$target_dir: $count skills synced"
@@ -259,37 +370,14 @@ sync_pack() {
     local dir_name
     dir_name="$(basename "$skill_dir")"
 
-    # Link audit-references into core/audit/references/ so orchestrators find them
+    # Pack audit references are runtime-generated, not linked into tracked source.
     if [[ "$dir_name" == "audit-references" ]]; then
-      local audit_refs_dir="$CORE_DIR/audit/references"
-      [[ ! -d "$audit_refs_dir" ]] && continue
-      for ref_file in "$skill_dir"*.md; do
-        [[ ! -f "$ref_file" ]] && continue
-        local ref_name
-        ref_name="$(basename "$ref_file")"
-        local ref_dst="$audit_refs_dir/$ref_name"
-        if [[ -L "$ref_dst" ]]; then
-          local current
-          current="$(readlink "$ref_dst")"
-          [[ "$current" == "$ref_file" ]] && continue
-          if dry; then
-            log "[dry] repoint $ref_dst -> $ref_file"
-          else
-            rm "$ref_dst"
-          fi
-        fi
-        if dry; then
-          log "[dry] ln -s $ref_file -> $ref_dst"
-        else
-          ln -s "$ref_file" "$ref_dst"
-        fi
-      done
-      log "Pack '$pack_name': audit-references linked into $audit_refs_dir"
+      sync_pack_audit_references "$skill_dir"
       continue
     fi
 
     link_skill "$skill_dir" "$target_dir"
-    ((count++))
+    ((count+=1))
   done
 
   log "Pack '$pack_name': $count skills synced to $target_dir"


### PR DESCRIPTION
## Summary
Follow-up to [#12](https://github.com/phrazzld/agent-skills/pull/12).

This PR fixes the pack audit-reference delivery design so `sync.sh pack` no longer mutates tracked source under `core/audit/references/`. Instead, pack checklists are materialized into ignored runtime state, which keeps the repo clean while preserving dynamic domain discovery for `/audit`, `/fix`, and `/log-issues`.

## Changes
- Updated [scripts/sync.sh](/Users/phaedrus/Development/agent-skills/scripts/sync.sh) to sync pack audit refs into `core/audit/generated-references/` instead of `core/audit/references/`
- Added pruning for stale generated audit refs and cleanup for legacy pack-linked refs
- Added `core/audit/generated-references/` to [.gitignore](/Users/phaedrus/Development/agent-skills/.gitignore)
- Updated audit-family docs in [core/audit/SKILL.md](/Users/phaedrus/Development/agent-skills/core/audit/SKILL.md), [core/fix/SKILL.md](/Users/phaedrus/Development/agent-skills/core/fix/SKILL.md), [core/log-issues/SKILL.md](/Users/phaedrus/Development/agent-skills/core/log-issues/SKILL.md), and [CLAUDE.md](/Users/phaedrus/Development/agent-skills/CLAUDE.md)
- Fixed latent `set -e` early-exit bugs in `scripts/sync.sh` discovered while validating the pack flow

## Acceptance Criteria
- [x] `sync.sh pack` does not create untracked files in `core/audit/references/`
- [x] Pack-provided audit checklists still remain discoverable to audit-family workflows
- [x] Generated pack state is ignored by git
- [x] Growth pack dry-run completes without the previous early exit in `sync.sh`

## Manual QA
1. Verify shell syntax:
   - `bash -n scripts/sync.sh`
   - Expected: no output, exit code 0.
2. Verify pack dry-run targets ignored runtime state:
   - `./scripts/sync.sh pack growth /tmp/agent-skills-pack-test --dry-run`
   - Expected output includes `core/audit/generated-references/landing-checklist.md`, `onboarding-checklist.md`, and `virality-checklist.md`.
   - Expected output does not mention linking into `core/audit/references/`.
3. Verify tracked core refs remain clean:
   - `ls core/audit/references`
   - Expected: only tracked core checklist/docs files; no growth pack checklist symlinks.
4. Verify git ignore behavior:
   - `git status --short`
   - Expected: no untracked files created from pack audit refs.

Dogfood / visual QA: not applicable. This is an internal docs + shell workflow change with no user-facing UI.

## What Changed
Diagram omitted. This is a simple internal workflow fix: move pack audit checklist materialization from tracked source to ignored runtime state.

## Before / After
Before: running `sync.sh pack growth ...` could create untracked symlinks in `core/audit/references/`, which made the repo look dirty and mixed generated runtime state into tracked source. The same code path also had `set -e` edge cases that could cause `pack` sync to stop early.

After: pack audit refs are generated under ignored runtime state at `core/audit/generated-references/`, tracked source stays clean, and the pack sync flow completes consistently.

Screenshots: not applicable. No visible UI or CLI screenshots needed beyond the manual QA commands above.

## Test Coverage
This repo does not have an automated test harness for `scripts/sync.sh`.

Coverage for this change is command-driven:
- `bash -n scripts/sync.sh`
- `./scripts/sync.sh pack growth /tmp/agent-skills-pack-test --dry-run`

Gap: no automated shell tests currently exist for sync flows, so behavior is verified manually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended domain discovery to seamlessly include references from both core and dynamically loaded packs.

* **Improvements**
  * Audit, fix, and log-issues workflows now support references from multiple sources without mutating tracked source files.
  * Enhanced pack integration with improved reference synchronization and lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->