### PR TITLE
fix(delivery): close false-unblocked review gap

### DIFF
--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -142,6 +142,8 @@ The point is single ownership. One issue should map to one active autopilot lane
     - Use `--body-file` for `gh pr create`, `gh pr edit`, and PR comments
     - `gh pr create --draft --assignee phrazzld --body-file <path>`
     - Add context comment if notable decisions were made
+    - Opening or updating the PR creates the review lane. It does **not** mean the PR is review-clean.
+    - If your final push, `gh pr ready`, or PR edit triggers async reviewers, do not post any "PR Unblocked" or "ready for merge" signal unless `/pr-fix` has passed its live settlement gate on that PR
 15. **Retro** — Ensure `.groom/retro.md` exists first; initialize it with a minimal heading/template if missing. Then append implementation signals:
     ```
     mkdir -p .groom
@@ -238,7 +240,7 @@ NOT stopping conditions: lacks description, seems big, unclear approach.
 
 ## Output
 
-Report: issue worked, spec status, design status, TDD evidence (RED/GREEN), dogfood QA summary (issues found/fixed), walkthrough artifact summary, commits made, PR URL.
+Report: issue worked, spec status, design status, TDD evidence (RED/GREEN), dogfood QA summary (issues found/fixed), walkthrough artifact summary, commits made, PR URL, and whether review cleanup was merely handed off or actually closed via `/pr-fix`.
 
 ## Review Cadence
 

--- a/core/pr-fix/SKILL.md
+++ b/core/pr-fix/SKILL.md
@@ -1,349 +1,113 @@
 ---
 name: pr-fix
 description: |
-  Unblock a PR: resolve conflicts, fix CI, self-review, address feedback, refactor.
-  One command takes a blocked PR to green and mergeable.
-  Use when: PR blocked, CI red, unaddressed reviews, code review needed, refactoring.
+  Unblock a PR end-to-end: resolve conflicts, fix CI, self-review the diff, reconcile every review comment, and wait for async reviewers to settle before declaring success.
+  Use when: PR blocked, CI red, open review threads remain, bot comments keep reopening, or a branch looks green but is not actually review-clean.
   Trigger: /pr-fix, /fix-ci, /review-branch, /review-and-fix, /respond, /address-review, /refactor.
 argument-hint: "[PR-number]"
 ---
 
 # /pr-fix
 
-One command takes a blocked PR to green.
+Take a PR from blocked to actually mergeable.
 
 ## Role
 
-Senior engineer unblocking a PR. Methodical, not reactive. Each phase resolves a class of blocker in dependency order.
+Senior engineer unblocking a PR. Think like an owner, not a task runner.
 
 ## Objective
 
-Take PR `$ARGUMENTS` (or current branch's PR) from blocked to mergeable: no conflicts, CI green, reviews addressed, and **all open conversations on the PR resolved**.
-`dogfood`, `agent-browser`, and `browser-use` are available in this environment for user-flow verification.
+Take PR `$ARGUMENTS` (or the current branch PR) to this state:
+- no merge conflicts
+- required CI green
+- self-review complete
+- every actionable review item handled
+- no open review threads
+- no misleading "PR Unblocked" comment while review automation can still add findings
+
+## Latitude
+
+- Use judgment on whether feedback should be fixed now, deferred, or rejected.
+- Prefer deterministic tooling for exact inventory and state checks.
+- Prefer model reasoning for semantic triage, scope decisions, and reviewer synthesis.
+
+## Non-Negotiable Invariants
+
+1. **Inventory beats counts.** Do not trust a green merge button, `reviewDecision`, or a single unresolved-thread count. Build a full review inventory and reconcile each item.
+2. **Reply per item.** Aggregate "covered above" comments are not enough for actionable review findings.
+3. **Settle async reviewers before signaling success.** After every push, `gh pr ready`, or any action that can retrigger bots, rerun the review inventory after reviewer activity settles.
+4. **No quality-gate downgrades.** Fix the code or the tests. Do not weaken thresholds.
 
 ## Dependency Order
 
-Conflicts -> CI -> Self-Review -> Reviews. Can't run CI on conflicted code. Can't review broken code. Can't address others' reviews before fixing your own issues.
+Conflicts -> CI -> Self-Review -> Review Reconciliation -> Settlement -> Signal
 
-## LLM-First Implementation Rule (Mandatory)
+## Core Workflow
 
-For semantic fixes (classification/triage logic, intent inference, severity mapping, reviewer synthesis), prefer LLM reasoning over deterministic heuristics.
+Read [references/workflow.md](./references/workflow.md) and execute the phases in order:
+- assess the PR and list blockers
+- resolve conflicts first
+- fix CI before arguing with reviewers
+- self-review the diff
+- build a deterministic review inventory
+- reconcile every actionable item with a decision and direct reply
+- push, rerun inventory, and reconcile again
+- wait for async reviewers to settle
+- update the PR body if the implementation or evidence changed
+- only then post the unblocked summary
 
-Do not add heuristic-only semantic classifiers (regex-only labels, keyword score trees) unless the task is strictly syntactic.
+`dogfood`, `agent-browser`, and `browser-use` are available for user-flow verification when the diff is user-facing.
 
-Keep deterministic code for mechanical guarantees only: schema contracts, exact format parsing, permissions/safety enforcement.
+## Required References
 
-## Bounded Shell Output (MANDATORY)
+- Review reconciliation: [references/reconciliation-ledger.md](./references/reconciliation-ledger.md)
+- Detailed unblock sequence: [references/workflow.md](./references/workflow.md)
 
-- Size before detail: counts/metadata first
-- Never print unbounded logs/comments
-- Add explicit bounds: `--limit`, `head -n`, `tail -n`, `per_page`
-- If no useful signal in 20s: abort, narrow, rerun
-- Use `~/.claude/scripts/safe-read.sh` for large local files
+## Required Tooling
 
-## Workflow
-
-### 1. Assess
-
-```bash
-gh pr view $PR --json number,title,headRefName,baseRefName,mergeable,reviewDecision,statusCheckRollup
-gh pr checks $PR --json name,state,startedAt,completedAt,link
-gh pr view $PR --json body --jq '.body | split("\n")[:80] | join("\n")'
-```
-
-Read PR description and linked issue. Understand **what this PR is trying to do** — semantic context drives conflict resolution and review decisions.
-
-Fetch latest base:
+Use the inventory script during review reconciliation:
 
 ```bash
