### PR TITLE
feat(skills): codify context architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,20 +6,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A unified skills monorepo for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first, with some TypeScript helper scripts and tests (e.g., `core/web-search/`). Skills are distributed to agent harnesses via symlinks.
 
-**58 core skills** (universal engineering) + **4 domain packs** (19 skills, loaded per-project) + **5 repo-local** (live in their own repos).
+**63 core skills** (universal engineering) + **4 domain packs** (20 skills, loaded per-project) + **5 repo-local** (live in their own repos).
 
 ## Repo Structure
 
 ```
 agent-skills/
-├── core/           # 58 universal skills, synced to ~/.claude/skills/
+├── core/           # 63 universal skills, synced to ~/.claude/skills/
 │   ├── groom/
 │   ├── autopilot/
 │   ├── build/
 │   └── ...
 ├── packs/          # Domain packs, loaded per-project on demand
 │   ├── payments/   # bitcoin, lightning, stripe (3 skills + 5 checklists)
-│   ├── growth/     # brand, content, growth, ai-media, og-hero-image, app-screenshots, audit-website (7 skills + 3 checklists)
+│   ├── growth/     # brand, content, growth, ai-media, og-hero-image, app-screenshots, audit-website, product-marketing-context (8 skills + 3 checklists)
 │   ├── scaffold/   # github-app, slack-app, monorepo, mobile-migrate, bun (5 skills + 1 checklist)
 │   └── finance/    # finances-ingest, finances-report, finances-snapshot, crypto-gains (4 skills)
 ├── scripts/
@@ -99,8 +99,8 @@ Claude Code has a ~16K char description budget. Skills consume budget based on m
 | Reference | `user-invocable: false` | Auto-loaded by model | **Consumes budget** |
 | DMI | `disable-model-invocation: true` | User via `/command` | **Free** |
 
-Current split: ~26 budget-consuming + ~32 DMI = ~58 core total. Well within 16K.
-Pack skills (19) don't consume budget — they're loaded per-project only when needed.
+Current split: ~36 budget-consuming + ~27 DMI = ~63 core total. Well within 16K.
+Pack skills (20) don't consume budget — they're loaded per-project only when needed.
 
 ## Core Delivery Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ agent-skills/
 │   ├── growth/     # brand, content, growth, ai-media, og-hero-image, app-screenshots, audit-website, product-marketing-context (8 skills + 3 checklists)
 │   ├── scaffold/   # github-app, slack-app, monorepo, mobile-migrate, bun (5 skills + 1 checklist)
 │   └── finance/    # finances-ingest, finances-report, finances-snapshot, crypto-gains (4 skills)
+├── docs/
+│   └── context/    # Starter cold-memory artifacts for tuned repos
 ├── scripts/
 │   └── sync.sh
 └── CLAUDE.md
@@ -65,10 +67,12 @@ No build, lint, or test commands — this repo is documentation only.
 
 ## Skill Directory Convention
 
-Every skill lives in `core/{skill-name}/` with a required `SKILL.md`:
+Core skills live in `core/{skill-name}/`.
+Pack skills live in `packs/{pack-name}/{skill-name}/`.
+Every skill directory needs a required `SKILL.md`:
 
 ```
-core/{skill-name}/
+{core|packs/<pack>}/{skill-name}/
 ├── SKILL.md          # Required. Frontmatter + skill definition.
 ├── AGENTS.md         # Optional. Multi-agent guidance.
 └── references/       # Optional. Supporting docs, templates.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-58 core skills + 4 domain packs for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
+63 core skills + 4 domain packs for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
 
 Skills are Markdown-first with a handful of Python helper scripts. No application code, no dependencies. They teach agents *how to work*: debugging methodology, PR workflows, design systems, incident response, and dozens of domain-specific playbooks.
 
@@ -12,8 +12,8 @@ AI agents are only as good as their instructions. Generic prompts produce generi
 
 | Tier | Location | Distribution | Budget cost |
 |------|----------|-------------|-------------|
-| **Core** (58) | `core/` | `sync.sh claude` → global | Per-mode |
-| **Pack** (19) | `packs/` | `sync.sh pack <name> <project>` → per-project | Per-mode |
+| **Core** (63) | `core/` | `sync.sh claude` → global | Per-mode |
+| **Pack** (20) | `packs/` | `sync.sh pack <name> <project>` → per-project | Per-mode |
 | **Repo-local** (5) | `<repo>/.claude/skills/` | Lives in destination repo | Per-mode |
 
 Invocation modes within each tier:
@@ -107,6 +107,8 @@ Domains: bitcoin, btcpay, bun, docs, landing, lightning, observability, onboardi
 | `delegate` | Reference | Multi-AI orchestration primitive |
 | `agent-tools` | Reference | Agent tool patterns |
 | `/agentic-bootstrap` | DMI | Bootstrap `.pi/` for autonomous repos |
+| `break-the-frame` | Reference | Detect dead creative frames and force reframing |
+| `codified-context-architecture` | Reference | Place project knowledge into constitutions, routing, and cold-memory docs |
 | `prompt-context-engineering` | Reference | Production prompt design |
 | `llm-communication` | Reference | Effective LLM instructions |
 | `/llm-infrastructure` | Model+User | LLM evaluation, gateway routing, prompt ops |
@@ -127,7 +129,7 @@ Domains: bitcoin, btcpay, bun, docs, landing, lightning, observability, onboardi
 
 ### References (auto-loaded)
 
-`git-mastery` · `naming-conventions` · `external-integration-patterns` · `ui-skills` · `business-model-preferences` · `toolchain-preferences` · `next-patterns` · `database` · `delegate` · `cli-reference` · `ralph-patterns` · `skill-builder` · `agentic-ui-contract` · `webapp-testing`
+`git-mastery` · `naming-conventions` · `external-integration-patterns` · `ui-skills` · `business-model-preferences` · `toolchain-preferences` · `next-patterns` · `database` · `delegate` · `cli-reference` · `ralph-patterns` · `skill-builder` · `agentic-ui-contract` · `webapp-testing` · `break-the-frame` · `codified-context-architecture`
 
 ## Domain Packs
 
@@ -136,8 +138,8 @@ Packs are loaded per-project via `sync.sh pack <name> <project-dir>`.
 ### payments (3 skills + 5 checklists)
 `bitcoin` · `lightning` · `stripe`
 
-### growth (7 skills + 3 checklists)
-`brand` · `content` · `growth` · `ai-media` · `og-hero-image` · `app-screenshots` · `audit-website`
+### growth (8 skills + 3 checklists)
+`brand` · `content` · `growth` · `ai-media` · `og-hero-image` · `app-screenshots` · `audit-website` · `product-marketing-context`
 
 ### scaffold (5 skills + 1 checklist)
 `github-app-scaffold` · `slack-app-scaffold` · `monorepo-scaffold` · `mobile-migrate` · `bun`

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ cd agent-skills
 
 Skills are symlinked, not copied. Edit once, every harness sees the change.
 
+## Context Architecture
+
+This repo now ships starter cold-memory artifacts under `docs/context/`:
+
+- `docs/context/INDEX.md`
+- `docs/context/ROUTING.md`
+- `docs/context/DRIFT-WATCHLIST.md`
+- `docs/context/SUBSYSTEM-TEMPLATE.md`
+
+They are scaffolds, not encyclopedias. `/tune-repo` is expected to replace the
+starter rows with repo-specific subsystem docs and routing rules.
+
 ## Skills
 
 ### Delivery Pipeline

--- a/core/agentic-bootstrap/SKILL.md
+++ b/core/agentic-bootstrap/SKILL.md
@@ -14,6 +14,7 @@ Use this skill when creating or redesigning a repository's local Pi foundation.
 - Keep output focused and auditable.
 - Bias toward repo-specific fit over generic templates.
 - **Always generate a repo-local persona character in the root `AGENTS.md`.**
+- Scaffold tiered context, not one giant manifest.
 
 ## Workflow
 
@@ -33,6 +34,11 @@ Use this skill when creating or redesigning a repository's local Pi foundation.
    - Emit concrete artifacts (settings, overlays, prompts, pipelines, local workflow doc, and **AGENTS.md**).
    - **Design a personified character (`AGENTS.md`)**: The persona must be a *person* or *character* (e.g., an archivist, a chronomancer) deeply tied to the domain, complete with a Name, Title, Quote, Voice, and Belief System.
    - **Inject context front-and-center**: Do not bury capabilities or the persona in `.pi/persona.md`. The character identity, core domain rules, and essential capabilities must go directly into the repo-root `AGENTS.md` so the Pi runtime automatically loads them on every turn.
+   - Create a codified context architecture:
+     - hot memory: `CLAUDE.md`, `AGENTS.md`
+     - routing: `docs/context/ROUTING.md`
+     - cold memory: `docs/context/INDEX.md` + subsystem docs
+     - drift control: `docs/context/DRIFT-WATCHLIST.md`
    - Require explicit opt-ins in settings.
    - Keep role overlays goal-oriented (role + objective + success criteria + output contract).
 
@@ -47,6 +53,7 @@ Use this skill when creating or redesigning a repository's local Pi foundation.
 - Local config is explicit and narrow.
 - **The persona is a full character with Voice and Beliefs.**
 - **The persona and core rules/capabilities are loaded automatically via the root `AGENTS.md`.**
+- Context is tiered and maintainable, not one bloated file.
 - Workflow supports explore -> design -> implement -> review.
 - Instructions are high-signal and not procedurally bloated.
 - Artifacts are understandable by a new operator in one read.

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -62,20 +62,22 @@ Deterministic logic is limited to strict mechanics: schema checks, exact parsing
    - RED: failing targeted tests before implementation
    - GREEN: same tests passing after implementation
    - If test harness is broken, stop and flag blocker (no implementation without explicit user bypass)
+   - Delete compatibility scaffolding in greenfield/pre-user paths unless a real contract requires it
 7. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa --fix`. Fix P0/P1 before proceeding.
-8. **Refine** — `/pr-fix --refactor`, update docs inline, then run simplification pass:
-   - Preferred accelerator (if native in current harness): `/simplify`
-   - Portable fallback (required): `ousterhout` agent for module depth review + manual simplification edits
-9. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
+8. **Agentic QA** — If diff touches prompts, model routing, tool schemas, or agent instructions, run `/llm-infrastructure` and inspect trace/eval coverage before shipping.
+9. **Refine** — `/pr-fix --refactor`, update docs inline, then run simplification pass:
+    - Preferred accelerator (if native in current harness): `/simplify`
+    - Portable fallback (required): `ousterhout` agent for module depth review + manual simplification edits
+10. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
    Iterate until no P0/P1 issues remain. **Do not open a PR until QA passes.**
-10. **Commit** — Create semantic commits for all remaining changes:
+11. **Commit** — Create semantic commits for all remaining changes:
     - Categorize files: commit, gitignore, delete, consolidate
     - Group into logical commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
     - Subject: imperative, lowercase, no period, ~50 chars. Body: why not what.
     - Run quality gates (`lint`, `typecheck`, `test`) before pushing
     - `git fetch origin && git push origin HEAD` (rebase if behind)
     - Never force push. Never push to main without confirmation.
-11. **Ship** — Open a draft PR:
+12. **Ship** — Open a draft PR:
     - Stage and commit any uncommitted changes with semantic message
     - Read linked issue from branch name or recent commits
     - PR body must contain all sections:
@@ -89,7 +91,7 @@ Deterministic logic is limited to strict mechanics: schema checks, exact parsing
       - **Test Coverage**: Specific test files/functions. Note gaps.
     - `gh pr create --draft --assignee phrazzld`
     - Add context comment if notable decisions were made
-12. **Retro** — Append implementation signals to `.groom/retro.md`:
+13. **Retro** — Append implementation signals to `.groom/retro.md`:
     ```
     /retro append --issue $1 --predicted {effort_label} --actual {actual_effort} \
       --scope "{scope_changes}" --blocker "{blockers}" --pattern "{insight}"
