### PR TITLE
[codex] add simplify skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A unified skills monorepo for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first, with some TypeScript helper scripts and tests (e.g., `core/research/`). Skills are distributed to agent harnesses via symlinks.
 
-**64 core skills** (universal engineering) + **4 domain packs** (20 skills, loaded per-project) + **5 repo-local** (live in their own repos).
+**65 core skills** (universal engineering) + **4 domain packs** (20 skills, loaded per-project) + **5 repo-local** (live in their own repos).
 
 ## Repo Structure
 
 ```
 agent-skills/
-├── core/           # 64 universal skills, synced to ~/.claude/skills/
+├── core/           # 65 universal skills, synced to ~/.claude/skills/
 │   ├── groom/
 │   ├── autopilot/
 │   ├── build/
@@ -114,7 +114,7 @@ Claude Code has a ~16K char description budget. Skills consume budget based on m
 | Reference | `user-invocable: false` | Auto-loaded by model | **Consumes budget** |
 | DMI | `disable-model-invocation: true` | User via `/command` | **Free** |
 
-Current split: ~36 budget-consuming + ~28 DMI = ~64 core total. Well within 16K.
+Current split: ~36 budget-consuming + ~29 DMI = ~65 core total. Well within 16K.
 Pack skills (20) don't consume budget — they're loaded per-project only when needed.
 
 ## Core Delivery Pipeline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,22 +6,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A unified skills monorepo for multi-model AI agents (Claude, Codex, Gemini, Factory, Pi). Markdown-first, with some TypeScript helper scripts and tests (e.g., `core/research/`). Skills are distributed to agent harnesses via symlinks.
 
-**65 core skills** (universal engineering) + **4 domain packs** (20 skills, loaded per-project) + **5 repo-local** (live in their own repos).
+Core skills, domain packs, and repo-local skills for AI coding agents. Skills are added, absorbed, and reorganized over time, so avoid hard-coding inventory counts in docs.
 
 ## Repo Structure
 
 ```
 agent-skills/
-├── core/           # 65 universal skills, synced to ~/.claude/skills/
+├── core/           # Universal skills, synced to ~/.claude/skills/
 │   ├── groom/
 │   ├── autopilot/
 │   ├── build/
 │   └── ...
 ├── packs/          # Domain packs, loaded per-project on demand
-│   ├── payments/   # bitcoin, lightning, stripe (3 skills + 5 checklists)
-│   ├── growth/     # brand, content, growth, ai-media, og-hero-image, app-screenshots, audit-website, product-marketing-context (8 skills + 3 checklists)
-│   ├── scaffold/   # github-app, slack-app, monorepo, mobile-migrate, bun (5 skills + 1 checklist)
-│   └── finance/    # finances-ingest, finances-report, finances-snapshot, crypto-gains (4 skills)
+│   ├── payments/   # Payment-focused skills and checklists
+│   ├── growth/     # Growth and marketing skills
+│   ├── scaffold/   # Project scaffolding and migration skills
+│   └── finance/    # Personal finance workflows
 ├── docs/
 │   └── context/    # Starter cold-memory artifacts for tuned repos
 ├── scripts/
@@ -114,8 +114,7 @@ Claude Code has a ~16K char description budget. Skills consume budget based on m
 | Reference | `user-invocable: false` | Auto-loaded by model | **Consumes budget** |
 | DMI | `disable-model-invocation: true` | User via `/command` | **Free** |
 
-Current split: ~36 budget-consuming + ~29 DMI = ~65 core total. Well within 16K.
-Pack skills (20) don't consume budget — they're loaded per-project only when needed.
+Keep the budget-consuming surface lean. Prefer DMI for user-only workflows, and use packs for per-project specialization so the global core stays within budget.
 
 ## Core Delivery Pipeline
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-64 core skills + 4 domain packs for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
+65 core skills + 4 domain packs for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
 
 Skills are Markdown-first with a handful of Python helper scripts. No application code, no dependencies. They teach agents *how to work*: debugging methodology, PR workflows, design systems, incident response, and dozens of domain-specific playbooks.
 
@@ -72,6 +72,7 @@ starter rows with repo-specific subsystem docs and routing rules.
 | `/shape` | DMI | Product + technical planning (absorbs spec, architect, brainstorming) |
 | `/autopilot` | Model+User | Autonomous delivery: shape → build → walkthrough → commit → PR |
 | `/build` | Model+User | Implementation with TDD workflow |