-BASE="$(gh pr view $PR --json baseRefName --jq .baseRefName)"
-git fetch origin "$BASE"
+python3 scripts/review_inventory.py $PR > /tmp/pr-fix-review-inventory.json
 ```
 
-Determine blockers: conflicts? CI failures? pending reviews? Build a checklist.
-
-### 2. Resolve Conflicts
-
-**Skip if**: `mergeable != CONFLICTING`
-
-Rebase onto base branch:
-
-```bash
-git rebase "origin/$BASE"
-```
-
-When conflicts arise, resolve **semantically based on PR purpose**, not mechanically:
-
-- Read both sides. Understand intent.
-- Preserve the PR's behavioral changes. Integrate upstream structural changes.
-- Reference `git-mastery/references/conflict-resolution.md` for strategies.
-- Never blindly accept ours/theirs.
-
-After resolution, verify locally:
-
-```bash
-git rebase --continue
-# Run project's test/typecheck commands
-```
-
-### 3. Fix CI
-
-**Skip if**: all checks passing.
-
-Push current state and diagnose CI failures:
-
-```bash
-git push --force-with-lease
-gh run list --limit 5 --json databaseId,workflowName,status,conclusion,headBranch
-gh run view <run-id> --log-failed | tail -n 200
-```
-
-Classify failure type (Code Issue / Infrastructure / Flaky / Config), identify root cause,
-fix the code. See `references/fix-ci.md` for the full CI diagnosis procedure.
-
-If CI fixes create new conflicts: return to Phase 2 (max 2 full-pipeline retries).
-
-### 4. Self-Review the Diff
-
-**Always run this phase.** CI passing does not mean the code is good. Linters catch syntax; this catches logic.
-
-Review the full diff against base:
-
-```bash
-BASE="$(gh pr view $PR --json baseRefName --jq .baseRefName)"
-git diff "origin/$BASE"...HEAD
-```
-
-For each changed file, check for:
-
-- **Dead code**: unused variables (especially `_`-prefixed params that signal "I know this is unused"), unreachable branches, useMemo/useCallback with values never read
-- **Logic bugs**: loops that always break on first iteration, conditions that are always true/false, off-by-one errors
-- **Wasted computation**: expensive operations whose results are discarded, duplicate work (e.g., running the same test suite twice in CI)
-- **Wrong log levels**: success messages on stderr (`console.warn`/`console.error`), debug output on stdout in production
-- **Semantic mismatches**: function names that don't match behavior, comments that contradict code
-
-Fix every issue found. Run typecheck + tests after fixes. Commit before proceeding.
-
-This phase catches what CI cannot: code that compiles and passes tests but is wrong, wasteful, or misleading. A PR that's "green" but ships dead code or wasted computation is not actually unblocked — it's shipping tech debt.
-
-### 5. Address Reviews
-
-**Exit criterion for this phase:** the PR has zero unresolved review threads and zero remaining actionable open conversations. Do not call the PR unblocked while any conversation is still open.
-
-**Skip condition**: ALL THREE of these are zero: unresolved review threads, unreplied review comments, AND unaddressed bot issue comments. Use the queries below — never rely on `reviewDecision` alone or prior "PR Unblocked" summary comments.
-
-```bash
-OWNER="$(gh repo view --json owner --jq .owner.login)"
-REPO="$(gh repo view --json name --jq .name)"
-
-# Count unresolved review threads (inline comments)
-UNRESOLVED_THREADS="$(gh api graphql -f query='
-  query($owner:String!, $repo:String!, $number:Int!){
-    repository(owner:$owner,name:$repo){
-      pullRequest(number:$number){
-        reviewThreads(first:100){nodes{isResolved}}
-      }
-    }
-  }' -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false)] | length')"
-```
-
-#### 5a. Bot issue comments (MANDATORY)
-
-**Why this exists:** Some bot reviewers (Claude, CodeRabbit, etc.) post review feedback as **issue comments** (`/issues/$PR/comments`), not pull request review comments (`/pulls/$PR/comments`). These are a completely different API endpoint and are invisible to the GraphQL `reviewThreads` query. Missing them means missing actionable review feedback.
-
-```bash
-# Fetch bot issue comments — these are NOT in reviewThreads or PR comments
-BOT_COMMENTS="$(gh api "repos/$OWNER/$REPO/issues/$PR/comments?per_page=100" --paginate \
-  --jq '[.[] | select(.user.type == "Bot") | {id, user: .user.login, body: .body}]')"
-```
-
-Filter for comments that contain actionable review feedback (code suggestions, bug findings, security concerns). Ignore:
-- Status/summary comments (CI reports, merge readiness checks)
-- Comments you've already replied to with fixes
-- Informational comments with no action items
-
-For each bot comment with actionable findings:
-1. **Read the FULL comment body** — no truncation
-2. **Extract each finding** — bots typically number them or use headers
-3. **Read the current file** to check if already addressed
-4. **Fix or defer** each finding (same as review comments below)
-5. **Reply to the comment** with resolution status for each finding
-
-If an `Auto PR Feedback Digest` exists in context, use it only as triage seed. Always refresh live GitHub data before final replies.
-
-#### 5b. Review comments and threads
-
-**Independent verification (MANDATORY)**
-
-**Never trust prior session comments, "PR Unblocked" summaries, or claims that feedback was addressed.** For EVERY open review comment:
-
-1. **Read the FULL comment body** — no truncation. Use the GitHub API without `.body[:N]` limits.
-2. **Read the current file at the referenced line** to verify the fix is actually present.
-3. **Reply directly on the comment thread** with the specific commit SHA and line confirming the fix. An open thread without a reply = unaddressed, regardless of what a summary comment claims.
-
-```bash
-# Fetch ALL review comments with full bodies — never truncate
-gh api "repos/$OWNER/$REPO/pulls/$PR/comments?per_page=100" --paginate \
-  --jq '.[] | {id, user: .user.login, path, line, body, in_reply_to_id}'
-```
-
-For each comment without a reply from this PR's author:
-- If **already fixed in code**: reply with commit SHA + current line reference confirming the fix
-- If **needs fixing**: fix it, then reply with commit SHA
-- If **deferred**: reply with follow-up issue number
-- If **declined**: reply with public reasoning
-
-Bot feedback (CodeRabbit, Gemini, Codex, and other reviewer bots) gets the same treatment as human feedback.
-
-#### Execution
-
-1. **Categorize feedback** — Sort into critical / in-scope / follow-up / declined. Post transparent assessment to PR. Reviewer feedback CAN be declined with public reasoning. See `references/respond.md` for the full transparency workflow.
-
-2. **Classify and set severity** — For every actionable comment, record:
-   - Classification: `bug | risk | style | question`
-   - Severity: `critical | high | medium | low`
-   - Decision: `fix now | defer | reject` with reason
-   Policy:
-   - `critical/high`: fix now by default
-   - `medium`: fix now or open follow-up issue with rationale
-   - `low`: optional
-
-3. **TDD fixes** — For critical and in-scope items: write failing test, fix, verify pass, commit. Create GitHub issues for follow-up items. See `references/address-review.md` for the TDD fix procedure and `references/scope-rules.md` for in-scope vs out-of-scope guidance.
-
-4. **Reply to every open thread** — use `gh api repos/$OWNER/$REPO/pulls/$PR/comments/$ID/replies -f body='...'` so the thread shows addressed.
-   Reply format:
-   - `Classification: <bug|risk|style|question>`
-   - `Severity: <critical|high|medium|low>`
-   - `Decision: <fix now|defer|reject>. <reason>`
-   - `Change: <what changed>`
-   - `Verification: <tests/checks run or N/A>`
-
-5. **Resolve every thread via GraphQL** — Replies alone do NOT resolve threads. Non-outdated comments stay visible as open issues to reviewers even after fixing the code and replying. You MUST resolve them. The phase is incomplete until the unresolved thread count is `0`:
-
-```bash
-# Get unresolved thread IDs
-gh api graphql -F owner="$OWNER" -F repo="$REPO" -F number=$PR -f query='
-  query($owner: String!, $repo: String!, $number: Int!) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $number) {
-        reviewThreads(first: 100) {
-          nodes { id isResolved isOutdated }
-        }
-      }
-    }
-  }' --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id'
-
-# Resolve each thread
-gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "THREAD_ID"}) { thread { isResolved } } }'
-```
-
-Additive commits do NOT make comments outdated. Only changes to the diff hunk a comment is attached to trigger outdating. Resolve explicitly.
-
-### 6. Verify and Push
-
-```bash
-git push --force-with-lease
-```
-
-Watch checks. If a phase-4 or phase-5 fix broke CI, re-run the CI diagnosis (Phase 3) again (count toward 2-retry max).
-
-If 2 full retries exhausted: stop, summarize state, ask user.
-
-### 6b. Dogfood + Browser Flow Verification (MANDATORY for user-facing diffs)
-
-If fixes touch UI or user behavior (`app/`, `components/`, styles, route handlers, auth, checkout, onboarding):
-
-1. Run `/dogfood http://localhost:3000` before calling PR mergeable
-2. Fix P0/P1 findings, rerun on affected scope
-3. Use `agent-browser` / `browser-use` for targeted repro, screenshot evidence, and regression checks
-
-`/dogfood` is a skill command, not a shell binary probe.
-
-### 7. Update PR Description with Before / After + Walkthrough
-
-Edit the PR body to preserve the richer `/pr` structure and update the relevant sections documenting the fix.
-Refresh the `## Walkthrough` section too when the fix changes the merge case, evidence, or protecting check:
-
-```bash
-# Get current body, refresh the affected sections
-gh pr edit $PR --body "$(updated body)"
-```
-
-Before editing, read `../pr/references/pr-body-template.md`.
-
-Do not only append text. Refresh:
-- `Why This Matters` if the fix changed the PR's significance
-- `Trade-offs / Risks` if the fix changed reviewer concerns
-- `What Changed` diagrams if the final implementation shape drifted
-- `Before / After` evidence for the blocked vs unblocked state
-
-**Text (MANDATORY)**: Describe the blocked state (before) and the unblocked state (after).
-Example: "Before: CI failing on type error in auth module. After: Types corrected, CI green."
-
-**Screenshots (when applicable)**: Capture before/after for any visible change — CI status pages, error output, UI changes from review fixes. Use `![before](url)` / `![after](url)`.
-
-Skip screenshots only when all fixes are purely internal (conflict resolution with no behavior change, CI config fixes with no visible output difference).
-
-If the fixes materially change what reviewers should see, rerun `/pr-walkthrough` and update:
-
-- Artifact
-- Claim
-- Before / After scope
-- Persistent verification
-- Residual gap
-
-### 8. Signal
-
-Post summary comment on PR:
-
-```bash
-gh pr comment $PR --body "$(cat <<'EOF'
-## PR Unblocked
-
-**Conflicts**: [resolved N files / none]
-**CI**: [green / was: failure type]
-**Reviews**: [N fixed, N deferred (#issue), N declined (see above)]
-
-Ready for re-review.
-EOF
-)"
-```
+That inventory is mandatory and is the source of truth for review cleanup.
+
+## Hard Stop Rules
+
+Do not post `PR Unblocked` if any of these are still true:
+- required CI is failing
+- review-related checks are `QUEUED`, `IN_PROGRESS`, or `PENDING`
+- any actionable review item lacks a decision
+- any actionable PR review comment lacks a direct reply
+- any actionable review thread remains unresolved
+- the post-settlement inventory changed and has not been reconciled
 
 ## Retry Policy
 
