### PR TITLE
chore: post-merge auto-sync + duplicate PR guard

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Auto-sync skills to all harnesses after pull/merge
+echo "[agent-skills] syncing skills to harnesses..."
+./scripts/sync.sh all --prune

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Auto-sync skills after rebase (covers git pull --rebase)
+[ "$1" = "rebase" ] || exit 0
+echo "[agent-skills] syncing skills to harnesses..."
+./scripts/sync.sh all --prune

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ without mutating tracked source.
 
 No build, lint, or test commands — this repo is documentation only.
 
-## Auto-Sync (post-merge hook)
+## Auto-Sync (git hooks)
 
-A `post-merge` git hook auto-runs `sync.sh all --prune` after every `git pull` / `git merge`, keeping all harness symlinks current.
+Git hooks auto-run `sync.sh all --prune` after pulls and merges, keeping all harness symlinks current. Covers both merge-based (`post-merge`) and rebase-based (`post-rewrite`) pulls.
 
 **New machine setup (one-time):**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,17 @@ without mutating tracked source.
 
 No build, lint, or test commands — this repo is documentation only.
 
+## Auto-Sync (post-merge hook)
+
+A `post-merge` git hook auto-runs `sync.sh all --prune` after every `git pull` / `git merge`, keeping all harness symlinks current.
+
+**New machine setup (one-time):**
+```bash
+git config core.hooksPath .githooks
+```
+
+Manual `sync.sh` is still needed for pack loading and explicit refresh.
+
 ## Skill Directory Convention
 
 Core skills live in `core/{skill-name}/`.

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -140,7 +140,7 @@ The point is single ownership. One issue should map to one active autopilot lane
       - **Merge Confidence**: Confidence level, strongest evidence, residual risk.
     - Keep deep sections under `<details>` where useful, but do not hide the topline significance/trade-off story
     - Use `--body-file` for `gh pr create`, `gh pr edit`, and PR comments
