### PR TITLE
Add mandatory walkthrough workflow and skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A unified skills monorepo for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first, with some TypeScript helper scripts and tests (e.g., `core/research/`). Skills are distributed to agent harnesses via symlinks.
 
-**63 core skills** (universal engineering) + **4 domain packs** (20 skills, loaded per-project) + **5 repo-local** (live in their own repos).
+**64 core skills** (universal engineering) + **4 domain packs** (20 skills, loaded per-project) + **5 repo-local** (live in their own repos).
 
 ## Repo Structure
 
 ```
 agent-skills/
-├── core/           # 63 universal skills, synced to ~/.claude/skills/
+├── core/           # 64 universal skills, synced to ~/.claude/skills/
 │   ├── groom/
 │   ├── autopilot/
 │   ├── build/
@@ -103,7 +103,7 @@ Claude Code has a ~16K char description budget. Skills consume budget based on m
 | Reference | `user-invocable: false` | Auto-loaded by model | **Consumes budget** |
 | DMI | `disable-model-invocation: true` | User via `/command` | **Free** |
 
-Current split: ~36 budget-consuming + ~27 DMI = ~63 core total. Well within 16K.
+Current split: ~36 budget-consuming + ~28 DMI = ~64 core total. Well within 16K.
 Pack skills (20) don't consume budget — they're loaded per-project only when needed.
 
 ## Core Delivery Pipeline
@@ -112,7 +112,7 @@ Pack skills (20) don't consume budget — they're loaded per-project only when n
 /groom → /shape → /autopilot → /pr-fix → /pr-polish → merge
 ```
 
-`/autopilot` chains shape → build → pr with commit/PR behavior inlined.
+`/autopilot` chains shape → build → walkthrough → pr with commit/PR behavior inlined.
 
 ## Unified Audit / Fix / Log
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-63 core skills + 4 domain packs for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
+64 core skills + 4 domain packs for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
 
 Skills are Markdown-first with a handful of Python helper scripts. No application code, no dependencies. They teach agents *how to work*: debugging methodology, PR workflows, design systems, incident response, and dozens of domain-specific playbooks.
 
@@ -12,7 +12,7 @@ AI agents are only as good as their instructions. Generic prompts produce generi
 
 | Tier | Location | Distribution | Budget cost |
 |------|----------|-------------|-------------|
-| **Core** (63) | `core/` | `sync.sh claude` → global | Per-mode |
+| **Core** (64) | `core/` | `sync.sh claude` → global | Per-mode |
 | **Pack** (20) | `packs/` | `sync.sh pack <name> <project>` → per-project | Per-mode |
 | **Repo-local** (5) | `<repo>/.claude/skills/` | Lives in destination repo | Per-mode |
 
@@ -73,6 +73,7 @@ starter rows with repo-specific subsystem docs and routing rules.
 | `/autopilot` | Model+User | Autonomous delivery: shape → build → commit → PR |
 | `/build` | Model+User | Implementation with TDD workflow |
 | `/commit` | DMI | Semantic commits with quality gates |
+| `/pr-walkthrough` | DMI | Mandatory walkthrough package: script, artifact, evidence, persistent check |
 | `/pr` | DMI | PR creation with mandatory sections |
 | `/pr-fix` | Model+User | Unblock PRs: conflicts, CI, review feedback, refactoring |
 | `/pr-polish` | Model+User | Hindsight review and quality elevation |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ starter rows with repo-specific subsystem docs and routing rules.
 |-------|------|-------------|
 | `/groom` | DMI | Backlog grooming, health checks, hygiene |
 | `/shape` | DMI | Product + technical planning (absorbs spec, architect, brainstorming) |
-| `/autopilot` | Model+User | Autonomous delivery: shape → build → commit → PR |
+| `/autopilot` | Model+User | Autonomous delivery: shape → build → walkthrough → commit → PR |
 | `/build` | Model+User | Implementation with TDD workflow |
 | `/commit` | DMI | Semantic commits with quality gates |
 | `/pr-walkthrough` | DMI | Mandatory walkthrough package: script, artifact, evidence, persistent check |

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -18,8 +18,8 @@ Engineering lead running a sprint. Find work, ensure it's ready, delegate implem
 
 ## Objective
 
-Deliver Issue `$ARGUMENTS` (or highest-priority eligible open issue) as a draft PR with tests passing
-and a clean dogfood QA pass.
+Deliver Issue `$ARGUMENTS` (or highest-priority eligible open issue) as a draft PR with tests passing,
+a clean dogfood QA pass, and a walkthrough artifact that makes the merge case legible.
 
 ## Latitude
 
@@ -104,33 +104,23 @@ The point is single ownership. One issue should map to one active autopilot lane
     - Optional accelerator: use an `ousterhout` persona/agent if the harness provides one
 11. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
    Iterate until no P0/P1 issues remain. **Do not open a PR until QA passes.**
-12. **Commit** — Create semantic commits for all remaining changes:
+12. **Walkthrough** — Run `/pr-walkthrough` and produce the mandatory walkthrough package for the branch. Every PR needs an artifact, even if the change is internal or architectural.
+13. **Commit** — Create semantic commits for all remaining changes:
     - Categorize files: commit, gitignore, delete, consolidate
     - Group into logical commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
     - Subject: imperative, lowercase, no period, ~50 chars. Body: why not what.
     - Run quality gates (`lint`, `typecheck`, `test`) before pushing
     - `git fetch origin && git push origin HEAD` (rebase if behind)
     - Never force push. Never push to main without confirmation.