-Max 2 full-pipeline retries when fixing one phase breaks another. After 2: stop and escalate to user with clear status.
+Max 2 full-pipeline retries when one phase breaks another. After 2, stop and summarize clearly for the user.
 
 ## Anti-Patterns
 
-- Mechanical ours/theirs conflict resolution
-- Pushing without local verification
-- Silently ignoring review feedback
-- Retrying CI without understanding failures
-- Fixing review comments that should be declined
-- **Trusting prior "PR Unblocked" or summary comments** — always verify each comment against current code independently. A previous session claiming "fixed" means nothing until you read the file yourself.
-- **Leaving review threads without direct replies** — an open thread with no reply = unaddressed, even if the code is fixed. Reviewers can't see that you checked.
-- **Truncating comment bodies** — never use `.body[:N]` when fetching review comments. The actionable detail is often at the end of long comments.
-- **Replying without resolving** — a reply on a thread does NOT resolve it. Non-outdated threads with replies still show as open conversations. Use `resolveReviewThread` GraphQL mutation after replying.
-- **NEVER lowering quality gates to pass CI** — coverage thresholds, lint rules, type strictness, security gates. If a gate fails, write tests/code to meet it. Moving the goalpost is not a fix. This is an absolute, non-negotiable rule.
-- **Skipping self-review because CI is green** — CI catches syntax and test failures. Dead code, wasted computation, wrong log levels, and semantic mismatches all pass CI. Review the diff yourself before declaring unblocked.
-- **Only checking review threads and PR comments** — bot reviewers (Claude, CodeRabbit, etc.) often post feedback as issue comments (`/issues/$PR/comments`), not PR review comments (`/pulls/$PR/comments`). These are different API endpoints. You MUST check all three: GraphQL reviewThreads, REST PR comments, AND REST issue comments.
+- Treating `mergeable=MERGEABLE` as proof the PR is review-clean
+- Posting `PR Unblocked` before reviewer settlement
+- Using counts without reconciling individual comment ids
+- Replying with one aggregate comment instead of per-finding responses
+- Resolving threads without verifying the code actually matches the reply
+- Ignoring older comments because newer checks are green
+- Trusting prior "fixed" or "unblocked" comments without rebuilding the inventory
 
 ## Output
 