-    - `gh pr create --draft --assignee phrazzld`
+    - `gh pr create --draft --assignee phrazzld --body-file <path>`
     - Add context comment if notable decisions were made
 15. **Retro** — Ensure `.groom/retro.md` exists first; initialize it with a minimal heading/template if missing. Then append implementation signals:
     ```

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -21,6 +21,9 @@ Engineering lead running a sprint. Find work, ensure it's ready, delegate implem
 Deliver Issue `$ARGUMENTS` (or highest-priority eligible open issue) as a draft PR with tests passing,
 a clean dogfood QA pass, and a walkthrough artifact that makes the merge case legible.
 
+An open PR for that issue counts as the active delivery lane. Do not create a duplicate PR
+for the same issue unless you first surface and justify a superseding lane.
+
 ## Latitude
 
 - Codex writes first draft of everything (investigation, implementation, tests, docs)
@@ -75,6 +78,8 @@ The point is single ownership. One issue should map to one active autopilot lane
    - Auto-pick: choose the highest-priority open issue that is unassigned, not `In Progress`, and has no open PR or active autopilot lane
    - If there are no open issues, stop and report that the queue is empty
    - If open issues exist but none are eligible, stop and report that all open work is already claimed
+   - Preferred lane check: run `python3 scripts/issue_lane.py --repo <owner/name> --issue <N>` when the repo provides it
+   - Fallback: query open PRs with `gh pr list --state open --json number,title,body,headRefName,url`
 2. **Claim issue** —
    - Assign the issue to yourself
    - Ensure the issue is attached to the canonical delivery project
@@ -115,8 +120,26 @@ The point is single ownership. One issue should map to one active autopilot lane
 14. **Ship** — Open a draft PR:
     - Stage and commit any uncommitted changes with semantic message
     - Read linked issue from branch name or recent commits
+    - Re-run `python3 scripts/issue_lane.py --repo <owner/name> --issue <N>` immediately before opening the PR when available
+    - Otherwise re-run the in-flight gate immediately before opening the PR
+    - If an open PR already exists for the branch, use `gh pr edit`, not `gh pr create`
+    - If another open PR already exists for the same issue, stop and surface the duplication instead of creating a second lane
     - Load `../pr/references/pr-body-template.md` and follow it
     - The `Walkthrough` section must link the artifact and name the persistent verification that protects the demonstrated path
+    - PR body must contain all sections:
+      - **Why This Matters**: Problem, value added, why now, issue link. This is top-of-line.
+      - **Trade-offs / Risks**: Costs accepted, remaining concerns, why the trade is worthwhile.
+      - **Intent Reference**: Copy/paste issue intent contract summary + link to source issue section.
+      - **Changes**: Concise list of what was done. Key files/functions.
+      - **Alternatives Considered**: Do nothing, credible alternative(s), and why current approach won.
+      - **Acceptance Criteria**: From linked issue. Checkboxes.
+      - **Manual QA**: Step-by-step verification. Commands, expected output.
+      - **What Changed**: Mermaid flow chart for base branch, Mermaid flow chart for this PR, and a third Mermaid architecture/state/sequence diagram, plus explanation of why the new shape is better.
+      - **Before / After**: Text description mandatory. Screenshots for UI changes. Use `<details>` for heavy evidence.
+      - **Test Coverage**: Specific test files/functions. Note gaps.
+      - **Merge Confidence**: Confidence level, strongest evidence, residual risk.
+    - Keep deep sections under `<details>` where useful, but do not hide the topline significance/trade-off story
+    - Use `--body-file` for `gh pr create`, `gh pr edit`, and PR comments
     - `gh pr create --draft --assignee phrazzld`
     - Add context comment if notable decisions were made
 15. **Retro** — Ensure `.groom/retro.md` exists first; initialize it with a minimal heading/template if missing. Then append implementation signals:

--- a/core/pr/SKILL.md
+++ b/core/pr/SKILL.md
@@ -62,7 +62,7 @@ Keep `Why This Matters`, `Trade-offs / Risks`, and the opening `What Changed` ex
 10. **Comment** — Add context comment if notable decisions were made, and use `--body-file` for comment bodies.
 11. **Retro** — If this PR closes a GitHub issue, append implementation feedback:
    ```bash
-  /retro append --issue $ISSUE --predicted {effort_label} --actual {actual_effort} \
+   /retro append --issue $ISSUE --predicted {effort_label} --actual {actual_effort} \
      --scope "{what_changed_from_spec}" --blocker "{blockers}" --pattern "{insight}"
    ```
    This feeds the grooming feedback loop — `/groom` reads retro.md to calibrate


### PR DESCRIPTION
## Summary

- **Post-merge hook:** `.githooks/post-merge` runs `sync.sh all --prune` automatically after every pull/merge. One-time setup documented in CLAUDE.md.
- **Duplicate PR guard:** Autopilot and pr skills now check for existing open PRs before creating new ones — update the existing lane instead of opening duplicates. Adds `--body-file` for `gh pr create/edit/comment`.

## Before / After

**Before:** After merging PRs, harness symlinks required manual `sync.sh` runs. Autopilot could open duplicate PRs for issues that already had an open PR.

**After:** `git pull` auto-syncs all harnesses. Autopilot checks for in-flight lanes (via `issue_lane.py` or gh query) before creating PRs, and uses `gh pr edit` when a PR already exists.

## Test plan

- [ ] `git config core.hooksPath .githooks` then `git pull` triggers auto-sync
- [ ] `/autopilot` checks for open PRs before creating a new one
- [ ] `/pr` uses `gh pr edit` when branch already has a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic skill synchronization now runs after merge and rebase events.

* **Documentation**
  * Added setup instructions for enabling the auto-sync hooks on developer machines.
  * Expanded workflow guidance for PR validation, lane handling, and comprehensive PR body requirements; minor formatting tweaks to workflow docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->