-13. **Ship** — Open a draft PR:
+14. **Ship** — Open a draft PR:
     - Stage and commit any uncommitted changes with semantic message
     - Read linked issue from branch name or recent commits
-    - Load `../pr/references/pr-body-template.md` and mirror it
-    - PR body must contain all sections:
-      - **Why This Matters**: Problem, value added, why now, issue link. This is top-of-line.
-      - **Trade-offs / Risks**: Costs accepted, remaining concerns, why the trade is worthwhile.
-      - **Intent Reference**: Copy/paste issue intent contract summary + link to source issue section.
-      - **Changes**: Concise list of what was done. Key files/functions.
-      - **Alternatives Considered**: Do nothing, credible alternative(s), and why current approach won.
-      - **Acceptance Criteria**: From linked issue. Checkboxes.
-      - **Manual QA**: Step-by-step verification. Commands, expected output.
-      - **What Changed**: Mermaid flow chart for base branch, Mermaid flow chart for this PR, and a third Mermaid architecture/state/sequence diagram, plus explanation of why the new shape is better.
-      - **Before / After**: Text description mandatory. Screenshots for UI changes. Use `<details>` for heavy evidence.
-      - **Test Coverage**: Specific test files/functions. Note gaps.
-      - **Merge Confidence**: Confidence level, strongest evidence, residual risk.
-    - Keep deep sections under `<details>` where useful, but do not hide the topline significance/trade-off story
+    - Load `../pr/references/pr-body-template.md` and follow it
+    - PR body must include: `Why This Matters`, `Trade-offs / Risks`, `What Changed`, `Changes`, `Intent Reference`, `Alternatives Considered`, `Acceptance Criteria`, `Manual QA`, `Walkthrough`, `Before / After`, `Test Coverage`, and `Merge Confidence`
+    - The `Walkthrough` section must link the artifact and name the persistent verification that protects the demonstrated path
     - `gh pr create --draft --assignee phrazzld`
     - Add context comment if notable decisions were made