+| `/simplify` | DMI | First-principles repo simplification: understand, redesign, refactor, PR |
 | `/commit` | DMI | Semantic commits with quality gates |
 | `/pr-walkthrough` | DMI | Mandatory walkthrough package: script, artifact, evidence, persistent check |
 | `/pr` | DMI | PR creation with mandatory sections |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Skills
 
-65 core skills + 4 domain packs for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
+Portable skill library for AI coding agents. Works with Claude Code, Codex, Gemini, Factory, and Pi.
 
 Skills are Markdown-first with a handful of Python helper scripts. No application code, no dependencies. They teach agents *how to work*: debugging methodology, PR workflows, design systems, incident response, and dozens of domain-specific playbooks.
 
@@ -12,9 +12,9 @@ AI agents are only as good as their instructions. Generic prompts produce generi
 
 | Tier | Location | Distribution | Budget cost |
 |------|----------|-------------|-------------|
-| **Core** (64) | `core/` | `sync.sh claude` → global | Per-mode |
-| **Pack** (20) | `packs/` | `sync.sh pack <name> <project>` → per-project | Per-mode |
-| **Repo-local** (5) | `<repo>/.claude/skills/` | Lives in destination repo | Per-mode |
+| **Core** | `core/` | `sync.sh claude` → global | Per-mode |
+| **Pack** | `packs/` | `sync.sh pack <name> <project>` → per-project | Per-mode |
+| **Repo-local** | `<repo>/.claude/skills/` | Lives in destination repo | Per-mode |
 
 Invocation modes within each tier:
 
@@ -149,16 +149,16 @@ Domains: bitcoin, btcpay, bun, docs, landing, lightning, observability, onboardi
 
 Packs are loaded per-project via `sync.sh pack <name> <project-dir>`.
 
-### payments (3 skills + 5 checklists)
+### payments
 `bitcoin` · `lightning` · `stripe`
 
-### growth (8 skills + 3 checklists)
+### growth
 `brand` · `content` · `growth` · `ai-media` · `og-hero-image` · `app-screenshots` · `audit-website` · `product-marketing-context`
 
-### scaffold (5 skills + 1 checklist)
+### scaffold
 `github-app-scaffold` · `slack-app-scaffold` · `monorepo-scaffold` · `mobile-migrate` · `bun`
 
-### finance (4 skills)
+### finance
 `finances-ingest` · `finances-report` · `finances-snapshot` · `crypto-gains`
 
 ## Repo-Local Skills

--- a/core/simplify/SKILL.md
+++ b/core/simplify/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: simplify
+description: |
+  Find and ship the highest-leverage simplification a codebase can absorb in one pull request.
+  Use when simplifying architecture, deleting layers, reviewing a repo from first principles,
+  asking "what would we build today?", or looking for the cleanest Ousterhout-style refactor.
+  Keywords: /simplify, simplify this repo, first-principles redesign, strategic refactor,
+  module depth, information hiding, reduce complexity, clean architecture, single-PR refactor.
+disable-model-invocation: true
+argument-hint: "[optional focus area]"
+---
+
+# /simplify
+
+Take one concrete step toward the system you would design today, not the system history handed you.
+
+## Role
+
+Staff engineer and architecture editor. Understand why the system exists, imagine the clean rebuild,
+then ship the single best simplification that fits in one PR.
+
+## Objective
+
+For the whole repo or `$ARGUMENTS`, answer four questions with evidence:
+
+1. What does this system actually do?
+2. Why is it shaped this way?
+3. If rebuilding today, what are the cleanest plausible designs?
+4. Which one refactor removes the most complexity per unit of risk right now?
+
+Then implement that refactor, verify behavior, and open or update a draft PR via `../pr/SKILL.md`.
+
+## Latitude
+
+- Launch parallel subagents when the harness supports them; otherwise run the same lanes sequentially
+- Read code, docs, tests, ADRs, and bounded git history before proposing changes
+- Prefer deletion, consolidation, and stronger module boundaries over new abstractions
+- Use an `ousterhout` reviewer/persona if available; otherwise apply the same checks manually
+- If no safe, high-impact, single-PR simplification exists, say so explicitly instead of inventing churn
+
+## Workflow
+
+1. **Establish current truth** — Read the nearest `AGENTS.md`, `CLAUDE.md`, `README`, architecture docs, and the critical runtime/test modules. Inspect recent git history, big refactors, and ADRs to learn how the current shape emerged.
+2. **Split exploration into lanes** — Read `references/exploration-lanes.md`. Run only the minimum lanes needed to decide one safe, high-leverage simplification. Skip any lane that cannot change the decision.
+3. **Rebuild from first principles** — Generate several credible "build it today" designs, not just one. Force structural alternatives: deeper modules, fewer services, collapsed workflows, deleted compatibility layers, or cleaner seams.
+4. **Evaluate trade-offs** — Read `references/refactor-rubric.md`. Score the options on module depth, information hiding, operational simplicity, migration cost, behavior risk, and single-PR feasibility.
+5. **Choose one refactor** — Pick the change that maximizes complexity removed per unit of risk and fits in one pull request. Name what will be deleted, what will be consolidated, and what behavior must remain unchanged.
+6. **Implement with proof** — Before edits, write down the module invariants and external contract that must remain stable. Add or adjust tests against that contract where behavior risk is non-trivial. Make the refactor. Update docs if architecture or workflow meaningfully changes. Verify with the tightest commands that cover the affected surface.
+7. **Ship** — After boundary simplification and verification are complete, invoke `../pr/SKILL.md` and follow its workflow. The PR should explain the current shape, the first-principles alternatives considered, why this refactor won, and the follow-up work left behind.
+8. **Codify leftovers** — If the best future architecture cannot fit in one PR, create focused follow-up issues or record the roadmap in the PR body.
+
+## Output
+
+Default deliverable:
+
+- Current system model
+- First-principles design options
+- Trade-off evaluation
+- Chosen single-PR simplification
+- Verification evidence
+- PR URL
+
+## References
+
+- `references/exploration-lanes.md`
+- `references/refactor-rubric.md`