@@ -180,3 +182,12 @@ NOT stopping conditions: lacks description, seems big, unclear approach.
 ## Output
 
 Report: issue worked, spec status, design status, TDD evidence (RED/GREEN), commits made, dogfood QA summary (issues found/fixed), PR URL.
+
+## Review Cadence
+
+Agents accrete bloat when they keep extending stale mental models. Before each
+new sprint or major chunk:
+
+- Re-read the touched modules fully
+- Look for compatibility shims added only to preserve old structure
+- Simplify before adding the next layer

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -67,7 +67,8 @@ Deterministic logic is limited to strict mechanics: schema checks, exact parsing
 8. **Agentic QA** — If diff touches prompts, model routing, tool schemas, or agent instructions, run `/llm-infrastructure` and inspect trace/eval coverage before shipping.
 9. **Refine** — `/pr-fix --refactor`, update docs inline, then run simplification pass:
     - Preferred accelerator (if native in current harness): `/simplify`
-    - Portable fallback (required): `ousterhout` agent for module depth review + manual simplification edits
+    - Portable fallback (required): manual module-depth review + simplification edits using Ousterhout checks: shallow modules, information leakage, pass-throughs, and compatibility shims with no active contract
+    - Optional accelerator: use an `ousterhout` persona/agent if the harness provides one
 10. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
    Iterate until no P0/P1 issues remain. **Do not open a PR until QA passes.**
 11. **Commit** — Create semantic commits for all remaining changes:
@@ -162,7 +163,7 @@ After `/build` completes, parallelize the refinement phase:
 | Teammate | Task |
 |----------|------|
 | **Simplifier** | Run code-simplifier agent, commit |
-| **Depth reviewer** | Run ousterhout agent, commit |
+| **Depth reviewer** | Run manual module-depth review, or `ousterhout` if available, commit |
 | **Doc updater** | Update docs (README, ADRs, API docs), commit |
 
 Lead sequences commits after all teammates finish. Then dogfood QA, then `/pr`.

--- a/core/break-the-frame/SKILL.md
+++ b/core/break-the-frame/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: break-the-frame
+description: |
+  Recognize when a creative session is stuck inside a dead frame and force a
+  reframing move. Use during naming, copywriting, product strategy, design
+  exploration, brainstorming, or critique when recent rounds feel like
+  variations on a theme, human energy is flat, or the work is getting smarter
+  without getting truer.
+user-invocable: false
+---
+
+# Break The Frame
+
+Use this when the process is producing competent sludge.
+
+## Signals
+
+If 2+ are true, stop the current approach:
+
+- Last 3 suggestions feel like variants, not new ideas
+- Human says "think harder", "more out of the box", or goes flat
+- The agent built a rubric, matrix, or taxonomy nobody asked for
+- Everyone is politely agreeing but nobody lights up
+- You keep improving the current answer instead of questioning the frame
+
+## Moves
+
+Use one hard move, not five soft ones:
+
+1. Throw away the scaffolding. Ask what feeling the answer should create.
+2. Try the opposite. If the work is analytical, get emotional. If clever, get plain.
+3. Surface the odd human comment that doesn't fit the rubric. Amplify it.
+4. Ask the coffee question: "How would a friend say this out loud?"
+5. Change the output type. Stop ranking names; write taglines. Stop optimizing copy; tell the story simply.
+6. If still stuck, stop generating and ask one reframing question.
+
+## Rules
+
+- Smart is not enough. The best answers feel true.
+- Structured rounds are setup, not the answer.
+- Don't route a breakthrough back into the same dead framework.
+- In mixed human/agent sessions, human offhand remarks often contain the breakout.
+
+## Workflow
+
+1. Detect the frame.
+2. Name the current frame in one line.
+3. Pick one break move.
+4. Generate a small new set from the new angle.
+5. Stop if energy comes back. Keep going if it doesn't.
+
+## Integration
+
+- `shape`: use when ideation or critique rounds get trapped in frameworks
+- `design`: use when directions are distinct on paper but emotionally flat
+- `content`: use when copy gets cleverer instead of truer
+- `groom`: use when solutioning starts before the real problem is clear
+
+## References
+
+- `references/examples.md` -- Plus One naming and Brandon/Zosia copy examples

--- a/core/break-the-frame/references/examples.md
+++ b/core/break-the-frame/references/examples.md
@@ -1,0 +1,29 @@
+# Break The Frame Examples
+
+## Plus One Naming
+
+Symptoms:
+- 80+ names
+- rubrics and sentence tests
+- no excitement
+
+Break:
+- a human ignored the rubric and said "One"
+- another human reframed it as "Plus One"
+
+Lesson:
+- the answer was a relationship, not a scored noun
+
+## Brandon / Zosia Copy
+
+Symptoms:
+- repeated craft moves
+- cleverer drafts
+- human asked for "more out of the box"
+
+Break:
+- switch from joke-writing to how a friend would tell the story
+- simple, true, three-sentence version won
+
+Lesson:
+- true was funnier than clever

--- a/core/break-the-frame/references/examples.md
+++ b/core/break-the-frame/references/examples.md
@@ -14,7 +14,11 @@ Break:
 Lesson:
 - the answer was a relationship, not a scored noun
 
-## Brandon / Zosia Copy
+## Brandon / Zosia Copy Tightening
+
+Setup:
+- article anecdote about Brandon's agent refusing to answer a stranger bot
+- goal was not "write a joke," it was "tell this story in a way that feels true"
 
 Symptoms:
 - repeated craft moves

--- a/core/build/SKILL.md
+++ b/core/build/SKILL.md
@@ -48,18 +48,27 @@ Intent gate before coding:
 
 If on `master`/`main`, branch: `feature/issue-$1` or `fix/issue-$1`.
 
+Before adding new code, read the touched module end-to-end. Do not stack new
+layers on a partial mental model.
+
 ## TDD Gate (MANDATORY)
 
 TDD is enforced, not optional.
 
 For each acceptance-criteria chunk:
-1. Write/adjust test first.
+1. Write/adjust a behavior test first.
 2. Run targeted test command and confirm failure (RED).
 3. Implement minimal code.
 4. Re-run same targeted test and confirm pass (GREEN).
 5. Refactor with tests still green.
 
 Do not write production implementation before at least one relevant failing test exists.
+
+Tests should target module exports, public interfaces, and observable behavior.
+Avoid mock-heavy "unit tests" that pin internal structure.
+Default against backward-compat scaffolding that exists only to keep current
+tests green. In greenfield or low-user systems, delete bad layers instead of
+preserving them.
 
 If tests cannot run (harness/env failure), stop and report blocker. Do not continue implementation unless user explicitly approves bypass.
 
@@ -69,6 +78,8 @@ Before delegating any chunk:
 - Existing tests? Warn: "Don't break tests in [file]"
 - Add or replace? Be explicit
 - Pattern to follow? Include reference file path
+- Boundary to test? State the module export/public behavior explicitly
+- Mocks needed? Only for external boundaries and nondeterminism
 - Quality gates? Include verify command
 
 ## Execution Loop
@@ -76,6 +87,7 @@ Before delegating any chunk:
 For each logical chunk:
 
 1. **Understand** — Read issue/spec, find existing patterns to follow
+   Re-read touched modules before each major chunk if the design shifted.
 2. **Delegate** — Clear spec + pattern reference + verify command
 3. **Review** — capture RED→GREEN evidence + `git diff --stat && pnpm typecheck && pnpm lint && pnpm test`
 4. **Commit** — `feat: description (#$1)` if tests pass

--- a/core/build/SKILL.md
+++ b/core/build/SKILL.md
@@ -67,8 +67,12 @@ Do not write production implementation before at least one relevant failing test
 Tests should target module exports, public interfaces, and observable behavior.
 Avoid mock-heavy "unit tests" that pin internal structure.
 Default against backward-compat scaffolding that exists only to keep current
-tests green. In greenfield or low-user systems, delete bad layers instead of
-preserving them.
+tests green. Remove a compatibility layer only if one of these is true:
+- the spec/design explicitly allows the break
+- usage is proven dead or internal-only
+- the user explicitly approved the removal
+
+If evidence is missing, keep the behavior stable and log the cleanup separately.
 
 If tests cannot run (harness/env failure), stop and report blocker. Do not continue implementation unless user explicitly approves bypass.
 
@@ -80,6 +84,7 @@ Before delegating any chunk:
 - Pattern to follow? Include reference file path
 - Boundary to test? State the module export/public behavior explicitly
 - Mocks needed? Only for external boundaries and nondeterminism
+- Compatibility path safe to remove? Cite spec, usage evidence, or user approval
 - Quality gates? Include verify command
 
 ## Execution Loop

--- a/core/check-quality/SKILL.md
+++ b/core/check-quality/SKILL.md
@@ -18,10 +18,11 @@ Audit quality infrastructure. Fix gaps. Verify everything works.
 2. Audit git hooks (Lefthook, Husky)
 3. Audit CI/CD (GitHub Actions, branch protection)
 4. Audit linting/formatting (ESLint, Prettier, Biome)
-5. Security scan via `security-sentinel` agent
-6. Audit branch-protection/security baseline (required checks, conversation resolution, secret scanning)
-7. Fix identified gaps (install tools, create configs, set up CI)
-8. Verify fixes work end-to-end
+5. Audit custom guardrails (architecture, design tokens, import boundaries)
+6. Security scan via `security-sentinel` agent
+7. Audit branch-protection/security baseline (required checks, conversation resolution, secret scanning)
+8. Fix identified gaps (install tools, create configs, set up CI)
+9. Verify fixes work end-to-end
 
 **This is both audit AND setup.** It checks what exists, fixes what's missing, and proves it works.
 
@@ -73,6 +74,10 @@ grep -q '"strict": true' tsconfig.json 2>/dev/null && echo "V Strict mode" || ec
 
 # Custom guardrails
 [ -d "guardrails" ] && echo "V guardrails/" || echo "- No custom guardrails"