-14. **Retro** — Ensure `.groom/retro.md` exists first; initialize it with a minimal heading/template if missing. Then append implementation signals:
+15. **Retro** — Ensure `.groom/retro.md` exists first; initialize it with a minimal heading/template if missing. Then append implementation signals:
     ```
     mkdir -p .groom
     [ -f .groom/retro.md ] || cat > .groom/retro.md <<'EOF'
@@ -226,7 +216,7 @@ NOT stopping conditions: lacks description, seems big, unclear approach.
 
 ## Output
 
-Report: issue worked, spec status, design status, TDD evidence (RED/GREEN), commits made, dogfood QA summary (issues found/fixed), PR URL.
+Report: issue worked, spec status, design status, TDD evidence (RED/GREEN), dogfood QA summary (issues found/fixed), walkthrough artifact summary, commits made, PR URL.
 
 ## Review Cadence
 

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -116,7 +116,6 @@ The point is single ownership. One issue should map to one active autopilot lane
     - Stage and commit any uncommitted changes with semantic message
     - Read linked issue from branch name or recent commits
     - Load `../pr/references/pr-body-template.md` and follow it
-    - PR body must include: `Why This Matters`, `Trade-offs / Risks`, `What Changed`, `Changes`, `Intent Reference`, `Alternatives Considered`, `Acceptance Criteria`, `Manual QA`, `Walkthrough`, `Before / After`, `Test Coverage`, and `Merge Confidence`
     - The `Walkthrough` section must link the artifact and name the persistent verification that protects the demonstrated path
     - `gh pr create --draft --assignee phrazzld`
     - Add context comment if notable decisions were made

--- a/core/pr-fix/SKILL.md
+++ b/core/pr-fix/SKILL.md
@@ -260,9 +260,10 @@ If fixes touch UI or user behavior (`app/`, `components/`, styles, route handler
 
 `/dogfood` is a skill command, not a shell binary probe.
 
-### 7. Update PR Description with Before / After
+### 7. Update PR Description with Before / After + Walkthrough
 
-Edit the PR body to preserve the richer `/pr` structure and update the relevant sections documenting the fix:
+Edit the PR body to preserve the richer `/pr` structure and update the relevant sections documenting the fix.
+Refresh the `## Walkthrough` section too when the fix changes the merge case, evidence, or protecting check:
 
 ```bash
 # Get current body, refresh the affected sections
@@ -283,6 +284,14 @@ Example: "Before: CI failing on type error in auth module. After: Types correcte
 **Screenshots (when applicable)**: Capture before/after for any visible change — CI status pages, error output, UI changes from review fixes. Use `![before](url)` / `![after](url)`.
 
 Skip screenshots only when all fixes are purely internal (conflict resolution with no behavior change, CI config fixes with no visible output difference).
+
+If the fixes materially change what reviewers should see, rerun `/pr-walkthrough` and update:
+
+- artifact link
+- claim proven
+- before/after scope
+- persistent verification
+- residual gap
 
 ### 8. Signal
 

--- a/core/pr-fix/SKILL.md
+++ b/core/pr-fix/SKILL.md
@@ -287,11 +287,11 @@ Skip screenshots only when all fixes are purely internal (conflict resolution wi
 
 If the fixes materially change what reviewers should see, rerun `/pr-walkthrough` and update:
 
-- artifact link
-- claim proven
-- before/after scope
-- persistent verification
-- residual gap
+- Artifact
+- Claim
+- Before / After scope
+- Persistent verification
+- Residual gap
 
 ### 8. Signal
 

--- a/core/pr-polish/SKILL.md
+++ b/core/pr-polish/SKILL.md
@@ -156,9 +156,10 @@ pnpm typecheck && pnpm lint && pnpm test
 All gates must pass. Fix anything that doesn't.
 If repo-wide gates are already red from unrelated debt, still add the strongest PR-scoped automated checks you can and record the residual gap.
 
-### 7. Update PR Description with Before / After
+### 7. Update PR Description with Before / After + Walkthrough
 
-Edit the PR body to preserve the richer `/pr` structure and update the sections affected by the polish pass:
+Edit the PR body to preserve the richer `/pr` structure and update the sections affected by the polish pass.
+Refresh the `## Walkthrough` section too if the polish changes the strongest merge evidence:
 
 ```bash
 gh pr edit $PR --body "$(updated body)"
@@ -178,6 +179,14 @@ Refresh:
 **Screenshots (when applicable)**: Capture before/after for any visible change — refactored UI output, improved error messages, updated docs pages. Use `![before](url)` / `![after](url)`.
 
 Skip screenshots only when all polish was purely internal (refactoring with no visible output change).
+
+If polish changes the story reviewers should trust, rerun `/pr-walkthrough` and update:
+
+- artifact link
+- claim proven
+- before/after scope
+- persistent verification
+- residual gap
 
 ### 7.5 Diagram Audit
 

--- a/core/pr-polish/SKILL.md
+++ b/core/pr-polish/SKILL.md
@@ -182,11 +182,11 @@ Skip screenshots only when all polish was purely internal (refactoring with no v
 
 If polish changes the story reviewers should trust, rerun `/pr-walkthrough` and update:
 
-- artifact link
-- claim proven
-- before/after scope
-- persistent verification
-- residual gap
+- Artifact
+- Claim
+- Before / After scope
+- Persistent verification
+- Residual gap
 
 ### 7.5 Diagram Audit
 

--- a/core/pr-walkthrough/SKILL.md
+++ b/core/pr-walkthrough/SKILL.md
@@ -54,32 +54,14 @@ Do not script from the diff alone. The walkthrough must explain significance, no
 
 ### 2. Pick the renderer
 
-Use the renderer that best matches the change surface:
-
-| Change type | Primary renderer |
-|-------------|------------------|
-| UI, product flow, interaction | Browser walkthrough |
-| CLI, API, backend behavior | Terminal walkthrough with commands and outputs |
-| Infra, CI, architecture, refactor | Diagram-led walkthrough with command evidence |
-| Cross-cutting or stakeholder-facing change | Remotion walkthrough with narration |
-
-If multiple surfaces matter, use a mixed walkthrough. If a polished Remotion cut adds value, generate it after the deterministic evidence pass.
+Use the renderer selection in `references/walkthrough-contract.md`.
+If multiple surfaces matter, use a mixed walkthrough.
+If a polished Remotion cut adds value, treat it as a non-blocking pass after the deterministic evidence flow is already strong.
 
 ### 3. Write the walkthrough spec
 
 Use the contract in `references/walkthrough-contract.md`.
-
-At minimum, script these beats:
-
-1. Title and merge claim
-2. Why this work exists now
-3. Before state
-4. Change summary
-5. After state
-6. Verification evidence
-7. Residual risk
-8. Merge recommendation
-
+Use its default script beats as the canonical sequence.
 Every scene must map to observable evidence.
 
 ### 4. Capture evidence first

--- a/core/pr-walkthrough/SKILL.md
+++ b/core/pr-walkthrough/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: pr-walkthrough
+description: |
+  Create the mandatory walkthrough package for a pull request. Designs the script,
+  chooses the renderer (browser, terminal, diagram, or Remotion), captures before/after
+  evidence, and links one persistent verification check to the story being told.
+  Use when: opening a PR, preparing reviewer evidence, recording a demo, or proving why
+  a branch should merge. Keywords: walkthrough, demo video, QA walkthrough, before/after,
+  reviewer evidence, PR artifact.
+disable-model-invocation: true
+argument-hint: "[PR-number-or-branch]"
+---
+
+# /pr-walkthrough
+
+Generate the truth artifact for a PR.
+
+## Objective
+
+For every PR, produce one walkthrough package:
+
+- walkthrough spec
+- walkthrough artifact
+- evidence bundle
+- persistent verification link
+
+The walkthrough is mandatory for all PRs. The renderer changes by PR type. The contract does not.
+
+## Deliverables
+
+Every run must leave behind:
+
+1. A script that explains:
+   - what was wrong or missing before
+   - what changed on this branch
+   - what is true after
+   - why the change matters
+   - what test now protects it
+2. A primary artifact:
+   - browser recording
+   - terminal walkthrough
+   - Remotion-rendered narrated video
+   - mixed media walkthrough
+3. Evidence references for each major claim
+4. A PR body `## Walkthrough` section linking the artifact and the protecting check
+
+## Workflow
+
+### 1. Read the merge case
+
+Read the issue, diff, draft PR body, changed tests, and current QA evidence.
+
+Do not script from the diff alone. The walkthrough must explain significance, not just motion.
+
+### 2. Pick the renderer
+
+Use the renderer that best matches the change surface:
+
+| Change type | Primary renderer |
+|-------------|------------------|
+| UI, product flow, interaction | Browser walkthrough |
+| CLI, API, backend behavior | Terminal walkthrough with commands and outputs |
+| Infra, CI, architecture, refactor | Diagram-led walkthrough with command evidence |
+| Cross-cutting or stakeholder-facing change | Remotion walkthrough with narration |
+
+If multiple surfaces matter, use a mixed walkthrough. If a polished Remotion cut adds value, generate it after the deterministic evidence pass.
+
+### 3. Write the walkthrough spec
+
+Use the contract in `references/walkthrough-contract.md`.
+
+At minimum, script these beats:
+
+1. Title and merge claim
+2. Why this work exists now
+3. Before state
+4. Change summary
+5. After state
+6. Verification evidence
+7. Residual risk
+8. Merge recommendation
+
+Every scene must map to observable evidence.
+
+### 4. Capture evidence first
+
+Before recording the final walkthrough:
+
+- collect before/after screenshots, clips, command output, or diagrams
+- capture the happy path
+- capture one key edge, failure, or invariant when it materially affects confidence
+- identify the single automated check that best protects this change
+
+The walkthrough artifact is not enough on its own. The evidence must stand on its own if the video is skipped.
+
+### 5. Produce the artifact
+
+Preferred order:
+
+1. deterministic browser or terminal walkthrough
+2. optional polished Remotion cut with narration or music
+
+Never block a PR on a cinematic pass if the deterministic walkthrough is already strong and truthful.
+
+### 6. Tie it to persistent verification
+
+Every walkthrough must name the test, smoke check, or CI job that now protects the path it demonstrates.
+
+If no durable automated check exists:
+
+- add one when feasible
+- otherwise call out the gap explicitly and make fixing it the next quality task
+
+### 7. Update the PR body
+
+Add a `## Walkthrough` section that includes:
+
+- renderer used
+- artifact link
+- core claim the walkthrough proves
+- before/after scope covered
+- persistent check protecting the path
+- residual gap, if any
+
+## Rules
+
+- All PRs get a walkthrough. No exceptions.
+- The artifact must strengthen reviewer confidence, not just advertise polish.
+- Prefer deterministic evidence over high-production ambiguity.
+- Remotion is encouraged for high-value communication, not as a substitute for proof.
+- If the PR changes nothing user-visible, narrate invariants, architecture, and verification instead.
+
+## References
+
+- `references/walkthrough-contract.md` - renderer selection, script rubric, and PR section template