--- a/core/simplify/references/exploration-lanes.md
+++ b/core/simplify/references/exploration-lanes.md
@@ -1,0 +1,79 @@
+# Exploration Lanes
+
+Use subagents when available. If not, run the same lanes yourself in this order.
+
+Run only the minimum lanes needed to choose one safe, high-leverage simplification.
+Skip any lane that cannot change the decision. Four is the default ceiling.
+
+## Lane 1: Codebase Cartographer
+
+Objective: explain what the system does now.
+
+Gather:
+- entrypoints, major modules, data flow, runtime boundaries
+- where core behavior actually lives
+- tests that protect the important seams
+- obvious duplication, pass-through layers, or split responsibilities
+
+Return:
+- current architecture summary
+- deepest modules vs shallowest modules
+- 2-5 simplification opportunities with file evidence
+
+## Lane 2: Git Historian
+
+Objective: explain how the current shape emerged.
+
+Gather:
+- recent commits in the touched area
+- major refactors, migrations, rewrites, or reversals
+- ADRs, issue links, release notes, and commit messages that explain intent
+- signs of temporary scaffolding that became permanent
+
+Return:
+- architecture timeline
+- decisions that still look load-bearing
+- compatibility layers or legacy seams that may now be removable
+
+Treat history as evidence, not authority. Keep only constraints that still map to
+current product or runtime needs.
+
+## Lane 3: Product and Docs Analyst
+
+Objective: separate real product constraints from incidental implementation detail.
+
+Gather:
+- README, docs, specs, contracts, API surface, and operator workflows
+- main user journeys or internal jobs the system must support
+- explicit non-negotiables vs outdated prose
+
+Return:
+- what behavior is sacred
+- what complexity is policy-driven vs accidental
+- doc drift or contract ambiguity that affects refactor safety
+
+## Lane 4: Simplifier
+
+Objective: reason from first principles and Ousterhout-style module depth.
+
+Ask:
+- Which modules leak too much detail?
+- Which abstractions are only pass-throughs?
+- Which workflows are split for historical rather than present reasons?
+- What could be deleted or collapsed without losing capability?
+
+Return:
+- 3-7 candidate redesign moves
+- strongest conservative option
+- strongest aggressive option
+- the single best one-PR simplification candidate
+
+## Synthesis
+
+Merge the lanes into one view:
+
+1. Current system: what exists and why
+2. Candidate future shapes: several credible designs
+3. Single-PR move: best simplification available now
+
+Do not let one lane dominate without evidence from the others.