+
+# Design tokens (if design system exists)
+rg -n "@theme|--color-|--spacing-|tailwind\\.config|globals\\.css|app\\.css" . -g '!node_modules' >/dev/null 2>&1 && echo "V Design system detected" || echo "- No obvious design system"
+rg -n "guardrails/.+(token|color|spacing|radius)|no-raw-(hex|spacing|radius)" . -g '!node_modules' >/dev/null 2>&1 && echo "V Token guardrails" || echo "- No token guardrails"
 ```
 
 Spawn `security-sentinel` agent for vulnerability analysis.
@@ -90,11 +95,13 @@ Prioritize findings:
 | Conversation resolution disabled | P0 |
 | No coverage | P1 |
 | No git hooks | P1 |
+| No pre-commit fast feedback | P1 |
 | No linting | P1 |
 | Not strict TypeScript | P1 |
 | No commitlint | P2 |
 | No coverage in PRs | P2 |
-| No custom guardrails | P3 |
+| No custom guardrails | P2 |
+| Design system without token guardrails | P2 |
 | Tool upgrades | P3 |
 
 ### 3. Fix
@@ -102,6 +109,9 @@ Prioritize findings:
 Fix every gap. Delegate to Codex where appropriate.
 
 **Lefthook:** `pnpm add -D lefthook && pnpm lefthook install` + create `lefthook.yml` per `references/lefthook-config.md`
+
+Pre-commit should stay fast: lint, formatting, type/lint on changed files, custom guardrails.
+Push/CI should carry slower gates: full test suite, coverage, e2e.
 
 **Vitest:** `pnpm add -D vitest @vitest/coverage-v8` + config per `references/vitest-config.md`
 
@@ -117,6 +127,8 @@ Prove it works -- don't just check files exist:
 
 ```bash
 pnpm lefthook run pre-commit          # Hooks work
+pnpm eslint .                         # Lint + local guardrails work
+sg scan --config guardrails/sgconfig.yml  # If ast-grep guardrails exist
 pnpm test --run                        # Tests run
 echo "bad message" | pnpm commitlint   # Should fail
 echo "feat: valid" | pnpm commitlint   # Should pass
@@ -140,6 +152,8 @@ Coverage is diagnostic, not a goal. 60% meaningful > 95% testing implementation 
 - Don't skip hooks routinely -- fix root cause
 - Don't test implementation details -- test behavior
 - Don't rely on heavy mocking -- prefer integration tests
+- Don't put slow, flaky suites in pre-commit
+- Don't ship a design system with unenforced raw hex/magic spacing drift
 - CI on every PR, not just main
 
 ## Output Format

--- a/core/check-quality/SKILL.md
+++ b/core/check-quality/SKILL.md
@@ -75,9 +75,9 @@ grep -q '"strict": true' tsconfig.json 2>/dev/null && echo "V Strict mode" || ec
 # Custom guardrails
 [ -d "guardrails" ] && echo "V guardrails/" || echo "- No custom guardrails"
 
-# Design tokens (if design system exists)
-rg -n "@theme|--color-|--spacing-|tailwind\\.config|globals\\.css|app\\.css" . -g '!node_modules' >/dev/null 2>&1 && echo "V Design system detected" || echo "- No obvious design system"
-rg -n "guardrails/.+(token|color|spacing|radius)|no-raw-(hex|spacing|radius)" . -g '!node_modules' >/dev/null 2>&1 && echo "V Token guardrails" || echo "- No token guardrails"
+# Design tokens (heuristic only; confirm by reading the theme files)
+rg -n "(@theme|--(color|space|spacing|radius|font|shadow)-|tailwind\\.config|globals\\.css|app\\.css|tokens\\.(ts|js|json)|theme\\.(ts|js)|components/ui|src/components/ui)" . -g '!node_modules' >/dev/null 2>&1 && echo "V Design system detected (heuristic)" || echo "- No obvious design system"
+rg -n "(guardrails/.+(token|theme|color|spacing|radius)|no-raw-(color|hex|spacing|radius)|semantic-token|token-(usage|enforce)|design-token)" . -g '!node_modules' >/dev/null 2>&1 && echo "V Token guardrails (heuristic)" || echo "- No token guardrails"
 ```
 
 Spawn `security-sentinel` agent for vulnerability analysis.
@@ -153,7 +153,8 @@ Coverage is diagnostic, not a goal. 60% meaningful > 95% testing implementation 
 - Don't test implementation details -- test behavior
 - Don't rely on heavy mocking -- prefer integration tests
 - Don't put slow, flaky suites in pre-commit
-- Don't ship a design system with unenforced raw hex/magic spacing drift
+- Don't trust regex heuristics alone for design systems -- read the token files
+- Don't ship a design system with unenforced raw color/magic spacing drift
 - CI on every PR, not just main
 
 ## Output Format

--- a/core/check-quality/references/testing-standards.md
+++ b/core/check-quality/references/testing-standards.md
@@ -38,6 +38,7 @@ describe('Module Name', () => {
 ❌ "We need 80% coverage"
 ❌ "This file has low coverage, add more tests"
 ❌ Testing implementation details to hit coverage goals
+❌ Mock-heavy tests that fail on harmless refactors
 ❌ Writing tests just to make coverage numbers green
 
 ### The Right Approach
@@ -46,6 +47,7 @@ describe('Module Name', () => {
 - Public API surface, not internal implementation
 - Contract between modules
 - What callers depend on
+- Refactor-safe developer tests over mock choreography
 
 ✅ **Test critical paths and edge cases**
 - Happy path (most common use case)

--- a/core/codified-context-architecture/SKILL.md
+++ b/core/codified-context-architecture/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: codified-context-architecture
+description: |
+  Organize project knowledge for AI agents into hot memory, specialist routing,
+  and cold-memory subsystem docs. Use when tuning a repo, designing agent
+  infrastructure, deciding where knowledge should live, or replacing bloated
+  single-file manifests with tiered context that can scale.
+user-invocable: false
+---
+
+# Codified Context Architecture
+
+Use a 3-tier model:
+
+1. **Hot memory** — always-loaded constitution (`CLAUDE.md`, `AGENTS.md`)
+2. **Specialists** — failure-driven agents or workflows for risky domains
+3. **Cold memory** — on-demand subsystem docs under `docs/context/`
+
+## Placement Rules
+
+Put knowledge in hot memory if:
+- it must apply on every turn
+- violating it is expensive
+- it fits in a few sharp bullets
+
+Put knowledge in a specialist if:
+- a domain repeatedly fails without priming
+- the work needs a synthesized mental model
+- the same mistakes recur across sessions
+
+Put knowledge in cold memory if:
+- the subsystem is too large for hot memory
+- details are needed only when touching that area
+- multiple sessions keep re-reading the same files
+
+## Routing Rules
+
+Encode routing, don't rely on memory.
+
+- Maintain `docs/context/ROUTING.md`
+- Map file patterns or task signals to the right specialist / workflow
+- If no route exists for a risky area, that is a context gap
+
+## Drift Rules
+
+Stale specs are load-bearing bugs.
+
+- Maintain `docs/context/DRIFT-WATCHLIST.md`
+- Map subsystem docs to the files that should trigger review
+- If source changes without spec updates, flag drift
+
+## Creation Triggers
+
+- If you explained it twice, write it down
+- If retrieval returns nothing for a risky subsystem, stop and document first
+- If a domain keeps failing, create a specialist and restart with context
+- If hot memory keeps growing, push detail down into cold memory
+
+## Anti-Patterns
+
+- Treating `CLAUDE.md` as an encyclopedia
+- Creating specialists before observing failure patterns
+- Over-compressing high-risk domains into vague summaries
+- Letting docs drift while agents continue trusting them
+
+## References
+
+- `references/templates.md` -- Templates for `docs/context/` artifacts

--- a/core/codified-context-architecture/references/templates.md
+++ b/core/codified-context-architecture/references/templates.md
@@ -1,0 +1,33 @@
+# Context Architecture Templates
+
+## `docs/context/INDEX.md`
+
+```markdown
+# Context Index
+
+| Subsystem | Docs | Source Files | Notes |
+|-----------|------|--------------|-------|
+| auth | `docs/context/auth.md` | `src/auth/**` | session + token flows |
+```
+
+## `docs/context/ROUTING.md`
+
+```markdown
+# Routing Table
+
+| Trigger | Signal | Route |
+|---------|--------|-------|
+| Pre-change | `src/payments/**` | `stripe` specialist |
+| Post-change | auth/session files | security review |
+```
+
+## `docs/context/DRIFT-WATCHLIST.md`
+
+```markdown
+# Drift Watchlist
+
+| Files Changed | Review These Docs |
+|---------------|-------------------|
+| `src/auth/**` | `docs/context/auth.md` |
+| `src/payments/**` | `docs/context/payments.md` |
+```

--- a/core/delegate/SKILL.md
+++ b/core/delegate/SKILL.md
@@ -21,6 +21,14 @@ You don't analyze/review/audit yourself. You:
 3. **Curate** — Validate, filter, resolve conflicts
 4. **Synthesize** — Produce unified output
 
+Before routing, consult the repo's encoded context if it exists:
+- `AGENTS.md`
+- `CLAUDE.md`
+- `docs/context/ROUTING.md`
+- `docs/context/INDEX.md`
+
+Do not rely on memory for specialist selection when the repo has a routing table.
+
 ## Your Team
 
 ### Codex CLI — Implementation Agent
@@ -192,6 +200,8 @@ For each finding:
 **Validate**: Real issue or false positive? Applies to our context?
 **Filter**: Generic advice, style preferences contradicting conventions
 **Resolve Conflicts**: When tools disagree, explain tradeoff, make recommendation
+
+If no specialist or spec exists for a risky area, call that out as a context gap.
 
 ## Output Template
 

--- a/core/design/SKILL.md
+++ b/core/design/SKILL.md
@@ -165,6 +165,7 @@ User picks a direction (or hybrid). Then:
    - `references/web-design-guidelines.md` compliance
 
 3. **Scaffold component library** if none exists.
+4. **Codify token rules** with `/guardrail` so raw values fail at edit time.
 
 Detailed token references:
 - `references/design-tokens-color.md` -- OKLCH, semantic colors, brand-tinted neutrals
@@ -182,6 +183,7 @@ Update `app/globals.css` (or equivalent):
 - Migrate hardcoded values to tokens
 - Ensure dark mode support
 - Update components to use `var(--color-*)` and `var(--spacing-*)`
+- Add guardrails for token usage and wire them into pre-commit
 
 Naming convention: `--category-variant-state`
 ```
@@ -190,6 +192,11 @@ Naming convention: `--category-variant-state`
 --color-text-muted
 --spacing-component-gap
 ```
+
+Minimum guardrails for tokenized systems:
+- no raw hex colors outside token/theme files
+- no arbitrary spacing/radius values outside token/theme files
+- components consume semantic tokens, not palette literals
 
 ---
 

--- a/core/design/SKILL.md
+++ b/core/design/SKILL.md
@@ -194,7 +194,7 @@ Naming convention: `--category-variant-state`
 ```
 
 Minimum guardrails for tokenized systems:
-- no raw hex colors outside token/theme files
+- no raw color literals outside token/theme files (`#hex`, `rgb[a]`, `hsl[a]`, `oklch`, named colors)
 - no arbitrary spacing/radius values outside token/theme files
 - components consume semantic tokens, not palette literals
 

--- a/core/distill/SKILL.md
+++ b/core/distill/SKILL.md
@@ -44,6 +44,7 @@ Every line in CLAUDE.md must survive three questions:
 - "The auth middleware is load-bearing, all of it, don't be a hero" — counter-intuitive
 - "DATABASE_URL not POSTGRES_URL — Prisma's Rust engine reads it before Node" — painful gotcha
 - "e2e tests can't run headless due to extension limitations" — surprising constraint