--- a/core/pr-walkthrough/references/walkthrough-contract.md
+++ b/core/pr-walkthrough/references/walkthrough-contract.md
@@ -1,0 +1,94 @@
+# Walkthrough Contract
+
+Every PR needs one walkthrough package that answers five questions:
+
+1. What was wrong, missing, risky, or expensive before this branch?
+2. What changed?
+3. What is observably better or safer now?
+4. What evidence proves that claim?
+5. What persistent check protects the path going forward?
+
+## Evaluation Rubric
+
+Judge every walkthrough against this rubric:
+
+| Dimension | Question |
+|-----------|----------|
+| Significance | Does it explain why the change matters now? |
+| Baseline | Does it show the real before state instead of hand-waving it? |
+| Delta | Does it make the branch delta legible? |
+| Proof | Does each major claim map to evidence? |
+| Protection | Does it link the story to a durable automated check? |
+| Residual risk | Does it say what is still not proven? |
+
+## Renderer Selection
+
+| Situation | Best format | Evidence to include |
+|-----------|-------------|---------------------|
+| Frontend UX or workflow | Browser recording | before/after screenshots, happy path, one key edge case |
+| CLI or developer workflow | Terminal walkthrough | commands, expected output, before/after behavior |
+| Backend or API change | Terminal plus diagrams | request/response traces, data/state change, regression test |
+| Infra, CI, architecture, refactor | Diagram-led walkthrough | old vs new flow, invariants preserved, proof commands |
+| Broad launch or stakeholder update | Remotion video | narration, diagrams, screenshots, optional music/voiceover |
+
+Use mixed media when one renderer is insufficient.
+
+## Default Script
+
+Use this script unless the PR needs a stronger variant:
+
+1. **Title**
+   The PR name and one-sentence merge claim.
+2. **Why now**
+   The pain, risk, or opportunity that justified the work.
+3. **Before**
+   Show the old behavior, system state, or workflow.
+4. **What changed**
+   Summarize the key branch delta in human terms.
+5. **After**
+   Show the new behavior, system state, or workflow.
+6. **Verification**
+   Run or cite the automated check that protects this path.
+7. **Residual risk**
+   State what remains unproven or intentionally deferred.
+8. **Merge case**
+   Close with why shipping this branch is worth it.
+
+## Evidence Mapping
+
+For each scene, capture at least one of:
+
+- screenshot
+- browser clip
+- command output
+- test result
+- diagram
+- data diff
+
+If a scene has no evidence, cut or rewrite the claim.
+
+## PR Body Template
+
+Every PR should include a section like this:
+
+```md
+## Walkthrough
+
+- Renderer: Browser walkthrough | Terminal walkthrough | Remotion walkthrough | Mixed
+- Artifact: [link to video or walkthrough bundle]
+- Claim: [the single sentence this walkthrough proves]
+- Before / After scope: [what surfaces are covered]
+- Persistent verification: `[exact test, smoke check, or CI job]`
+- Residual gap: [what still is not automated or not shown]
+```
+
+## Persistent Check Rule
+
+The walkthrough should produce or reinforce one durable protection:
+
+- E2E test for user flow changes
+- integration or contract test for API/backend changes
+- smoke test or CI assertion for infra/tooling changes
+- regression test for bug fixes
+
+If the walkthrough reveals a path that matters and nothing protects it, that is a quality finding.