--- a/core/simplify/references/refactor-rubric.md
+++ b/core/simplify/references/refactor-rubric.md
@@ -1,0 +1,80 @@
+# Refactor Rubric
+
+Generate multiple candidates before choosing a refactor.
+
+Default set:
+- one conservative simplification
+- one boundary-reset or module-consolidation option
+- one aggressive "if rebuilding today" option
+
+Large repos often need 5+ candidates.
+
+## Ousterhout Checks
+
+Prefer options that:
+
+- create deeper modules with smaller visible interfaces
+- hide implementation detail instead of spreading it across callers
+- remove pass-through layers and temporal coupling
+- replace special cases with one clear invariant
+- delete code and concepts instead of relocating them
+- reduce the number of modules touched by common changes
+- reduce prerequisite knowledge required to use the module
+- make future changes cheaper, not just this patch smaller
+
+## Single-PR Filter
+
+A candidate is eligible only if it:
+
+- fits inside one reviewable pull request
+- has a clear behavior-preservation story
+- can be tested with existing or easily added checks
+- has bounded migration and rollback risk
+- does not require a speculative platform rewrite
+
+If a candidate fails this filter, keep it as future architecture, not the current PR.
+
+## Selection Questions
+
+For each candidate, answer:
+
+1. What complexity disappears if this lands?
+2. What interface or boundary becomes simpler?
+3. What important behavior could regress?
+4. What evidence would make that risk acceptable?
+5. Why is this the best move now, not just the prettiest diagram?
+
+Required evidence per candidate:
+
+- public API or operator surface that changes, if any
+- call-sites that currently require internal knowledge
+- expected files touched for a routine feature change before vs after
+
+## Lightweight Scorecard
+
+Use a simple rubric such as `high`, `medium`, `low`:
+
+| Candidate | Simplicity Gain | Risk | Effort | Future Leverage | PR Fit |
+|-----------|-----------------|------|--------|-----------------|--------|
+
+The winner is not the most ambitious idea. It is the option with the best ratio of:
+
+`complexity removed / delivery risk`
+
+## Output Contract
+
+Use a report structure close to this:
+
+## Current Shape
+
+## Why It Ended Up Here
+
+## First-Principles Alternatives
+
+## Chosen Simplification
+
+## Verification Plan
+
+## PR Outcome
+
+Adapt section names if the repo already has a house style.


### PR DESCRIPTION
## Summary
This change adds a new `/simplify` skill for the agent-skills repo and wires it into the repo's published skill catalog. The new skill is a user-invocable workflow for understanding a codebase, reconstructing how it got its current shape, exploring several first-principles redesigns, and then choosing and shipping the single highest-impact simplification that fits within one pull request.

## User Impact
Before this change, other skills such as `/autopilot` and `/pr-polish` referenced `/simplify` as a preferred accelerator, but there was no actual skill implementation behind that interface. That left a gap in the delivery pipeline: agents had a named simplification step but no concrete shared workflow for doing the work. After this change, that step is real, documented, and packaged as a reusable skill.

## Root Cause
The repository had grown references to a simplification capability before the capability itself existed as a tracked skill. That meant the architecture-improvement phase was implied in prose across other skills, but not codified as a first-class workflow with a trigger surface, reference docs, and validation.

## Fix
The patch introduces `core/simplify/` with a lean `SKILL.md` and two supporting references:

- `references/exploration-lanes.md` defines the minimum useful parallel exploration lanes for current-shape, git-history, docs/product intent, and simplification analysis.
- `references/refactor-rubric.md` defines how to generate multiple redesign candidates, apply Ousterhout-style depth and information-hiding checks, filter for single-PR feasibility, and choose a refactor based on complexity removed versus delivery risk.

The patch also updates `README.md` and `CLAUDE.md` so the repo's published skill counts and delivery-skill table include `/simplify`.

## Validation
I validated the new skill with:

```bash
python3 core/skill-builder/scripts/validate_skill.py core/simplify
```

The validator passed with no warnings. I also packaged the skill during development to confirm the structure was distributable, then removed the generated artifact before commit so the repo remains source-only.

## Risk
Risk is low. The change is documentation and skill-definition only; it does not alter runtime code paths or sync behavior. The main risk is instruction quality, and this was reduced by tightening the wording to avoid process theater, require explicit invariant capture before refactoring, and make candidate evaluation less subjective.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "/simplify" delivery skill for running a single, high-leverage architectural refactor in one PR.

* **Documentation**
  * Added detailed simplify workflow guidance, exploration lanes, and a refactor evaluation rubric.
  * Updated README and docs to use a portable, non-numeric description of core skills and simplified domain pack headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->