-Summary: blockers found, phases executed, conflicts resolved, CI fixes applied, reviews addressed/deferred/declined, final check status, and explicit confirmation that open conversation count is zero.
+Summarize:
+- blockers found
+- phases executed
+- CI fixes applied
+- review items fixed / deferred / rejected
+- final check status
+- explicit confirmation that the review inventory is closed
 
 ## Absorbed Skills (References)
 
-These skills are consolidated here. Their full content is in `references/`:
-
-- **fix-ci** — [references/fix-ci.md](./references/fix-ci.md) — CI failure classification and resolution
-- **review-branch** — [references/review-branch.md](./references/review-branch.md) — Multi-reviewer code review orchestration
-- **code-review-checklist** — [references/code-review-checklist.md](./references/code-review-checklist.md) — Checklist for purpose, quality, correctness, security, performance, testing
-- **respond** — [references/respond.md](./references/respond.md) — Transparent PR review feedback response workflow
-- **address-review** — [references/address-review.md](./references/address-review.md) — TDD-based review finding resolution
-- **refactor** — [references/refactor.md](./references/refactor.md) — Two-pass code refinement (clarity then architecture)
-- **reviewer-prompts** — [references/reviewer-prompts.md](./references/reviewer-prompts.md) — Prompt templates for AI reviewers
-- **scope-rules** — [references/scope-rules.md](./references/scope-rules.md) — In-scope vs out-of-scope guidance
-- **tdd-fix-pattern** — [references/tdd-fix-pattern.md](./references/tdd-fix-pattern.md) — TDD fix workflow
-- **deferred-issue** — [references/deferred-issue.md](./references/deferred-issue.md) — Template for deferred GitHub issues
+- **fix-ci** — [references/fix-ci.md](./references/fix-ci.md)
+- **review-branch** — [references/review-branch.md](./references/review-branch.md)

--- a/core/pr-fix/references/reconciliation-ledger.md
+++ b/core/pr-fix/references/reconciliation-ledger.md
@@ -1,0 +1,105 @@
+# Reconciliation Ledger
+
+Use this reference during the review phase of `/pr-fix`.
+
+## Purpose
+
+The goal is not "counts are zero right now." The goal is:
+- every actionable review item is inventoried
+- every actionable item has a decision
+- every actionable PR review comment has a direct reply
+- every actionable review thread is resolved
+- every actionable bot issue comment has an explicit response
+- the inventory is still clean after review automation settles
+
+## Deterministic Inventory
+
+Use the inventory script first:
+
+```bash
+python3 scripts/review_inventory.py $PR > /tmp/pr-fix-review-inventory.json
+```
+
+The script gathers:
+- review threads
+- PR review comments
+- issue comments
+- current PR checks
+
+It does **not** decide what is actionable. That part is semantic and belongs to the model.
+
+## Working Ledger
+
+Build a scratch ledger from the inventory with one row per actionable item:
+
+| source | id | author | path | decision | reply | resolved | notes |
+|--------|----|--------|------|----------|-------|----------|-------|
+| thread | ... | ... | ... | fix now | yes | yes | ... |
+| issue-comment | ... | ... | ... | defer | yes | n/a | issue #... |
+
+Required states:
+- `decision`: `fix now | defer | reject`
+- `reply`: `yes`
+- `resolved`: `yes` for review threads, `n/a` for issue comments
+
+If any actionable row is incomplete, the PR is not unblocked.
+
+## Actionable vs Non-Actionable
+
+Usually actionable:
+- bug reports
+- security findings
+- correctness concerns
+- explicit suggestions tied to behavior or recovery
+- requests for missing tests
+
+Usually non-actionable:
+- pure summaries
+- "review in progress" status comments
+- check-run dashboards with no concrete ask
+- informational bot help text
+
+When unsure, bias toward treating the item as actionable until you classify it explicitly.
+
+## Direct Reply Rule
+
+Do not replace direct replies with a summary comment.
+
+For PR review comments:
+- reply on the thread itself
+- then resolve the thread
+
+For bot issue comments:
+- post a direct response comment that references the specific finding or comment id
+- do not rely on a generic "addressed all bot comments" post
+
+## Settlement Gate
+
+After every push, `gh pr ready`, or explicit bot trigger:
+1. wait for review automation to settle
+2. rerun the inventory script
+3. compare the new inventory against your ledger
+4. reconcile any newly-added items
+
+Do not post `PR Unblocked` until the post-settlement inventory is clean.
+
+Review automation commonly includes:
+- `CodeRabbit`
+- `Greptile`
+- `Cerberus`
+- `Gemini`
+- `Claude`
+- `Codex`
+- checks named `review / ...`
+
+If the repo is known to emit comments after the checks finish, require one more quiet poll with no inventory changes.
+
+## Final Verification Checklist
+
+Before signaling success, confirm all of these:
+- required CI is green
+- no review-related checks are still pending
+- actionable ledger rows are fully closed
+- unresolved review thread count is zero
+- no actionable bot issue comment is left without a response
+- no new comments appeared in the final post-settlement inventory