--- a/core/pr/SKILL.md
+++ b/core/pr/SKILL.md
@@ -33,64 +33,7 @@ Create a draft PR from current branch. Link to issue, make the significance obvi
 ## PR Body Requirements (MANDATORY)
 
 Every PR body must follow [references/pr-body-template.md](./references/pr-body-template.md).
-A PR missing these sections is not ready.
-
-```
-## Why This Matters
-Top-line significance first:
-- what problem existed
-- what value this adds
-- why this is worth doing now
-- link to issue
-
-## Trade-offs / Risks
-State the value gained, the costs/risks incurred, and why the trade is still worth it.
-
-## What Changed
-Show the delta, not just the end state:
-- Mermaid flow chart for the base branch
-- Mermaid flow chart for this PR
-- Mermaid architecture/state/sequence diagram for the deeper structural change
-- Short explanation of why this is an improvement
-
-## Changes
-Concise mechanical summary. Reference key files/functions.
-
-## Intent Reference
-Link to the issue/spec/intent contract that justifies the work.
-
-## Alternatives Considered
-At minimum: do nothing, one credible alternate approach, and why the chosen approach won.
-
-## Acceptance Criteria
-Copied or derived from the linked issue. Checkboxes.
-
-## Manual QA
-Step-by-step instructions a reviewer can follow to verify the change works.
-Include: setup steps, exact commands, expected output, URLs to visit.
-
-## Walkthrough
-Link the walkthrough package for this PR.
-Include: renderer used, artifact link, core claim proven, before/after scope covered,
-the persistent verification check that now protects this path, and any residual gap.
-
-## Before / After
-Show the state before and after this PR. MANDATORY for every PR.
-
-**Text**: Describe the previous behavior/state and the new behavior/state.
-**Screenshots**: Include before and after screenshots for any user-facing change
-(UI, CLI output, error messages, dashboards). Use `![before](url)` / `![after](url)`.
-
-Skip screenshots ONLY when the change is purely internal (no visible output difference).
-When in doubt, screenshot.
-
-## Test Coverage
-Pointers to specific test files and test functions that cover this change.
-Note any gaps: what ISN'T tested and why.
-
-## Merge Confidence
-State confidence level, strongest evidence, and residual risk.
-```
+A PR missing template sections is not ready.
 
 Use `<details>/<summary>` to collapse larger sections such as Alternatives,
 Manual QA, Acceptance Criteria, Test Coverage, Walkthrough evidence, and screenshot-heavy Before / After evidence.
@@ -118,7 +61,7 @@ Keep `Why This Matters`, `Trade-offs / Risks`, and the opening `What Changed` ex
 9. **Open / Update** — Use `gh pr create --draft --assignee phrazzld --body-file <path>` for new PRs. Use `gh pr edit --body-file <path>` when the branch already has a PR.
 10. **Comment** — Add context comment if notable decisions were made, and use `--body-file` for comment bodies.
 11. **Retro** — If this PR closes a GitHub issue, append implementation feedback:
-  ```
+   ```bash
   /retro append --issue $ISSUE --predicted {effort_label} --actual {actual_effort} \
      --scope "{what_changed_from_spec}" --blocker "{blockers}" --pattern "{insight}"
    ```

--- a/core/pr/SKILL.md
+++ b/core/pr/SKILL.md
@@ -18,15 +18,17 @@ Engineer shipping clean, well-documented PRs.
 
 ## Objective
 
-Create a draft PR from current branch. Link to issue, make the significance obvious, and give reviewers the value/trade-off context they need at a glance.
+Create a draft PR from current branch. Link to issue, make the significance obvious, give reviewers the value/trade-off context they need at a glance, and attach the walkthrough package that proves the merge case.
 
 ## Latitude
 
 - Stage and commit any uncommitted changes with semantic message
 - Read linked issue from branch name or recent commits
 - Write PR body that explains significance, value, trade-offs, and alternatives, not just changes
+- Run `/pr-walkthrough` and treat its output as required PR evidence
 - `dogfood`, `agent-browser`, and `browser-use` are available here; use them for flow QA evidence
 - Load [references/pr-body-template.md](./references/pr-body-template.md) before writing the PR body
+- Treat an existing PR for the same branch or issue as the lane to update, not a reason to create another PR
 
 ## PR Body Requirements (MANDATORY)
 
@@ -67,6 +69,11 @@ Copied or derived from the linked issue. Checkboxes.
 Step-by-step instructions a reviewer can follow to verify the change works.
 Include: setup steps, exact commands, expected output, URLs to visit.
 
+## Walkthrough
+Link the walkthrough package for this PR.
+Include: renderer used, artifact link, core claim proven, before/after scope covered,
+the persistent verification check that now protects this path, and any residual gap.
+
 ## Before / After
 Show the state before and after this PR. MANDATORY for every PR.
 
@@ -86,25 +93,33 @@ State confidence level, strongest evidence, and residual risk.
 ```
 
 Use `<details>/<summary>` to collapse larger sections such as Alternatives,