+- "Delete compatibility shims in greenfield paths — they compound fast and mislead agents" — earned by pain
 
 ## Inputs
 
@@ -178,6 +179,8 @@ Scan the session for:
 - Debugging insights ("the real problem was...")
 - Workflow improvements discovered
 - Patterns that should be enforced
+- Repeated explanations that should become cold-memory docs
+- Retrieval misses that exposed undocumented subsystems
 
 ### Codification Targets (highest leverage first)
 
@@ -186,8 +189,12 @@ Scan the session for:
 3. **Agent** — Should a reviewer catch this pattern?
 4. **Skill** — Is this a reusable workflow?
 5. **CLAUDE.md** — Is this philosophy/convention?
+6. **Cold-memory doc** — Does `docs/context/<subsystem>.md` need to exist or be updated?
 
 Lint rules are ideal for: import boundaries, naming conventions, deprecated API usage, auth enforcement, architectural layering violations.
+
+Compatibility shims added only to preserve current structure are codification
+targets too: either document the real contract or delete the shim.
 
 ### Anti-Patterns
 

--- a/core/done/SKILL.md
+++ b/core/done/SKILL.md
@@ -39,6 +39,7 @@ From conversation context:
 | **Bugs introduced** | What broke and why? | Dict access on dataclass |
 | **Missing artifacts** | What would have prevented friction? | Module API reference |
 | **Architecture insights** | Design decisions right/wrong? | SQLite for persistence |
+| **Bloat signals** | What layers should be deleted? | Compatibility shim with no real users |
 
 ### 3. Codification Pass
 
@@ -55,6 +56,9 @@ Docs      -> Reference doc needs update?
 ```
 
 **Default: codify. Exception: justify not codifying.**
+
+If you explained a subsystem twice, add or update a cold-memory doc.
+If a risky subsystem had no relevant doc, record that retrieval miss explicitly.
 
 ### 3.5. Retro Append
 
@@ -77,7 +81,7 @@ This feeds `/groom`'s planning feedback loop.
 
 ### 3.6. Tune Repo
 
-Run `/tune-repo` to refresh `.glance.md` summaries and update CLAUDE.md/AGENTS.md
+Run `/tune-repo` to refresh context artifacts and update CLAUDE.md/AGENTS.md
 if drift detected.
 
 ### 4. Execute Codification
@@ -149,6 +153,7 @@ During planning, `/groom` reads retro.md and extracts:
 - Scope patterns ("Webhook issues always need retry logic")
 - Blocker patterns ("External API docs frequently wrong")
 - Domain insights ("Bitcoin wallet needs regtest testing")
+- Bloat patterns ("Agent kept layering fallback paths instead of deleting old code")
 
 ## Anti-Patterns
 

--- a/core/groom/SKILL.md
+++ b/core/groom/SKILL.md
@@ -70,8 +70,10 @@ Verify that codebase context artifacts are current:
 # CODEBASE_MAP.md — is last_mapped within 2 weeks?
 [ -f docs/CODEBASE_MAP.md ] && head -5 docs/CODEBASE_MAP.md || echo "No CODEBASE_MAP.md"
 
-# .glance.md files — do they exist for key directories?
-find . -name ".glance.md" -maxdepth 3 2>/dev/null | wc -l
+# docs/context artifacts
+[ -f docs/context/INDEX.md ] && echo "Context index exists" || echo "No context index"
+[ -f docs/context/ROUTING.md ] && echo "Routing table exists" || echo "No routing table"
+[ -f docs/context/DRIFT-WATCHLIST.md ] && echo "Drift watchlist exists" || echo "No drift watchlist"
 
 # CLAUDE.md and AGENTS.md — do they exist with essential sections?
 [ -f CLAUDE.md ] && echo "CLAUDE.md exists" || echo "No CLAUDE.md"
@@ -166,7 +168,7 @@ For each theme the user wants to explore, before making scoping decisions:
    - Trace execution paths through affected code
    - Map dependencies and blast radius
    - Identify existing utilities, helpers, and patterns to reuse
-   - Check `.glance.md` files and `docs/CODEBASE_MAP.md` for architecture context
+   - Check `docs/context/INDEX.md`, `docs/context/ROUTING.md`, and `docs/CODEBASE_MAP.md` for architecture context
 
 4. **Compile research brief** — Structured findings per theme:
    ```markdown

--- a/core/groom/references/project-md-format.md
+++ b/core/groom/references/project-md-format.md
@@ -10,7 +10,9 @@ tune-repo artifacts don't cover: vision, users, priorities, domain language.
 | `CLAUDE.md` | `/tune-repo` | Commands, stack, gotchas (code context) |
 | `AGENTS.md` | `/tune-repo` | Commit, test, PR, style conventions |
 | `docs/CODEBASE_MAP.md` | `/cartographer` | Architecture, modules, data flow |
-| `.glance.md` (per-dir) | `glance` | Per-directory summaries |
+| `docs/context/INDEX.md` | `/tune-repo` | Cold-memory subsystem index |
+| `docs/context/ROUTING.md` | `/tune-repo` | Trigger table for specialist routing |
+| `docs/context/*.md` | `/tune-repo` | Subsystem specifications |
 | `docs/adr/*.md` | `/tune-repo` | Architectural decision records |
 | **`project.md`** | **`/groom`** | **Vision, users, domain, quality bar** |
 

--- a/core/guardrail/SKILL.md
+++ b/core/guardrail/SKILL.md
@@ -27,6 +27,8 @@ written — and `fast-feedback.py` surfaces the error immediately so Claude self
 - Deprecated pattern blocking ("no direct fetch, use apiClient")
 - Auth enforcement ("handlers must call requireAuth")
 - Naming conventions that go beyond basic linting
+- Design-token enforcement ("no raw hex outside theme files")
+- Raw-value blocking ("no arbitrary spacing/radius outside token definitions")
 
 ## Workflow
 
@@ -41,6 +43,7 @@ Clarify the constraint:
 - What EXACTLY should be flagged? (imports, function calls, patterns)
 - What's the fix? (alternative import, wrapper function)
 - Are there exceptions? (test files, migrations, the repository itself)
+- If this is a design-system rule, isolate allowed token/theme files up front
 
 ### Phase 2: Choose Engine
 
@@ -69,6 +72,11 @@ Generate:
 1. Rule implementation with clear error message and fix suggestion
 2. Rule metadata (docs URL, fixable, schema)
 3. Test cases (valid AND invalid examples from the actual codebase)
+
+Common high-value rules:
+- No raw hex/rgb/oklch color literals outside token files
+- No magic spacing/radius values outside theme definitions
+- No direct imports across architectural boundaries
 
 ### Phase 4: Test
 
@@ -188,3 +196,4 @@ GUARDRAIL CREATED:
 | `/tune-repo` | Discovers patterns, recommends `/guardrail` invocations |
 | `/check-quality` | Audits `guardrails/` completeness |
 | CI (GitHub Actions) | Standard `eslint .` or `sg scan` in workflow |
+| pre-commit hooks | Run changed-file guardrails for edit-time enforcement |

--- a/core/issue/SKILL.md
+++ b/core/issue/SKILL.md
@@ -112,7 +112,7 @@ Fill missing issue sections using sub-agent research.
 
 | Missing Section | Agent | Prompt |
 |----------------|-------|--------|
-| Affected Files | Codebase explorer | "Find files related to [issue topic]. Check .glance.md and CODEBASE_MAP.md." |
+| Affected Files | Codebase explorer | "Find files related to [issue topic]. Check docs/context/INDEX.md, docs/context/ROUTING.md, and CODEBASE_MAP.md." |
 | Verification | Codebase explorer | "Find test commands and verification steps for [affected area]." |
 | Acceptance Criteria | General-purpose | "Write Given/When/Then acceptance criteria for: [problem statement]" |
 | Approach | Web researcher + codebase explorer | "Research best practices for [topic]. Find existing patterns in codebase." |

--- a/core/llm-infrastructure/SKILL.md
+++ b/core/llm-infrastructure/SKILL.md
@@ -21,6 +21,10 @@ Rigorous audit of all LLM-powered features. Model currency, prompt quality, eval
 
 **Observe everything.** Every LLM call should be traceable.
 
+**Default to OpenRouter + Langfuse.** OpenRouter gives cheap routing and observability-friendly metadata. Langfuse gives prompt, trace, and cost visibility.
+
+**Don't tweak in the dark.** Review real traces before changing prompts, tools, or skills.
+
 ## Process
 
 ### 1. Audit
@@ -61,9 +65,19 @@ If using a gateway (OpenRouter, LiteLLM):
 - Confirm cost tracking active
 - Validate model version pinning
 
+Prefer OpenRouter by default unless there is a clear reason not to.
+
 #### Observability Audit
 
 Check for tracing (Langfuse, Phoenix), user ID attachment, token usage capture.
+
+#### Trace Review Loop
+
+Run a few representative tasks, then inspect real traces:
+- Read prompts actually sent in production/dev
+- Look for irrelevant prompt bulk, repeated warnings, and dead instructions
+- Review tool calls, latency, failure paths, and reasoning metadata if available
+- Promote interesting failures/confusions into eval cases
 
 ### 2. Plan
 
@@ -73,7 +87,7 @@ Check for tracing (Langfuse, Phoenix), user ID attachment, token usage capture.
 
 ### 3. Execute
 
-Update models (env vars, not hardcoded), rewrite poor prompts, create eval suite, add observability, add CI gate.
+Update models (env vars, not hardcoded), rewrite poor prompts, create eval suite, add observability, add CI gate, and trim irrelevant prompt jank found in traces.
 
 ### 4. Verify
 
@@ -93,3 +107,4 @@ Run full eval suite, security scan, verify tracing, verify CI gate triggers.
 | `references/evaluation.md` | Promptfoo setup, assertions, CI/CD, red teaming |
 | `references/gateway-routing.md` | OpenRouter, LiteLLM, routing strategies |
 | `references/llm-communication.md` | Writing effective prompts and agent instructions |
+| `references/trace-review-loop.md` | Review Langfuse traces before tweaking prompts |

--- a/core/llm-infrastructure/references/trace-review-loop.md
+++ b/core/llm-infrastructure/references/trace-review-loop.md
@@ -1,0 +1,30 @@
+# Trace Review Loop
+
+Do not tweak prompts, tools, or skills in the dark.
+
+Default stack:
+
+- OpenRouter for routing, model experiments, and cheap provider switching
+- Langfuse for trace inspection, prompt review, and cost/latency visibility
+
+Loop:
+
+1. Run a few representative tasks end-to-end.
+2. Open recent Langfuse traces.
+3. Read the actual prompt/tool payloads sent.
+4. Look for confusion:
+   - irrelevant system-prompt bulk
+   - repeated warnings/instructions
+   - tool misuse
+   - missing context
+   - bad routing/model choice
+5. Promote failures and edge cases into evals.
+6. Trim prompt jank before adding more instructions.
+
+Questions to ask on every trace:
+
+- Did the model have the right context?
+- Did the prompt include irrelevant policy clutter?
+- Did the model choose the right tool?
+- Did the tool schema make the right path obvious?
+- Did latency/cost justify the model choice?