--- a/core/pr-fix/references/workflow.md
+++ b/core/pr-fix/references/workflow.md
@@ -1,0 +1,183 @@
+# Workflow
+
+Use this reference for the ordered `/pr-fix` execution path.
+
+## 1. Assess
+
+Read the PR, the linked issue, and the current check state. Understand what the branch is trying to do before touching conflicts or reviews.
+
+```bash
+gh pr view $PR --json number,title,headRefName,baseRefName,mergeable,reviewDecision,statusCheckRollup,isDraft
+gh pr checks $PR --json name,state,startedAt,completedAt,link
+gh pr view $PR --json body --jq '.body | split("\n")[:80] | join("\n")'
+BASE="$(gh pr view $PR --json baseRefName --jq .baseRefName)"
+git fetch origin "$BASE"
+```
+
+Build a short blocker list:
+- conflicts
+- failing checks
+- open review threads
+- actionable bot issue comments
+- pending review automation
+
+## 2. Resolve Conflicts
+
+Skip if `mergeable != CONFLICTING`.
+
+Rebase onto base and resolve semantically. Preserve the PR's behavior; integrate upstream structure.
+
+```bash
+git rebase "origin/$BASE"
+```
+
+Verify locally before moving on.
+
+## 3. Fix CI
+
+Skip if required checks already pass.
+
+Push the current branch, inspect failing jobs, classify the failure, and fix root cause.
+
+```bash
+git push --force-with-lease
+gh run list --limit 5 --json databaseId,workflowName,status,conclusion,headBranch
+gh run view <run-id> --log-failed | tail -n 200
+```
+
+If the CI fix creates conflicts, return to step 2.
+
+## 4. Self-Review the Diff
+
+Always do this, even when CI is green.
+
+```bash
+BASE="$(gh pr view $PR --json baseRefName --jq .baseRefName)"
+git diff "origin/$BASE"...HEAD
+```
+
+Look for:
+- dead code
+- logic bugs
+- wasted computation
+- wrong log levels
+- semantic mismatches between names, comments, and behavior
+
+Fix what you find. Re-run the relevant verification before moving on.
+
+## 5. Build the Review Inventory
+
+Read [reconciliation-ledger.md](./reconciliation-ledger.md) and use the inventory script.
+
+```bash
+python3 scripts/review_inventory.py $PR > /tmp/pr-fix-review-inventory.json
+```
+
+From that inventory, build a working ledger of actionable items across:
+- GraphQL review threads
+- REST PR review comments
+- REST issue comments from bots
+
+For each actionable item, record:
+- source
+- comment or thread id
+- author
+- classification: `bug | risk | style | question`
+- severity: `critical | high | medium | low`
+- decision: `fix now | defer | reject`
+- reply status
+- thread status
+
+Do not continue while any actionable item lacks a decision.
+
+## 6. Address the Ledger
+
+For each actionable item:
+- **fix now**: write the fix, verify it, commit it
+- **defer**: create or link a follow-up issue, then reply publicly
+- **reject**: reply publicly with reasoning
+
+For every actionable PR review comment:
+- reply directly on that thread
+- include classification, severity, decision, change, and verification
+
+For every actionable bot issue comment:
+- reply explicitly; do not rely on a summary comment elsewhere on the PR
+
+For every actionable review thread:
+- resolve it after replying
+
+If a new push or `gh pr ready` retriggers reviewers, the ledger is stale. Rebuild it.
+
+## 7. Verify, Push, and Reconcile Again
+
+```bash
+git push --force-with-lease
+```
+
+After any push, rerun the review inventory and reconcile again. Do not assume previously closed gaps stayed closed.
+
+If a review fix breaks CI, go back to step 3.
+
+## 8. Dogfood User-Facing Changes
+
+If the fixes touch UI or user behavior:
+- run `/dogfood http://localhost:3000`
+- fix P0/P1 findings
+- rerun on affected scope
+
+Skip only when the diff is fully internal.
+
+## 9. Settlement Gate
+
+Before signaling success:
+- wait for review automation triggered by your last action to settle
+- rerun the review inventory after settlement
+- verify the ledger is still fully reconciled
+
+Treat these as review automation unless you know the repo says otherwise:
+- `CodeRabbit`
+- `Greptile`
+- `Cerberus`
+- `Gemini`
+- `Claude`
+- `Codex`
+- checks named like `review / ...`
+
+Do **not** post `PR Unblocked` while review-related checks are still `QUEUED`, `IN_PROGRESS`, or `PENDING`.
+
+If the repo is known to post delayed findings even after checks complete, require one more quiet poll with no new review items before signaling success.
+
+## 10. Refresh PR Description
+
+If the fix materially changes implementation, evidence, or merge risk, update the PR body and walkthrough.
+
+Before editing, read `../pr/references/pr-body-template.md`.
+
+Refresh:
+- `Why This Matters`
+- `Trade-offs / Risks`
+- `What Changed`
+- `Before / After`
+- `Walkthrough`
+
+## 11. Signal
+
+Only after the settlement gate passes, post the PR summary comment:
+
+```bash
+gh pr comment $PR --body "$(cat <<'EOF'
+## PR Unblocked
+
+**Conflicts**: [resolved N files / none]
+**CI**: [green / was: failure type]
+**Reviews**: [N fixed, N deferred (#issue), N rejected]
+**Open Threads**: 0
+**Review Automation**: settled
+
+Ready for re-review.
+EOF
+)"
+```
+
+If the settlement gate fails, do not post this comment.