-Manual QA, Acceptance Criteria, Test Coverage, and screenshot-heavy Before / After evidence.
+Manual QA, Acceptance Criteria, Test Coverage, Walkthrough evidence, and screenshot-heavy Before / After evidence.
 Keep `Why This Matters`, `Trade-offs / Risks`, and the opening `What Changed` explanation visible.
 
 ## Workflow
 
-1. **Clean** — Commit any uncommitted changes with semantic message
-2. **Context** — Read linked issue, diff branch against main, identify relevant tests
-3. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa`. Fix any P0/P1 issues before opening PR. Capture screenshots for Before/After section.
-4. **Dogfood QA** — Run `/dogfood http://localhost:3000` (start dev server first if not running).
+1. **Duplicate PR Gate** — Before writing anything to GitHub:
+   - Detect the linked issue from branch name, commit messages, or diff context
+   - Preferred: run `python3 scripts/issue_lane.py --repo <owner/name> --issue <N>` when the repo provides it
+   - Check for an existing PR from the current branch
+   - Check for other open PRs already referencing the same issue number
+   - If the current branch already has a PR, update it with `gh pr edit` instead of creating a new one
+   - If another branch already has an open PR for the same issue, stop and surface the duplicate lane unless you are explicitly superseding it
+2. **Clean** — Commit any uncommitted changes with semantic message
+3. **Context** — Read linked issue, diff branch against main, identify relevant tests
+4. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa`. Fix any P0/P1 issues before opening PR. Capture screenshots for Before/After section.
+5. **Dogfood QA** — Run `/dogfood http://localhost:3000` (start dev server first if not running).
    `/dogfood` is a skill command (not a PATH CLI check). Use `agent-browser` / `browser-use` for focused repro as needed.
    Fix all P0/P1 issues found. Iterate until clean. **Do not open a PR until this passes.**
    Include dogfood summary (issues found, fixed) in PR body under Manual QA section.
-5. **Describe** — Title from issue, body follows [references/pr-body-template.md](./references/pr-body-template.md). Lead with significance/value/trade-offs, not the diff recap.
-6. **Before/After** — Use screenshots from visual QA + dogfood steps. For non-UI changes, describe behavioral difference in text. If the PR body gets long, move heavy evidence into `<details>`.
-7. **Open** — `gh pr create --draft --assignee phrazzld`
-8. **Comment** — Add context comment if notable decisions were made
-9. **Retro** — If this PR closes a GitHub issue, append implementation feedback:
-   ```
-   /retro append --issue $ISSUE --predicted {effort_label} --actual {actual_effort} \
+6. **Walkthrough** — Run `/pr-walkthrough`. Every PR needs a walkthrough package, even when the change is not user-facing. Use browser, terminal, diagram, Remotion, or mixed media as appropriate.
+7. **Describe** — Title from issue, body follows [references/pr-body-template.md](./references/pr-body-template.md). Lead with significance/value/trade-offs, not the diff recap.
+8. **Before/After** — Use screenshots or evidence from visual QA, dogfood, and `/pr-walkthrough`. For non-UI changes, describe behavioral or architectural difference in text. If the PR body gets long, move heavy evidence into `<details>`.
+9. **Open / Update** — Use `gh pr create --draft --assignee phrazzld --body-file <path>` for new PRs. Use `gh pr edit --body-file <path>` when the branch already has a PR.
+10. **Comment** — Add context comment if notable decisions were made, and use `--body-file` for comment bodies.
+11. **Retro** — If this PR closes a GitHub issue, append implementation feedback:
+  ```
+  /retro append --issue $ISSUE --predicted {effort_label} --actual {actual_effort} \
      --scope "{what_changed_from_spec}" --blocker "{blockers}" --pattern "{insight}"
    ```
    This feeds the grooming feedback loop — `/groom` reads retro.md to calibrate

--- a/core/pr/references/pr-body-template.md
+++ b/core/pr/references/pr-body-template.md
@@ -14,7 +14,7 @@ Use this structure when creating or heavily rewriting a PR description.
 
 These sections should stay visible on first load:
 
-```md
+````markdown
 ## Why This Matters
 - Problem:
 - Value:
@@ -51,7 +51,7 @@ graph TD
 Why this is better:
 - ...
 - ...
-```
+````
 
 ## Visibility Toggles
 
@@ -156,14 +156,23 @@ Exact commands, URLs, setup, expected output. Keep long logs or screenshots unde
 
 This is the proof package for the PR.
 
-- Renderer used
-- Artifact link
-- Core claim proven
-- Before / after scope covered
-- Persistent verification that protects this path
-- Residual gap, if any
+- Renderer
+- Artifact
+- Claim
+- Before / After scope
+- Persistent verification
+- Residual gap
 
 For the script and rubric, load `../../pr-walkthrough/references/walkthrough-contract.md`.
+
+### `## Before / After`
+
+Show the previous state and the new state explicitly.
+
+- Text is mandatory for every PR
+- Screenshots are mandatory for user-visible changes
+- For internal-only changes, explain why screenshots are not needed
+
 ### `## Test Coverage`
 
 Point to exact test files or suites. Call out gaps plainly.