--- a/core/pr-fix/SKILL.md
+++ b/core/pr-fix/SKILL.md
@@ -18,7 +18,7 @@ Senior engineer unblocking a PR. Methodical, not reactive. Each phase resolves a
 
 ## Objective
 
-Take PR `$ARGUMENTS` (or current branch's PR) from blocked to mergeable: no conflicts, CI green, reviews addressed.
+Take PR `$ARGUMENTS` (or current branch's PR) from blocked to mergeable: no conflicts, CI green, reviews addressed, and **all open conversations on the PR resolved**.
 `dogfood`, `agent-browser`, and `browser-use` are available in this environment for user-flow verification.
 
 ## Dependency Order
@@ -128,6 +128,8 @@ This phase catches what CI cannot: code that compiles and passes tests but is wr
 
 ### 5. Address Reviews
 
+**Exit criterion for this phase:** the PR has zero unresolved review threads and zero remaining actionable open conversations. Do not call the PR unblocked while any conversation is still open.
+
 **Skip condition**: ALL THREE of these are zero: unresolved review threads, unreplied review comments, AND unaddressed bot issue comments. Use the queries below — never rely on `reviewDecision` alone or prior "PR Unblocked" summary comments.
 
 ```bash
@@ -217,7 +219,7 @@ Bot feedback (CodeRabbit, Gemini, Codex, and other reviewer bots) gets the same 
    - `Change: <what changed>`
    - `Verification: <tests/checks run or N/A>`
 
-5. **Resolve every thread via GraphQL** — Replies alone do NOT resolve threads. Non-outdated comments stay visible as open issues to reviewers even after fixing the code and replying. You MUST resolve them:
+5. **Resolve every thread via GraphQL** — Replies alone do NOT resolve threads. Non-outdated comments stay visible as open issues to reviewers even after fixing the code and replying. You MUST resolve them. The phase is incomplete until the unresolved thread count is `0`:
 
 ```bash
 # Get unresolved thread IDs
@@ -312,7 +314,7 @@ Max 2 full-pipeline retries when fixing one phase breaks another. After 2: stop 
 
 ## Output
 
-Summary: blockers found, phases executed, conflicts resolved, CI fixes applied, reviews addressed/deferred/declined, final check status.
+Summary: blockers found, phases executed, conflicts resolved, CI fixes applied, reviews addressed/deferred/declined, final check status, and explicit confirmation that open conversation count is zero.
 
 ## Absorbed Skills (References)
 

--- a/core/pr-polish/SKILL.md
+++ b/core/pr-polish/SKILL.md
@@ -67,6 +67,9 @@ Address hindsight findings using two-pass refinement (see `pr-fix/references/ref
 
 **Pass 2 — Architecture:** Shallow module consolidation, unnecessary abstraction removal, information hiding improvements.
 
+Delete compatibility layers that only exist to preserve agent-added structure.
+Passing tests do not justify bloat.
+
 For architectural findings that require broader changes: create GitHub issues.
 
 ```bash
@@ -178,17 +181,18 @@ gh pr view $PR --json body | jq -r '.body'
 
 Omit only when the change is purely internal with no branching or relationships.
 
-### 8. Refresh Glance Summaries (Conditional)
+### 8. Refresh Context Artifacts (Conditional)
 
 If this PR added, removed, or significantly restructured directories:
 
-```bash
-glance   # run from repo root — skips up-to-date directories automatically
-```
+Refresh the relevant context artifacts if the repo uses them:
 
-Do NOT pass `-force`. Glance handles intelligent regeneration based on existing `.glance.md` files. Only affects directories that changed.
+- `docs/CODEBASE_MAP.md`
+- `docs/context/INDEX.md`
+- `docs/context/ROUTING.md`
+- `docs/context/DRIFT-WATCHLIST.md`
 
-Commit any updated `.glance.md` files with the PR branch.
+Commit any updated context artifacts with the PR branch.
 
 ### 9. Codify (Optional)
 
@@ -205,6 +209,7 @@ Skip if nothing novel surfaced.
 - Leaving missing CI unaddressed when the PR depends on local-only verification
 - Documenting obvious mechanics instead of non-obvious decisions
 - Skipping hindsight and jumping straight to refactoring
+- Preserving unnecessary backward-compat shims in greenfield or pre-user code
 
 ## Output
 

--- a/core/pr-polish/SKILL.md
+++ b/core/pr-polish/SKILL.md
@@ -31,10 +31,14 @@ gh pr view $PR --json mergeable,statusCheckRollup,reviewDecision
 
 Requirements:
 - No merge conflicts
-- CI green
+- CI green for any relevant existing checks
 - No unaddressed critical review feedback
 
-**If any fail**: Tell user to run `/pr-fix` first. Do not proceed.
+If mergeability is broken, relevant CI is red, or critical review feedback is still open:
+- run `/pr-fix` first
+- do not proceed with polish
+
+If the repo simply lacks the relevant CI checks, continue. Missing CI is a polish target and must be called out in the merge-confidence ledger.
 
 ## Workflow
 

--- a/core/pr-polish/SKILL.md
+++ b/core/pr-polish/SKILL.md
@@ -18,6 +18,8 @@ Staff engineer doing a retrospective pass. Not finding bugs — asking "would we
 ## Objective
 
 Elevate PR `$ARGUMENTS` (or current branch's PR) from "works" to "exemplary": clean architecture, solid tests, current docs.
+Secondary question: **"How confident are we that merging this will not break existing behavior?"**
+Treat confidence as an explicit deliverable, not a vibe.
 
 ## Precondition Gate
 
@@ -88,10 +90,44 @@ Review test coverage for the PR's changed files. Look for:
 - Missing edge cases
 - Error path coverage
 - Behavior tests (not implementation tests — per `/testing-philosophy`)
+- Module-boundary tests over internal call choreography
 - Boundary conditions
 - Integration gaps
 
 Write missing tests. Each test should justify its existence — no coverage-padding.
+
+If tests are mock-heavy or fail on refactor-only changes, rewrite them as developer tests against exports/public behavior.
+
+### 4.25 Merge Confidence Audit
+
+Ask directly: **"What evidence says this merge will not break existing behavior, and what evidence is still missing?"**
+
+Build a short confidence ledger:
+- `Evidence` — passing tests, typechecks, builds, lint, manual QA, dogfood runs, screenshots, production-safe invariants
+- `Gaps` — missing regression tests, no CI, weak smoke tests, unverified migration paths, untouched error paths, missing browser/runtime verification
+- `Risk` — what could still break despite current green checks
+
+Then remediate the highest-leverage gaps you can within polish scope:
+- Add or strengthen regression/smoke tests for changed behavior
+- Add or tighten CI when checks are missing or too weak
+- Run build/typecheck/lint/test commands that cover the changed surface
+- Run targeted manual QA or browser QA for user-facing diffs
+- Verify compatibility paths explicitly when multiple entrypoints exist (`npm` vs `bun`, web vs mobile, API vs UI)
+
+Rules:
+- If there is **no CI** for the relevant checks, add it or document precisely why it cannot be added in this pass
+- If confidence depends on a manual assumption, turn it into an automated check when feasible
+- Do not claim "high confidence" while major evidence gaps remain
+- If a gap is too broad for polish, create a follow-up issue and call out the residual risk in the PR
+
+### 4.5 Agentic Audit
+
+If the PR touches prompts, model routing, tool schemas, or agent instructions:
+
+- Run `/llm-infrastructure`
+- Review real traces before changing prompts again
+- Add eval cases for observed confusions/regressions
+- Remove irrelevant prompt bulk discovered in traces
 
 ### 5. Documentation
 
@@ -111,6 +147,7 @@ pnpm typecheck && pnpm lint && pnpm test
 ```
 
 All gates must pass. Fix anything that doesn't.
+If repo-wide gates are already red from unrelated debt, still add the strongest PR-scoped automated checks you can and record the residual gap.
 
 ### 7. Update PR Description with Before / After
 
@@ -164,9 +201,11 @@ Skip if nothing novel surfaced.
 - Polishing a PR that doesn't work yet (use `/pr-fix` first)
 - Architectural refactors in a polish pass (create issues instead)
 - Adding tests for coverage percentage instead of confidence
+- Claiming merge confidence without listing concrete evidence and residual risk
+- Leaving missing CI unaddressed when the PR depends on local-only verification
 - Documenting obvious mechanics instead of non-obvious decisions
 - Skipping hindsight and jumping straight to refactoring
 
 ## Output
 
-Summary: hindsight findings, refactors applied, issues created, tests added, docs updated, quality gate results, learnings codified.
+Summary: hindsight findings, refactors applied, issues created, tests added, docs updated, quality gate results, merge-confidence evidence/gaps, learnings codified.

--- a/core/shape/SKILL.md
+++ b/core/shape/SKILL.md
@@ -76,11 +76,15 @@ Present: "Here's what I understand. Let me explore the problem space."
    - What it enables downstream
 
    **Recommend one.** Lead with recommendation and reasoning.
+   If ideas become polished variants or the room goes flat, invoke `break-the-frame`.
 
 3. **Discuss** — User steers. One question at a time. Multiple choice preferred.
    Iterate until product direction is locked.
 
-4. **Draft spec** — Post on issue:
+4. **Find the cheapest test** — If uncertainty is real, define the fastest cheap
+   experiment that would change the decision. Prefer probes over speculation.
+
+5. **Draft spec** — Post on issue:
 
    ```markdown
    ## Product Spec
@@ -134,7 +138,7 @@ Present: "Here's what I understand. Let me explore the problem space."
 
    | Agent | Focus |
    |-------|-------|
-   | Codebase explorer | Existing patterns, touch points, .glance.md context |
+   | Codebase explorer | Existing patterns, touch points, docs/context + CODEBASE_MAP context |
    | Web researcher | Best practices, framework docs, how others solve this |
    | Cross-repo investigator | Prior art in org repos, shared patterns |
 
@@ -202,6 +206,7 @@ Once both product and technical directions are locked:
 4. **Apply standards** — Labels, milestones, org-wide standards (see `groom/references/org-standards.md`)
 5. **Signal readiness** — `status/ready` for `/build` or `/autopilot`
 6. **Stress-test** — Run critique (see `references/critique-personas.md`) to find gaps
+7. **Prefer probe issues first** — if uncertainty remains high, create a cheap experiment issue before the full build issue
 
 Post spec + design as comments on each issue.
 

--- a/core/shape/SKILL.md
+++ b/core/shape/SKILL.md
@@ -53,6 +53,7 @@ Accept input: raw idea (string), issue ID, or observation.
 2. If issue exists: `gh issue view $1 --comments`
 3. Load `project.md` if present (falls back to `vision.md`)
 4. Read relevant codebase context — adjacent features, existing patterns, constraints
+5. If `docs/context/` is missing, bootstrap `INDEX.md`, `ROUTING.md`, and `DRIFT-WATCHLIST.md` from `codified-context-architecture/references/templates.md` or explicitly note that repo context is not tuned yet. Do not cite cold-memory docs that do not exist.
 
 Present: "Here's what I understand. Let me explore the problem space."
 

--- a/core/skill-builder/SKILL.md
+++ b/core/skill-builder/SKILL.md
@@ -92,6 +92,7 @@ Before creating, determine if foundational or workflow:
 - What problem does this solve?
 - What trigger terms would activate it?
 - Is it cross-project or project-specific?
+- Which tier should hold it: hot memory, specialist, cold memory, or hook?
 
 ### 2. Draft Structure
 Reference `references/structure-guide.md` for ideal anatomy.
@@ -101,6 +102,12 @@ Reference `references/description-patterns.md` for trigger-rich descriptions (~1
 
 ### 4. Validate
 Run `scripts/validate_skill.py <skill-path>` to check structure and frontmatter.
+
+Also verify:
+- Metadata is concise and trigger-rich
+- Body stays lean; push detail into `references/`
+- No absolute paths unless the runtime truly requires them
+- Tool scope is explicit when a skill depends on special tools
 
 ### 5. Inform User
 After creating, tell user:
@@ -114,6 +121,9 @@ Keep SKILL.md lean (<100 lines). Put detailed specs in `references/`:
 - Detailed examples → `references/examples.md`
 - Edge cases → `references/edge-cases.md`
 - Anti-patterns → `references/anti-patterns.md`
+
+Beware brevity bias: compress aggressively for general doctrine, but do not
+over-compress high-failure domains that need real mental models.
 
 ## Code Opportunities
 

--- a/core/skill-creator/SKILL.md
+++ b/core/skill-creator/SKILL.md
@@ -198,6 +198,10 @@ Claude reads REDLINING.md or OOXML.md only when the user needs those features.
 
 - **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
 - **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+- **Keep metadata tight** - Descriptions should be trigger-rich and compact, not mini-manuals.
+- **Avoid absolute paths in skill content** - Use relative paths unless the runtime or harness location is the point.
+- **Scope tool requirements** - If a skill depends on special tools, say so precisely instead of implying broad access.
+- **Avoid brevity bias** - Some risky domains need substantial embedded context; don't compress them into useless slogans.
 
 ## Skill Creation Process
 

--- a/core/test-coverage/SKILL.md
+++ b/core/test-coverage/SKILL.md
@@ -2,7 +2,8 @@
 name: test-coverage
 description: |
   Test audit, TDD enforcement, and coverage analysis. Prefer Vitest.
-  Runs coverage, identifies gaps, enforces test-first workflow.
+  Runs coverage, identifies gaps, enforces test-first workflow, and pushes
+  developer tests over mock-heavy unit tests.
   Use for: "run test audit", "coverage gaps", "write tests", "TDD",
   "testing philosophy", "vitest setup", "test quality review".
 disable-model-invocation: true
@@ -36,6 +37,15 @@ REPEAT
 **The critical step most skip:** After writing a failing test, verify it fails
 for the right reason -- not syntax errors, wrong imports, or incorrect assertions.
 
+## Developer Test Rule
+
+Prefer developer tests over mock-heavy unit tests.
+
+- Test module exports and public behavior
+- Test what callers observe, not internal message sends
+- Refactor-hostile tests are bad tests even when green
+- If a refactor breaks tests without changing behavior, fix the tests or the design
+
 ## Testing Philosophy
 
 **Test behavior, not implementation.** Tests should verify WHAT code does,
@@ -44,6 +54,7 @@ not HOW it does it. Implementation changes; behavior remains stable.
 ### What to Test
 
 - Public API (what callers depend on)
+- Module exports / boundary behavior
 - Business logic (critical rules, calculations)
 - Error handling (failure modes)
 - Edge cases (boundaries, null, empty)
@@ -51,6 +62,8 @@ not HOW it does it. Implementation changes; behavior remains stable.
 ### What NOT to Test
 
 - Private implementation details
+- Call order between internal collaborators
+- Which internal method called which dependency
 - Third-party libraries
 - Simple getters/setters (unless they have logic)
 - Framework code
@@ -61,6 +74,7 @@ not HOW it does it. Implementation changes; behavior remains stable.
 - **NEVER mock:** Your own domain logic, internal collaborators (`@/lib/*`)
 - **Red flag:** >3 mocks = coupling to implementation. Refactor.
 - **Pattern:** If mock path starts with `@/` or `../`, reconsider.
+- **Reject:** internal call-count/order assertions unless that order is behavior
 
 ### Test Structure: AAA
 
@@ -71,6 +85,17 @@ Assert:  Verify expected outcome
 ```
 
 One behavior per test. Name: "should [behavior] when [condition]".
+
+## Test Properties
+
+Good programmer tests should be:
+
+- Fast enough to preserve flow
+- Deterministic and isolated
+- Behavioral and structure-insensitive
+- Specific when they fail
+- Cheap to write, read, and change
+- Predictive enough for the level they claim to cover
 
 ## Coverage Philosophy
 
@@ -155,6 +180,7 @@ code, third-party code. Always add a comment explaining WHY.
 ## References
 
 - `references/testing-philosophy.md` -- Full testing philosophy
+- `references/developer-tests.md` -- Behavioral developer-test doctrine
 - `references/tdd-protocol.md` -- Complete TDD workflow and rationalizations
 - `references/vitest-config.md` -- Vitest configuration details
 - `references/vitest-pool-config.md` -- Pool selection guide

--- a/core/test-coverage/references/developer-tests.md
+++ b/core/test-coverage/references/developer-tests.md
@@ -1,0 +1,27 @@
+# Developer Tests
+
+Prefer developer tests over mock-heavy unit tests.
+
+Core rules:
+
+- Test module exports and public behavior
+- Couple tests to behavior, decouple them from structure
+- Mock only external systems and nondeterminism
+- Treat call-order assertions and internal collaborator checks as smells
+
+Good developer tests are:
+
+- Fast
+- Deterministic
+- Isolated
+- Specific on failure
+- Behavioral
+- Structure-insensitive
+- Cheap to read and change
+
+Red flags:
+
+- Refactoring changes tests without changing behavior
+- `>3` mocks in one test
+- Assertions about which internal object called which method
+- Tests that mirror source structure line-for-line

--- a/core/test-coverage/references/tdd-protocol.md
+++ b/core/test-coverage/references/tdd-protocol.md
@@ -19,6 +19,7 @@ Write one minimal test showing what should happen.
 Requirements:
 - One behavior
 - Clear name
+- Test exported/public behavior
 - Real code (no mocks unless unavoidable)
 
 ### Verify RED (MANDATORY, NEVER SKIP)
@@ -56,6 +57,8 @@ After green only. Remove duplication, improve names, extract helpers. Stay green
 - AI implements code to pass tests (human reviews)
 - Tests are specifications in executable form
 - Commit tests separately before implementation
+- Prefer developer tests over mock-heavy unit tests
+- Avoid asserting internal call order unless that order is user-visible behavior
 
 ## Bug Fix Pattern
 

--- a/core/tune-repo/SKILL.md
+++ b/core/tune-repo/SKILL.md
@@ -3,8 +3,8 @@ name: tune-repo
 disable-model-invocation: true
 description: |
   Deeply specialize agents for a specific repository.
-  Runs Glance (bottom-up directory summaries) + Cartographer (top-down architecture map),
-  then synthesizes into CLAUDE.md, AGENTS.md, ADRs, and memory.
+  Build a codified context architecture: hot-memory constitution, routing table,
+  cold-memory subsystem docs, and supporting repo artifacts.
   Use when: onboarding to a new repo, improving agent effectiveness, repo setup, agent tuning.
 ---
 
@@ -24,210 +24,183 @@ Transform a repository from "generic AI agent target" to "finely tuned agent wor
 
 - CLAUDE.md is the constitution, not the encyclopedia. Keep it token-cheap.
 - Policy in tracked files. State in memory. Procedures in skills.
-- Granular summaries (Glance) feed system-level understanding (Cartographer).
+- Use tiered context: hot memory, routing, cold memory.
 - Document invariants, not obvious mechanics.
 - Every gotcha captured now saves 10 agent iterations later.
+- Stale specs are load-bearing bugs.
 
 ## Preconditions
 
 Verify the repo is ready:
 
 ```bash
-git rev-parse --is-inside-work-tree  # Must be a git repo
-git remote get-url origin            # Need remote context
+git rev-parse --is-inside-work-tree
+git remote get-url origin
 ```
 
-Read what already exists — don't overwrite good work:
+Read what already exists:
 
 ```bash
-# Check for existing docs
-ls CLAUDE.md AGENTS.md docs/CODEBASE_MAP.md docs/adr/ 2>/dev/null || true
+ls CLAUDE.md AGENTS.md docs/CODEBASE_MAP.md docs/context/ docs/adr/ 2>/dev/null || true
 ```
 
 ## Workflow
 
-### Phase 1: Glance Scan (Fast, Cheap)
+### Phase 1: Context Audit
 
-Generate bottom-up per-directory summaries. This gives agents granular navigation context.
+Inventory the current context architecture:
 
-```bash
-# Check if glance is available
-which glance
+- `CLAUDE.md`
+- `AGENTS.md`
+- `docs/CODEBASE_MAP.md`
+- `docs/context/INDEX.md`
+- `docs/context/ROUTING.md`
+- `docs/context/DRIFT-WATCHLIST.md`
+- `docs/context/*.md`
 
-# Run glance on the repo root
-glance
-```
+Detect:
+- missing hot-memory rules
+- missing subsystem docs
+- routing gaps
+- likely stale docs
 
-Glance produces `.glance.md` in each directory. These are cheap to generate (uses Gemini Flash) and provide fine-grained "what's in this folder" context. Glance skips directories that already have a `.glance.md` by default — intelligent regeneration is built in, so never pass `-force`.
+### Phase 2: Cartographer
 
-**If glance is not installed:** Skip this phase. Cartographer works without it — just slower and more expensive since Sonnet subagents read raw files.
+Invoke `/cartographer` to produce or refresh `docs/CODEBASE_MAP.md`.
 
-### Phase 2: Cartographer (Comprehensive, Top-Down)
+If `docs/CODEBASE_MAP.md` exists and is recent, run in update mode.
 
-Invoke `/cartographer` to produce `docs/CODEBASE_MAP.md`.
+Output:
+- system overview
+- architecture diagrams
+- module guide
+- data flow
+- conventions
+- gotchas
 
-Cartographer's Sonnet subagents will naturally discover and leverage the glance.md files from Phase 1, reducing the raw code they need to parse.
+### Phase 3: Cold Memory Scaffold
 
-**If `docs/CODEBASE_MAP.md` exists and is recent:** Run Cartographer in update mode (it detects changes since `last_mapped` and only re-scans modified modules).
+Create or update `docs/context/`:
 
-**Output:** System overview, architecture diagrams, module guide, data flow, conventions, gotchas, navigation guide.
+- `docs/context/INDEX.md` — subsystem -> docs -> source-file map
+- `docs/context/ROUTING.md` — trigger table mapping file patterns/signals to specialists or workflows
+- `docs/context/DRIFT-WATCHLIST.md` — files changed -> docs to review
+- `docs/context/<subsystem>.md` — focused subsystem specs for risky areas
 
-### Phase 3: CLAUDE.md Audit + Update
+Start with the highest-failure or highest-change subsystems first.
 
-Read the current CLAUDE.md (if any). Read the Cartographer output. Synthesize.
+Rules:
+- one subsystem per doc
+- write for agents, not humans
+- include file paths, key APIs, invariants, and failure modes
+- stop if you are writing encyclopedias
 
-CLAUDE.md must cover — and ONLY cover — these sections:
+### Phase 4: CLAUDE.md Audit + Update
 
-1. **What This Is** — 2-3 sentences. Purpose, users, business context.
-2. **Essential Commands** — dev, build, test, lint, deploy. Copy-pasteable.
-3. **Architecture** — High-level module diagram or description. Link to CODEBASE_MAP.md for details.
-4. **Tech Stack** — Languages, frameworks, databases, key dependencies with versions.
-5. **Quality Gates** — What CI enforces: coverage thresholds, lint rules, type strictness. The exact commands.
-6. **Gotchas** — Things that trip agents up. Earned-by-pain knowledge. Be specific.
-7. **Environment** — Required env vars, secrets, external services.
-8. **Deployment** — How code gets to production.
+Read current `CLAUDE.md`, Cartographer output, and `docs/context/`.
 
-**Hard constraint: 200 lines max.** Every line must earn its place. Link to docs/ for details. If CLAUDE.md exceeds 200 lines, you're writing an encyclopedia, not a constitution.
+CLAUDE.md should cover only:
 
-**Preserve existing content** that's accurate. Don't rewrite good prose — merge new findings.
+1. What this repo is
+2. Essential commands
+3. Architecture at high level
+4. Quality gates
+5. Gotchas
+6. Environment/deployment if non-obvious
 
-### Phase 4: AGENTS.md Scaffold
+Hard constraint: 200 lines max.
+
+Preserve accurate existing content. Merge, don't churn.
+
+### Phase 5: AGENTS.md Scaffold
 
 AGENTS.md is the operational playbook for AI agents. It covers what CLAUDE.md doesn't: how to work here.
 
 Sections:
 
-1. **Commit Conventions** — Message format, scope, conventional commits style.
-2. **Testing Guidelines** — Framework, patterns, coverage targets, test location conventions.
-3. **PR Guidelines** — Required sections, review expectations, merge strategy.
-4. **Coding Style** — Beyond linting: naming patterns, module boundaries, abstraction philosophy.
-5. **Issue Workflow** — Labels, status transitions, how to pick work.
-6. **Definition of Done** — What "complete" means for an issue in this repo.
-7. **Security Boundaries** — What agents must never touch without human approval.
+1. Commit conventions
+2. Testing guidelines
+3. PR guidelines
+4. Coding style beyond linting
+5. Issue workflow
+6. Definition of done
+7. Security boundaries
+8. Routing rules pointing to `docs/context/ROUTING.md`
 
-**If AGENTS.md already exists:** Audit it against current reality. Fill gaps, correct drift.
+If AGENTS.md exists, audit and correct drift.
 
-**If it doesn't exist:** Create it. Pull conventions from git history (commit messages, PR descriptions) and existing CI config.
-
-### Phase 5: ADR Inventory
+### Phase 6: ADR Inventory
 
 Scan for undocumented architectural decisions:
 
 ```bash
-# Check existing ADRs
 ls docs/adr/ 2>/dev/null || mkdir -p docs/adr
-
-# Look for decision signals in git history
-git log --oneline --all --grep="decision\|migrate\|replace\|switch\|deprecat" | head -20
-
-# Look for decision signals in code
-# (framework choices, database selection, auth strategy, API design)
+git log --oneline --all --grep="decision\\|migrate\\|replace\\|switch\\|deprecat" | head -20
 ```
 
-For each significant decision found without an existing ADR:
+Create at most 5 ADRs per run. Focus on decisions that would confuse a new agent.
 
-```markdown
-# docs/adr/NNN-title.md
+### Phase 7: Memory Seeding
 
-# NNN. Decision Title
+Extract repo-specific gotchas into:
 
-Date: YYYY-MM-DD
-
-## Status
-Accepted
-
-## Context
-[Why was this decision needed?]
-
-## Decision
-[What was decided?]
-
-## Consequences
-[What are the implications — good and bad?]
-```
-
-Focus on decisions that would confuse a new agent:
-- Why this framework/library over alternatives?
-- Why this data model shape?
-- Why this deployment strategy?
-- Why this testing approach?
-
-**Limit: 5 ADRs max per tune-repo run.** Don't boil the ocean. Capture the most impactful decisions.
-
-### Phase 6: Memory Seeding
-
-Extract project-specific gotchas into the auto-memory file:
-
-```
+```text
 ~/.claude/projects/<escaped-repo-path>/memory/MEMORY.md
 ```
 
-Good memory entries:
-- CLI quirks specific to this project's toolchain
-- API/service gotchas discovered in git history or issue tracker
-- Flaky tests and their root causes
-- Environment setup footguns
-- Things that look wrong but are intentional
+Good entries:
+- CLI quirks
+- flaky test causes
+- environment footguns
+- intentional weirdness
 
-Bad memory entries:
-- Anything already in CLAUDE.md (don't duplicate)
-- Generic language/framework knowledge
-- Temporary state (current branch, active PR)
+Bad entries:
+- anything already in CLAUDE.md
+- generic framework knowledge
+- temporary branch state
 
-### Phase 7.5: Guardrail Discovery
+### Phase 8: Guardrail Discovery
 
-Analyze Cartographer output and codebase for architectural invariants worth enforcing as lint rules. Look for:
+Analyze codebase + context docs for invariants worth enforcing:
 
-- **Import boundaries** — Are there modules that should only be accessed through a facade? (e.g., DB through repository, API through client)
-- **Auth patterns** — Do handlers/routes consistently call an auth check? Any that don't?
-- **Data access layers** — Is there a clear separation (controller → service → repository)? Violations?
-- **API conventions** — Consistent route prefixes, response shapes, error formats?
-- **Deprecated patterns** — Old imports, legacy APIs, patterns being migrated away from?
-- **Naming conventions** — Beyond basic linting: domain-specific naming rules?
+- import boundaries
+- auth patterns
+- data access layers
+- API conventions
+- deprecated patterns
+- naming conventions
 
-For each pattern found, output a recommendation:
+Report candidates for `/guardrail`. Do not generate the rules here.
 
-```
-Guardrail candidates:
-- /guardrail "all DB access must go through repository layer" (3 violations found)
-- /guardrail "API routes must use /api/v1 prefix" (0 violations — already clean, protect it)
-- /guardrail "no direct fetch() — use apiClient wrapper" (7 violations found)
-```
+### Phase 9: Skill Gap Analysis
 
-**Do NOT generate rules here.** `/guardrail` owns rule generation. This phase only discovers and recommends.
+Assess whether the repo needs project-specific skills:
 
-### Phase 8: Skill Gap Analysis
+- unique build/deploy workflow
+- repeated multi-step maintenance rituals
+- domain workflows general skills do not cover
 
-Assess whether this repo needs project-specific skills:
-
-- Does it have a unique build/deploy pipeline that `/build` doesn't cover?
-- Does it use a CLI tool that agents invoke frequently? (e.g., a repo-specific internal CLI)
-- Are there repetitive multi-step workflows specific to this domain?
-
-If yes: document the gap as a recommendation. Don't build the skill in this run — that's a separate task.
-
-```bash
-# Report recommendation
-echo "Skill gap: This repo could benefit from a custom /deploy-$REPO skill for [reason]"
-```
+Document the recommendation. Do not build the skill in this run unless explicitly asked.
 
 ## Anti-Patterns
 
-- Writing CLAUDE.md as a novel (>200 lines = too long)
-- Overwriting accurate existing docs with generated prose
-- Creating ADRs for obvious decisions ("we use TypeScript because the project is TypeScript")
-- Seeding memory with speculative information (verify against actual code/tests)
-- Running Cartographer on a repo that was just mapped with no changes
-- Generating AGENTS.md conventions that contradict what git history shows
+- Writing CLAUDE.md as a novel
+- Overwriting accurate docs with generic generated prose
+- Creating ADRs for obvious decisions
+- Seeding memory with speculation
+- Ignoring routing gaps and expecting humans to remember specialist selection
+- Treating stale subsystem docs as harmless
 
 ## Output
 
 Report:
-- Glance: directories scanned, summaries generated
 - Cartographer: CODEBASE_MAP.md created/updated
+- Context index: created/updated subsystems
+- Routing table: created/updated triggers
+- Drift watchlist: created/updated mappings
 - CLAUDE.md: sections added/updated, final line count
 - AGENTS.md: created or audited, sections covered
-- ADRs: new ADRs created (list titles)
-- Memory: entries seeded (list topics)
-- Guardrail candidates: patterns recommended for `/guardrail`
-- Skill gaps: recommendations (if any)
+- ADRs: new ADRs created
+- Memory: entries seeded
+- Guardrail candidates: recommended patterns
+- Skill gaps: recommendations

--- a/docs/context/DRIFT-WATCHLIST.md
+++ b/docs/context/DRIFT-WATCHLIST.md
@@ -1,0 +1,11 @@
+# Drift Watchlist
+
+Starter drift map for tuned repos.
+
+When these areas change, review the linked context docs in the same PR.
+
+| Files Changed | Review These Docs |
+|---------------|-------------------|
+| `CLAUDE.md`, `AGENTS.md` | `docs/context/INDEX.md`, `docs/context/ROUTING.md` |
+| `core/skill-builder/**`, `core/skill-creator/**` | `docs/context/ROUTING.md` |
+| `core/tune-repo/**`, `core/codified-context-architecture/**` | `docs/context/INDEX.md`, `docs/context/DRIFT-WATCHLIST.md` |

--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -1,0 +1,9 @@
+# Context Index
+
+Starter cold-memory index for tuned repos.
+
+Use `/tune-repo` to replace placeholders with real subsystem docs.
+
+| Subsystem | Docs | Source Files | Notes |
+|-----------|------|--------------|-------|
+| context-architecture | `docs/context/ROUTING.md`, `docs/context/DRIFT-WATCHLIST.md` | `CLAUDE.md`, `AGENTS.md`, `docs/context/**` | repo-level context plumbing |

--- a/docs/context/ROUTING.md
+++ b/docs/context/ROUTING.md
@@ -1,0 +1,11 @@
+# Routing Table
+
+Starter trigger table for tuned repos.
+
+Use `/tune-repo` to replace placeholders with real routes tied to source areas.
+
+| Trigger | Signal | Route |
+|---------|--------|-------|
+| Pre-change | skill creation or modification | `skill-builder` + `skill-creator` |
+| Pre-change | repo tuning / agent foundation work | `codified-context-architecture` + `/tune-repo` |
+| Post-change | PR blocked on CI, reviews, or conflicts | `/pr-fix` |

--- a/docs/context/SUBSYSTEM-TEMPLATE.md
+++ b/docs/context/SUBSYSTEM-TEMPLATE.md
@@ -1,0 +1,30 @@
+# Subsystem Template
+
+Use this shape for focused cold-memory docs under `docs/context/`.
+
+```markdown
+# <Subsystem Name>
+
+## Scope
+- Files:
+- Entry points:
+- Non-goals:
+
+## Invariants
+- Always:
+- Never:
+
+## Key Flows
+1.
+2.
+
+## Failure Modes
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+
+## Routing Notes
+- Which specialist / workflow to invoke:
+
+## Drift Triggers
+- If these files change, update this doc:
+```

--- a/packs/growth/content/SKILL.md
+++ b/packs/growth/content/SKILL.md
@@ -17,6 +17,8 @@ Full content lifecycle: write, edit, publish, humanize.
 This skill consolidates: `copywriting`, `copy-editing`, `copy-lab`,
 `social-content`, `post`, `announce`, `email-sequence`, `humanizer`.
 
+Foundation skill: `product-marketing-context` -- load first.
+
 ---
 
 ## Quick Start
@@ -46,6 +48,16 @@ This skill consolidates: `copywriting`, `copy-editing`, `copy-lab`,
 
 ---
 
+## First Move
+
+Before writing:
+
+1. Load `product-marketing-context`
+2. Summarize offer, audience, positioning, proof, and current experiment
+3. Only ask for missing context if the gap blocks the draft
+
+If the copy gets cleverer without getting truer, invoke `break-the-frame`.
+
 ## Copywriting
 
 ### Before Writing
@@ -62,6 +74,7 @@ Gather context (ask if not provided):
 - **Specificity over vagueness** -- "Cut reporting from 4 hours to 15 minutes"
 - **Customer language** -- mirror voice-of-customer
 - **One idea per section** -- build a logical flow
+- **True over clever** -- write like a sharp human, not a rubric machine
 
 ### Writing Style
 1. Simple over complex ("use" not "utilize")
@@ -131,6 +144,9 @@ Design-lab pattern for copy. Five distinct approaches, not word variants.
 4. **Iterate until all 5 hit 90+** -- revise using review findings, keep distinct
 5. **Present catalog** -- approach name, strategy, final copy, scores, rationale
 6. **User selects** -- pick or mix, synthesize final draft, re-review
+
+If the five approaches start collapsing into the same frame, stop scoring and
+reframe the problem with `break-the-frame`.
 
 ---
 

--- a/packs/growth/growth/SKILL.md
+++ b/packs/growth/growth/SKILL.md
@@ -21,6 +21,8 @@ This skill consolidates: `marketing-ops`, `marketing-dashboard`, `marketing-stat
 `analytics-tracking`, `seo-audit`, `seo-baseline`, `schema-markup`, `programmatic-seo`,
 `pseo-generator`.
 
+Foundation skill: `product-marketing-context` -- load first.
+
 ---
 
 ## Quick Start
@@ -61,6 +63,24 @@ This skill consolidates: `marketing-ops`, `marketing-dashboard`, `marketing-stat
 ```
 
 ---
+
+## First Move
+
+Before any growth work:
+
+1. Load `product-marketing-context`
+2. Summarize offer, audience, positioning, proof, and current experiment
+3. Mark guesses as hypotheses
+
+Do not jump into tactics from a blank slate.
+
+## Operating Principles
+
+- Cheap experiments beat long strategy debates
+- A dozen sloppy tests teach more than one perfect theory
+- If options feel competent but dead, invoke `break-the-frame`
+- Prefer one clear hypothesis per test
+- Learning rate matters more than polish
 
 ## SEO
 
@@ -132,7 +152,8 @@ Route by conversion context:
 3. Identify friction points and drop-off
 4. Propose changes with rationale
 5. Design A/B test
-6. Implement winning variant
+6. Implement the cheapest valid test first
+7. Implement winning variant
 
 ---
 
@@ -163,6 +184,7 @@ Define for each event: name, trigger, properties, implementation.
 3. **Sample size**: calculate required sample for statistical significance
 4. **Duration**: minimum 1-2 full business cycles
 5. **Segmentation**: who sees which variant
+6. **Cheap first pass**: ask whether a dirt-cheap probe can invalidate the idea sooner
 
 ### Common Tests
 - Headlines and CTAs

--- a/packs/growth/product-marketing-context/SKILL.md
+++ b/packs/growth/product-marketing-context/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: product-marketing-context
+description: |
+  Shared product-marketing context for growth-pack skills. Read this before
+  writing copy, planning launches, doing CRO, pricing, SEO, social content, or
+  campaign strategy. Builds a minimal context bundle from the offer, audience,
+  positioning, proof, competitors, and current experiments so downstream
+  marketing skills stop improvising from thin air.
+user-invocable: false
+---
+
+# Product Marketing Context
+
+Load this before `growth`, `content`, `brand`, `audit-website`, or launch work.
+
+## Context Bundle
+
+Collect the minimum viable context:
+
+- Offer: what it is, who it is for, what changed
+- Audience: ICP, pain, desired outcome, objections, language
+- Positioning: category, alternatives, why this wins
+- Proof: metrics, testimonials, customer stories, screenshots, social proof
+- Distribution context: acquisition channel, traffic intent, launch moment
+- Experiment context: active tests, hypotheses, recent learnings
+
+## Read In This Order
+
+1. `brand.yaml` or `brand-profile.yaml`
+2. product README / landing page / current pricing page
+3. customer notes, testimonials, launch docs, or issue brief
+4. analytics or experiment notes if available
+
+If context is missing, ask only for the highest-leverage gap.
+
+## Rules
+
+- Do not write generic SaaS copy from first principles if context exists.
+- Mirror customer language before inventing new language.
+- State the current best hypothesis, not fake certainty.
+- Prefer one sharp audience over mushy universality.
+
+## Output
+
+Before downstream work, summarize:
+- Offer
+- Audience
+- Positioning
+- Proof
+- Active experiment or learning angle
+
+If any line is guessed, mark it as a hypothesis.
+
+## References
+
+- `references/context-template.md` -- Minimal bundle to fill before marketing work

--- a/packs/growth/product-marketing-context/references/context-template.md
+++ b/packs/growth/product-marketing-context/references/context-template.md
@@ -1,0 +1,12 @@
+# Product Marketing Context Template
+
+- Offer:
+- Audience:
+- Pain:
+- Desired outcome:
+- Positioning:
+- Alternatives:
+- Proof:
+- Distribution channel:
+- Current experiment:
+- Unknowns / hypotheses:


### PR DESCRIPTION
## Summary
This PR codifies a tiered context architecture for agent harnesses and replaces the old `glance`/`.glance.md` paradigm with explicit `docs/context/` artifacts. It also folds recent workflow findings into the core skills so repo tuning, delegation, planning, testing, and growth work all route through the same context-placement model.

This also moves the previously local-only `refactor: add merge confidence audit to pr polish` commit off `master` and into reviewable PR history.

## Changes
- Add `codified-context-architecture` as a new foundational reference skill with templates for `docs/context/INDEX.md`, `ROUTING.md`, and `DRIFT-WATCHLIST.md`.
- Add `break-the-frame` and `product-marketing-context` reference skills.
- Rewrite `tune-repo` around hot memory + routing + cold memory instead of generated `.glance.md` summaries.
- Update `agentic-bootstrap`, `delegate`, `done`, `distill`, `skill-builder`, and `skill-creator` to encode tier placement, drift, retrieval misses, and anti-brevity-bias guidance.
- Update `shape`, `growth`, and `content` to prefer cheap experiments and use `break-the-frame` when ideation or copy rounds flatten out.
- Strengthen `build`, `autopilot`, `pr-polish`, `check-quality`, `test-coverage`, `design`, `guardrail`, and `llm-infrastructure` around developer tests, token guardrails, tracing, and anti-bloat rules.
- Update repo inventories in `README.md` and `CLAUDE.md` and remove repo logic that referenced `.glance.md`.

## Acceptance Criteria
- [x] Add a reusable foundational skill for codified context architecture.
- [x] Remove the repo's operational dependence on `glance` / `.glance.md` and replace it with explicit context artifacts.
- [x] Fold the paper's findings into the existing core skills via routing, drift control, and knowledge-tier placement.
- [x] Keep the changes reviewable on a feature branch instead of leaving them on `master`.

## Manual QA
1. Verify the new foundational skill validates:
   - `python3 core/skill-builder/scripts/validate_skill.py core/codified-context-architecture`
   - Expected: JSON output with `"valid": true`.
2. Verify the previously added reference skills still validate:
   - `python3 core/skill-builder/scripts/validate_skill.py core/break-the-frame`
   - `python3 core/skill-builder/scripts/validate_skill.py packs/growth/product-marketing-context`
   - Expected: JSON output with `"valid": true` for both.
3. Verify the repo no longer uses `.glance.md` as a context mechanism:
   - `rg -n "\.glance\.md|glance" core packs README.md CLAUDE.md AGENTS.md`
   - Expected: only plain-English copy like "at a glance" remains; no workflow instructions depend on `glance`.
4. Inspect the rewritten tuning path:
   - `sed -n '1,260p' core/tune-repo/SKILL.md`
   - Expected: `docs/context/INDEX.md`, `ROUTING.md`, and `DRIFT-WATCHLIST.md` are the context artifacts referenced.
5. Inspect branch state:
   - `git log --oneline --decorate -n 5`
   - Expected: this branch contains the feature commits while local `master` has been reset to `origin/master`.

## What Changed
```mermaid
graph TD
    A[CLAUDE.md / AGENTS.md\nhot memory] --> B[docs/context/ROUTING.md\nencoded routing]
    B --> C[Specialists / workflows\ninvoked by signal]
    B --> D[docs/context/INDEX.md\ncold-memory index]
    D --> E[docs/context/subsystem.md\nsubsystem specs]
    E --> F[docs/context/DRIFT-WATCHLIST.md\ndrift control]
    F --> G[tune-repo / delegate / distill\nupdated workflows]
```

## Before / After
Before: repo guidance referenced `glance` and `.glance.md` as if per-directory generated summaries were part of the tuning path, and the paper's codified-context findings were only partially reflected in the skills. One local commit also lived directly on `master`.

After: the repo uses an explicit tiered context model centered on `CLAUDE.md`/`AGENTS.md`, `docs/context/` routing and cold-memory artifacts, and specialist/drift rules baked into the existing skill workflows. The former local `master` commit now lives on this review branch instead of on `master`.

No screenshots: the diff is documentation/instructions only.

## Test Coverage
- Structural validation covered by `core/skill-builder/scripts/validate_skill.py` for:
  - `core/codified-context-architecture`
  - `core/break-the-frame`
  - `packs/growth/product-marketing-context`
- Search-based regression check covered by:
  - `rg -n "\.glance\.md|glance" core packs README.md CLAUDE.md AGENTS.md`

Gaps:
- This repo is Markdown-first and has no broader automated test suite for skill behavior beyond the validator and targeted text checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new development skills: Break The Frame, Codified Context Architecture, and Product Marketing Context; growth pack expanded with a new product-marketing-context skill and preparatory workflow.

* **Documentation & Guidance**
  * Introduced tiered context guidance (hot memory, routing, cold memory), drift/watchlist and routing artifacts, trace-review loop, developer-test standards, token/guardrail policies, and new templates for context and subsystem docs.

* **Other**
  * Updated reported skill totals and minor workflow refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->