--- a/core/pr-fix/scripts/review_inventory.py
+++ b/core/pr-fix/scripts/review_inventory.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+
+def run_gh(args: list[str]) -> str:
+    result = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "gh command failed")
+    return result.stdout
+
+
+def gh_json(args: list[str]) -> Any:
+    return json.loads(run_gh(args))
+
+
+def repo_parts(repo: str | None) -> tuple[str, str]:
+    if repo:
+        owner, name = repo.split("/", 1)
+        return owner, name
+    payload = gh_json(["repo", "view", "--json", "owner,name"])
+    return payload["owner"]["login"], payload["name"]
+
+
+def viewer_login() -> str:
+    return gh_json(["api", "user"])["login"]
+
+
+def rest_pages(path: str) -> list[dict[str, Any]]:
+    page = 1
+    items: list[dict[str, Any]] = []
+    while True:
+        separator = "&" if "?" in path else "?"
+        payload = gh_json(["api", f"{path}{separator}per_page=100&page={page}"])
+        if not payload:
+            break
+        if not isinstance(payload, list):
+            raise RuntimeError(f"expected list payload from {path}, got {type(payload).__name__}")
+        items.extend(payload)
+        if len(payload) < 100:
+            break
+        page += 1
+    return items
+
+
+def review_threads(owner: str, repo: str, pr: int) -> list[dict[str, Any]]:
+    query = """
+query($owner:String!, $repo:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100, after:$after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:20) {
+            nodes {
+              id
+              url
+              body
+              path
+              line
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+    threads: list[dict[str, Any]] = []
+    after: str | None = None
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"repo={repo}",
+            "-F",
+            f"number={pr}",
+        ]
+        if after:
+            args += ["-F", f"after={after}"]
+        payload = gh_json(args)["data"]["repository"]["pullRequest"]["reviewThreads"]
+        threads.extend(payload["nodes"])
+        if not payload["pageInfo"]["hasNextPage"]:
+            break
+        after = payload["pageInfo"]["endCursor"]
+    return threads
+
+
+def checks(owner: str, repo: str, pr: int) -> list[dict[str, Any]]:
+    return gh_json(
+        [
+            "pr",
+            "checks",
+            str(pr),
+            "--repo",
+            f"{owner}/{repo}",
+            "--json",
+            "name,state,link,startedAt,completedAt",
+        ]
+    )
+
+
+def top_level_review_comments(pr_comments: list[dict[str, Any]], author: str) -> list[dict[str, Any]]:
+    replies_by_parent: dict[int, list[dict[str, Any]]] = {}
+    for comment in pr_comments:
+        parent = comment.get("in_reply_to_id")
+        if parent is not None:
+            replies_by_parent.setdefault(parent, []).append(comment)
+
+    top_level: list[dict[str, Any]] = []
+    for comment in pr_comments:
+        if comment.get("in_reply_to_id") is not None:
+            continue
+        replies = replies_by_parent.get(comment["id"], [])
+        top_level.append(
+            {
+                "id": comment["id"],
+                "author": comment["user"]["login"],
+                "path": comment.get("path"),
+                "line": comment.get("line"),
+                "url": comment.get("html_url"),
+                "body": comment.get("body", ""),
+                "reply_count": len(replies),
+                "author_reply_count": sum(1 for reply in replies if reply["user"]["login"] == author),
+                "reply_ids": [reply["id"] for reply in replies],
+            }
+        )
+    return top_level
+
+
+def bot_issue_comments(issue_comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": comment["id"],
+            "author": comment["user"]["login"],
+            "url": comment.get("html_url"),
+            "body": comment.get("body", ""),
+        }
+        for comment in issue_comments
+        if comment["user"].get("type") == "Bot"
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Inventory PR review surfaces for reconciliation.")
+    parser.add_argument("pr", type=int, help="Pull request number")
+    parser.add_argument("--repo", help="owner/repo (defaults to current gh repo)")
+    args = parser.parse_args()
+
+    owner, repo = repo_parts(args.repo)
+    author = viewer_login()
+    pr_comments = rest_pages(f"repos/{owner}/{repo}/pulls/{args.pr}/comments")
+    issue_comments = rest_pages(f"repos/{owner}/{repo}/issues/{args.pr}/comments")
+    threads = review_threads(owner, repo, args.pr)
+
+    payload = {
+        "repo": f"{owner}/{repo}",
+        "pr": args.pr,
+        "author": author,
+        "checks": checks(owner, repo, args.pr),
+        "review_threads": {
+            "total": len(threads),
+            "unresolved_count": sum(1 for thread in threads if not thread["isResolved"]),
+            "items": [
+                {
+                    "id": thread["id"],
+                    "is_resolved": thread["isResolved"],
+                    "is_outdated": thread["isOutdated"],
+                    "comments": [
+                        {
+                            "id": comment["id"],
+                            "author": comment["author"]["login"] if comment.get("author") else None,
+                            "path": comment.get("path"),
+                            "line": comment.get("line"),
+                            "url": comment.get("url"),
+                            "body": comment.get("body", ""),
+                        }
+                        for comment in thread["comments"]["nodes"]
+                    ],
+                }
+                for thread in threads
+            ],
+        },
+        "review_comments": {
+            "total": len(pr_comments),
+            "top_level_total": sum(1 for comment in pr_comments if comment.get("in_reply_to_id") is None),
+            "top_level": top_level_review_comments(pr_comments, author),
+        },
+        "issue_comments": {
+            "total": len(issue_comments),
+            "bot_total": sum(1 for comment in issue_comments if comment["user"].get("type") == "Bot"),
+            "bot": bot_issue_comments(issue_comments),
+        },
+    }
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/pr/SKILL.md
+++ b/core/pr/SKILL.md
@@ -20,6 +20,8 @@ Engineer shipping clean, well-documented PRs.
 
 Create a draft PR from current branch. Link to issue, make the significance obvious, give reviewers the value/trade-off context they need at a glance, and attach the walkthrough package that proves the merge case.
 
+`/pr` opens or updates the review lane. It does not certify that the live PR is review-clean after async reviewer automation runs.
+
 ## Latitude
 
 - Stage and commit any uncommitted changes with semantic message
@@ -59,8 +61,12 @@ Keep `Why This Matters`, `Trade-offs / Risks`, and the opening `What Changed` ex
 7. **Describe** — Title from issue, body follows [references/pr-body-template.md](./references/pr-body-template.md). Lead with significance/value/trade-offs, not the diff recap.
 8. **Before/After** — Use screenshots or evidence from visual QA, dogfood, and `/pr-walkthrough`. For non-UI changes, describe behavioral or architectural difference in text. If the PR body gets long, move heavy evidence into `<details>`.
 9. **Open / Update** — Use `gh pr create --draft --assignee phrazzld --body-file <path>` for new PRs. Use `gh pr edit --body-file <path>` when the branch already has a PR.
-10. **Comment** — Add context comment if notable decisions were made, and use `--body-file` for comment bodies.
-11. **Retro** — If this PR closes a GitHub issue, append implementation feedback:
+10. **Review Settlement Handoff** — If the final push, `gh pr ready`, or PR update triggered async reviewers:
+   - do not post `PR Unblocked` or claim the PR is review-clean
+   - route live review reconciliation through `/pr-fix`
+   - only treat the PR as unblocked after `/pr-fix` closes the post-settlement review inventory
+11. **Comment** — Add context comment if notable decisions were made, and use `--body-file` for comment bodies.
+12. **Retro** — If this PR closes a GitHub issue, append implementation feedback:
    ```bash
    /retro append --issue $ISSUE --predicted {effort_label} --actual {actual_effort} \
      --scope "{what_changed_from_spec}" --blocker "{blockers}" --pattern "{insight}"
@@ -78,4 +84,4 @@ Like a colleague leaving context for future-you:
 
 ## Output
 
-PR URL. Retro entry appended to `.groom/retro.md` (if issue-linked).
+PR URL. Retro entry appended to `.groom/retro.md` (if issue-linked). If review automation is pending or unresolved, say that explicitly instead of implying the PR is unblocked.

--- a/docs/walkthroughs/pr-fix-review-reconciliation.md
+++ b/docs/walkthroughs/pr-fix-review-reconciliation.md
@@ -1,0 +1,101 @@
+# PR Walkthrough: Review Reconciliation Redesign
+
+## Claim
+
+This branch closes the false-"PR Unblocked" gap by making `pr-fix` inventory-driven, settlement-gated, and explicit about handoff boundaries in `pr` and `autopilot`.
+
+## Renderer
+
+Diagram-led walkthrough with proof commands.
+
+## Why Now
+
+The old `pr-fix` shape let a PR look clean while old actionable review comments were still unresolved. That is a real workflow failure, not wording polish.
+
+## Before
+
+```mermaid
+graph TD
+  A["Green checks / mergeable"] --> B["Spot-check counts"]
+  B --> C["Resolve some threads"]
+  C --> D["Post PR Unblocked"]
+  D --> E["Older actionable comments can still be open"]
+```
+
+The failure mode was count-driven reconciliation. A temporary clean-looking surface could mask unresolved older review items.
+
+## What Changed
+
+```mermaid
+graph TD
+  A["Read PR state"] --> B["Build deterministic review inventory"]
+  B --> C["Create actionable ledger"]
+  C --> D["Fix / defer / reject every item"]
+  D --> E["Reply directly per item"]
+  E --> F["Resolve actionable threads"]
+  F --> G["Wait for async review automation to settle"]
+  G --> H["Rerun inventory"]
+  H --> I["Only then signal unblocked"]
+```
+
+The redesign moved the critical rule into the skill contract:
+- inventory beats counts
+- reply per actionable item
+- rerun inventory after async reviewers settle
+- `pr` and `autopilot` cannot imply review-clean status without `/pr-fix`
+
+## After
+
+```mermaid
+stateDiagram-v2
+  [*] --> DraftPR
+  DraftPR --> Reconciling: review findings arrive
+  Reconciling --> Waiting: replies posted + threads resolved
+  Waiting --> Reconciling: new async findings appear
+  Waiting --> ReviewClean: settled inventory is clean
+  ReviewClean --> [*]
+```
+
+The important change is not just "do more review." It is "do not signal success until the live PR inventory stays closed after settlement."
+
+## Evidence
+
+### Structural validation
+
+```bash
+python3 core/skill-builder/scripts/validate_skill.py core/pr-fix
+python3 core/skill-builder/scripts/validate_skill.py core/pr
+python3 core/skill-builder/scripts/validate_skill.py core/autopilot
+```
+
+Observed result:
+- `pr-fix`: valid, no warnings
+- `pr`: valid, no warnings
+- `autopilot`: valid, existing pre-branch warning about long body remains
+
+### Live failure-mode probe
+
+```bash
+python3 core/pr-fix/scripts/review_inventory.py 533 --repo misty-step/bitterblossom
+```
+
+Observed result:
+- unresolved threads: `6`
+- top-level review comments: `19`
+- bot issue comments: `4`
+- checks: `21`
+
+This is the key proof. The new inventory script exposes the exact missed state that previously slipped through.
+
+## Persistent Verification
+
+Current durable checks:
+- `python3 core/skill-builder/scripts/validate_skill.py core/pr-fix`
+- `python3 core/skill-builder/scripts/validate_skill.py core/pr`
+- `python3 core/skill-builder/scripts/validate_skill.py core/autopilot`
+
+These protect packaging and structural integrity of the skill changes.
+
+## Residual Gap
+
+There is still no fully automated regression harness that simulates delayed bot comments and proves the settlement gate behavior end-to-end. The branch improves the prompt contract and adds deterministic inventory tooling, but that live-review workflow is not yet mechanically tested.


### PR DESCRIPTION
## Why This Matters
- Problem: `/pr-fix` could leave a PR looking clean while older actionable review comments were still unresolved.
- Value: This makes review cleanup inventory-driven instead of count-driven, which closes a real false-confidence gap.
- Why now: A live run against `misty-step/bitterblossom#533` exposed the failure mode clearly.
- Issue: Closes #22.

## Trade-offs / Risks
- Value gained: `pr-fix` now has a deterministic review inventory, an explicit reconciliation ledger, and a hard post-settlement gate before `PR Unblocked` can be posted.
- Cost / risk incurred: The skill is stricter and a bit slower because it forces one more inventory pass after async reviewers settle.
- Why this is still the right trade: A slower truthful workflow is better than a fast false-clean signal.
- Reviewer watch-outs: Most of the protection is still prompt-contract plus tooling; there is not yet an end-to-end regression harness for delayed bot comments.

## What Changed
This branch turns `/pr-fix` into an inventory-and-settlement workflow instead of a counts-and-mergeability workflow, then updates adjacent delivery skills so they no longer imply review-clean status unless `/pr-fix` closes the live PR inventory.

### Base Branch
```mermaid
graph TD
  A["Green checks / mergeable"] --> B["Spot-check counts"]
  B --> C["Resolve some visible threads"]
  C --> D["Post PR Unblocked"]
  D --> E["Older actionable comments can still remain"]
```

### This PR
```mermaid
graph TD
  A["Read PR state"] --> B["Build deterministic inventory"]
  B --> C["Create actionable ledger"]
  C --> D["Fix / defer / reject each item"]
  D --> E["Reply directly per item"]
  E --> F["Resolve actionable threads"]
  F --> G["Wait for async review automation to settle"]
  G --> H["Rerun inventory"]
  H --> I["Only then signal unblocked"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> DraftPR
  DraftPR --> Reconciling: findings arrive
  Reconciling --> Waiting: replies posted + threads resolved
  Waiting --> Reconciling: new async findings appear
  Waiting --> ReviewClean: settled inventory is clean
  ReviewClean --> [*]
```

Why this is better:
- It makes the missed-state impossible to ignore because the workflow now starts with a full inventory.
- It separates “PR opened” from “PR review-clean,” which was previously too blurry across `pr`, `autopilot`, and `pr-fix`.

<details>
<summary>Intent Reference</summary>

## Intent Reference

Issue [#22](https://github.com/phrazzld/agent-skills/issues/22) captures the live failure:
- `/pr-fix` must inventory review threads, PR review comments, and bot issue comments
- every actionable item needs a `fix now | defer | reject` decision
- async reviewers must settle before any unblocked signal
- adjacent delivery skills must not imply review-clean status without `/pr-fix`

</details>

<details>
<summary>Changes</summary>

## Changes

- rewrote [`core/pr-fix/SKILL.md`](core/pr-fix/SKILL.md) around explicit invariants and hard-stop rules
- added [`core/pr-fix/references/reconciliation-ledger.md`](core/pr-fix/references/reconciliation-ledger.md)
- added [`core/pr-fix/references/workflow.md`](core/pr-fix/references/workflow.md)
- added [`core/pr-fix/scripts/review_inventory.py`](core/pr-fix/scripts/review_inventory.py)
- updated [`core/pr/SKILL.md`](core/pr/SKILL.md) so `/pr` opens the lane but does not imply review-clean status
- updated [`core/autopilot/SKILL.md`](core/autopilot/SKILL.md) so `/autopilot` explicitly hands live review cleanup to `/pr-fix`
- added the walkthrough artifact at [`docs/walkthroughs/pr-fix-review-reconciliation.md`](docs/walkthroughs/pr-fix-review-reconciliation.md)

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered

### Option A — Do nothing
- Upside: No workflow churn.
- Downside: The false-"unblocked" failure remains.
- Why rejected: We already hit the failure in live use.

### Option B — Add more warnings to `/pr-fix`
- Upside: Smaller diff.
- Downside: Still count-driven, still easy to skip complete reconciliation.
- Why rejected: This was a structural workflow gap, not a wording gap.

### Option C — Current approach
- Upside: Inventory, ledger, direct-reply rule, and settlement gate all become explicit.
- Downside: Slightly heavier workflow and more supporting files.
- Why chosen: It directly targets the real failure mode and gives adjacent skills clean boundaries.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria

- [x] `/pr-fix` requires a deterministic review inventory before signaling success
- [x] `/pr-fix` requires a per-item decision and direct replies for actionable findings
- [x] `/pr-fix` forbids `PR Unblocked` before post-settlement reconciliation
- [x] `/pr` no longer implies that an opened PR is review-clean
- [x] `/autopilot` no longer implies that a shipped draft PR is review-clean

</details>

<details>
<summary>Manual QA</summary>

## Manual QA

```bash
python3 core/skill-builder/scripts/validate_skill.py core/pr-fix
python3 core/skill-builder/scripts/validate_skill.py core/pr
python3 core/skill-builder/scripts/validate_skill.py core/autopilot
python3 core/pr-fix/scripts/review_inventory.py 533 --repo misty-step/bitterblossom
./scripts/sync.sh all
```

Expected result:
- all three skills validate successfully
- `review_inventory.py` exposes the live missed state on PR `#533`
- sync completes cleanly across local harnesses

Observed live probe summary:
- unresolved threads: `6`
- top-level review comments: `19`
- bot issue comments: `4`
- checks: `21`

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough

- Renderer: Diagram-led walkthrough
- Artifact: [docs/walkthroughs/pr-fix-review-reconciliation.md](https://github.com/phrazzld/agent-skills/blob/codex/pr-fix-review-reconciliation/docs/walkthroughs/pr-fix-review-reconciliation.md)
- Claim: This branch closes the false-"PR Unblocked" gap by forcing inventory-based reconciliation and post-settlement verification.
- Before / After scope: `pr-fix`, plus handoff boundaries in `pr` and `autopilot`
- Persistent verification: `python3 core/skill-builder/scripts/validate_skill.py core/pr-fix`
- Residual gap: There is still no end-to-end automated harness for delayed bot comments.

</details>

<details>
<summary>Before / After</summary>

## Before / After

Before:
- a PR could look mergeable and partially reviewed while old actionable comments still existed
- adjacent delivery skills were too loose about the difference between “opened a PR” and “review-clean PR”

After:
- `/pr-fix` is explicit about inventory, ledger closure, direct replies, and settlement
- `/pr` and `/autopilot` treat review-clean status as a `/pr-fix` concern instead of implying it themselves

Screenshots are not needed because this change is internal skill/process behavior.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage

- structural validation via `core/skill-builder/scripts/validate_skill.py`
- live inventory smoke check via `core/pr-fix/scripts/review_inventory.py 533 --repo misty-step/bitterblossom`

Known gap:
- no mocked end-to-end regression test for delayed async review comments yet

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence

- Confidence level: Medium-high
- Strongest evidence: the new inventory script surfaces the exact unresolved review state that triggered this redesign
- Remaining uncertainty: prompt-level workflow changes are harder to prove exhaustively than code-level logic with full fixtures
- What could still go wrong after merge: future skills outside this repo-local PR flow could still imply review-clean status unless they adopt the same contract

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR workflow guidance to clarify review process boundaries and merge readiness criteria.
  * Added comprehensive documentation on review reconciliation procedures and inventory-based settlement workflows.

* **Improvements**
  * Enhanced PR-fix workflow with systematic review tracking and explicit merge state validation before signaling completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->