--- a/core/pr/references/pr-body-template.md
+++ b/core/pr/references/pr-body-template.md
@@ -7,6 +7,7 @@ Use this structure when creating or heavily rewriting a PR description.
 - Lead with significance, not mechanics.
 - Explain value added, trade-offs accepted, and why those trade-offs are worth it.
 - Make the diff legible with before/after diagrams, not a single abstract chart.
+- Make the walkthrough artifact part of the merge case, not an afterthought.
 - Keep the top of the PR skimmable; push heavier detail into `<details>` blocks.
 
 ## Top-Level Shape
@@ -61,6 +62,7 @@ Use `<details>` for sections that are valuable but not needed at first glance:
 - `Acceptance Criteria`
 - `Alternatives Considered`
 - `Manual QA`
+- `Walkthrough`
 - `Test Coverage`
 - `Merge Confidence`
 - `Screenshots / before-after evidence`
@@ -150,6 +152,18 @@ Copy or derive from the issue. Use checkboxes.
 
 Exact commands, URLs, setup, expected output. Keep long logs or screenshots under `<details>`.
 
+### `## Walkthrough`
+
+This is the proof package for the PR.
+
+- Renderer used
+- Artifact link
+- Core claim proven
+- Before / after scope covered
+- Persistent verification that protects this path
+- Residual gap, if any
+
+For the script and rubric, load `../../pr-walkthrough/references/walkthrough-contract.md`.
 ### `## Test Coverage`
 
 Point to exact test files or suites. Call out gaps plainly.
@@ -183,3 +197,4 @@ For Mermaid syntax examples and GitHub rendering constraints, load
 - Do not use a single diagram when before/after comparison is the actual point.
 - Do not force screenshots for purely internal changes, but do provide text before/after.
 - Do use `<details>` to keep the PR readable when sections get long.
+- Do make the walkthrough point to one durable automated check, not just a polished artifact.


### PR DESCRIPTION
## Why This Matters
- Problem: the repo described strong PR hygiene, but it did not require a proof-backed walkthrough artifact or a canonical PR body template that made merge significance legible.
- Value: this branch turns walkthroughs into first-class PR evidence, so reviewers get before/after context, an explicit merge claim, and a linked protecting check instead of just a diff summary.
- Why now: the workflow discussion on this branch argued that every PR should ship with a walkthrough, even for internal or docs-heavy changes.
- Issue: no linked GitHub issue; this PR implements the branch discussion directly.

## Trade-offs / Risks
- Value gained: more consistent reviewer context, stronger merge narratives, and a reusable walkthrough primitive that other PR skills can compose.
- Cost / risk incurred: the PR workflow becomes more prescriptive, PR bodies get longer, and internal changes still require judgment about the lightest valid walkthrough format.
- Why this is still the right trade: the overhead is documentation-level, while the payoff is clearer review quality and better proof of significance.
- Reviewer watch-outs: the repo still lacks CI enforcement for the new PR body contract, so adoption depends on skill compliance for now.

## What Changed
This PR adds a dedicated walkthrough skill, gives `/pr` a canonical in-repo body template with a required `Walkthrough` section, and updates the rest of the PR lifecycle skills so the walkthrough survives follow-on fixes and polishing.

### Base Branch
```mermaid
graph TD
  A["Branch changes"] --> B["/pr"]
  B --> C["Summary + manual QA + before/after"]
  C --> D["Reviewer infers significance from prose and diff"]
```

### This PR
```mermaid
graph TD
  A["Branch changes"] --> B["/pr-walkthrough"]
  B --> C["Renderer + script + evidence + protecting check"]
  C --> D["/pr with canonical template"]
  D --> E["Walkthrough section + before/after + merge confidence"]
  E --> F["Reviewer gets explicit merge case and proof"]
```

### Architecture / State Change
```mermaid
graph TD
  PR["/pr"] --> TEMPLATE["pr-body-template.md"]
  PR --> WALK["/pr-walkthrough"]
  WALK --> CONTRACT["walkthrough-contract.md"]
  AUTO["/autopilot"] --> TEMPLATE
  FIX["/pr-fix"] --> PR
  POLISH["/pr-polish"] --> PR
```

Why this is better:
- It gives the PR workflow one reusable walkthrough primitive instead of scattering ad hoc expectations across multiple skills.
- It teaches the update skills to preserve the walkthrough story instead of letting it rot after fixes or polish.

<details>
<summary>Changes</summary>

## Changes
- Added `core/pr-walkthrough/SKILL.md` to define the walkthrough package workflow.
- Added `core/pr-walkthrough/references/walkthrough-contract.md` to define renderer selection, script beats, evidence rules, and the protecting-check requirement.
- Added `core/pr/references/pr-body-template.md` as the canonical PR body structure.
- Updated `core/pr/SKILL.md` to require `/pr-walkthrough` and a `## Walkthrough` section.
- Updated `core/autopilot/SKILL.md` so its inlined PR flow follows the same template.
- Updated `core/pr-fix/SKILL.md` and `core/pr-polish/SKILL.md` so walkthrough metadata gets refreshed when the PR story changes.
- Tightened the docs after hindsight review by making `pr-body-template.md` the single source of truth for section shape instead of repeating that contract in multiple skills.
- Fixed the canonical template example so nested code fences render correctly and added the missing canonical `## Before / After` section.
- Aligned walkthrough field names in `/pr-fix` and `/pr-polish` with the contract and marked cinematic Remotion output as non-blocking polish rather than gate-critical behavior.
- Updated `README.md` and `CLAUDE.md` to list the new skill and the new core count.

</details>

<details>
<summary>Intent Reference</summary>

## Intent Reference
Intent for this branch:
- add a dedicated walkthrough skill
- require `/pr` to use it
- make walkthroughs mandatory PR evidence for all change types
- keep follow-on PR workflows in sync with that contract

This intent came from the branch discussion rather than a pre-existing GitHub issue.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered

### Option A — Do nothing
- Upside: zero process overhead
- Downside: PRs keep relying on inconsistent prose and ad hoc reviewer interpretation
- Why rejected: it leaves the core problem unchanged

### Option B — Inline walkthrough logic only inside `/pr`
- Upside: fewer files and no new skill
- Downside: other PR lifecycle skills still drift, and the walkthrough logic becomes harder to reuse or evolve
- Why rejected: it duplicates responsibility instead of composing a primitive

### Option C — Add `/pr-walkthrough` and make `/pr` call it
- Upside: one reusable walkthrough contract, shared template, clearer composition
- Downside: one more skill in the repo and a slightly larger PR body contract
- Why chosen: it keeps the logic modular and makes the new behavior explicit

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] A dedicated walkthrough skill exists for PR artifacts
- [x] `/pr` requires a walkthrough section and points to a canonical template
- [x] `/autopilot`, `/pr-fix`, and `/pr-polish` preserve the walkthrough contract
- [x] Repo indexes mention the new skill and updated counts

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
Run from the repo root:

```bash
python3 core/skill-builder/scripts/validate_skill.py core/pr
python3 core/skill-builder/scripts/validate_skill.py core/pr-walkthrough
python3 core/skill-builder/scripts/validate_skill.py core/autopilot
python3 core/skill-builder/scripts/validate_skill.py core/pr-fix
python3 core/skill-builder/scripts/validate_skill.py core/pr-polish
```

Then inspect the changed docs:

```bash
git diff --stat origin/master...HEAD
git diff origin/master...HEAD -- core/pr/SKILL.md core/pr-walkthrough/SKILL.md core/pr/references/pr-body-template.md core/autopilot/SKILL.md core/pr-fix/SKILL.md core/pr-polish/SKILL.md
```

Expected result:
- all five skill validations return `valid: true`
- `/pr` references the canonical template
- the template includes `Walkthrough`
- the template includes `Before / After`
- the follow-on PR skills preserve the walkthrough update path

Repository note:
- this repo has no `package.json`, so skill validation is the real quality gate for this pass rather than `pnpm` scripts

</details>

## Walkthrough
- Renderer: Diagram-led walkthrough
- Artifact: https://gist.github.com/phrazzld/a3879da362ab45a5c37337a53f0dc5eb
- Claim: this PR makes proof-backed walkthroughs a first-class required part of PR creation and PR maintenance flows
- Before / After scope: `/pr`, `/autopilot`, `/pr-fix`, `/pr-polish`, repo indexes, and the new walkthrough contract docs
- Persistent verification: `python3 core/skill-builder/scripts/validate_skill.py core/pr-walkthrough`
- Residual gap: there is still no CI gate that enforces live PR body conformance or end-to-end walkthrough generation

<details>
<summary>Before / After</summary>

## Before / After
Before:
- the repo had no dedicated walkthrough primitive
- `/pr` had no canonical in-repo template file
- follow-on PR skills did not explicitly preserve walkthrough evidence

After:
- `/pr-walkthrough` defines the walkthrough package
- `/pr` uses a canonical template with a required `Walkthrough` section
- `/pr-fix` and `/pr-polish` refresh walkthrough metadata when the merge story changes
- the canonical template now renders correctly and explicitly defines `## Before / After`

Screenshots:
- None. This is an internal docs/skill change with no UI surface.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `python3 core/skill-builder/scripts/validate_skill.py core/pr`
- `python3 core/skill-builder/scripts/validate_skill.py core/pr-walkthrough`
- `python3 core/skill-builder/scripts/validate_skill.py core/autopilot`
- `python3 core/skill-builder/scripts/validate_skill.py core/pr-fix`
- `python3 core/skill-builder/scripts/validate_skill.py core/pr-polish`

Coverage gap:
- no automated test currently exercises PR body generation against a live GitHub PR
- no CI guard currently asserts that the walkthrough section stays present

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence: medium-high
- Strongest evidence: docs-only diff, canonical template and walkthrough primitive are now the single public contracts, and all five touched skill directories validate cleanly
- Remaining uncertainty: the workflow semantics have not yet been exercised on a second real PR after this one
- What could still go wrong after merge: wording drift or partial adoption if future skills bypass the canonical template, and there is still no CI rule enforcing live PR body conformance

</details>
