### PR TITLE
Wire verify-ac into /autopilot pipeline

### DIFF
--- a/.groom/retro.md
+++ b/.groom/retro.md
@@ -8,3 +8,12 @@
 - scope: created foundational `core/verify-ac/SKILL.md`; no runtime scripts required
 - blocker: none
 - pattern: AC enforcement works best as a composable reference skill with explicit retry + hard gate semantics
+
+## 2026-03-10 — Issue #5
+
+- issue: #5
+- predicted: effort/s
+- actual: effort/s
+- scope: wired `verify-ac` into `core/autopilot/SKILL.md` as a hard pre-commit gate and into `core/pr-fix/references/workflow.md` as a self-review secondary check
+- blocker: none
+- pattern: verification skills become real quality gates only when the delivery workflow names the exact stop condition and failure semantics

--- a/.groom/walkthroughs/issue-5-verify-ac.md
+++ b/.groom/walkthroughs/issue-5-verify-ac.md
@@ -27,7 +27,7 @@ Evidence:
 graph TD
   A[Dogfood QA passes] --> B[Verify ACs via verify-ac]
   B -->|all ACs verified or partial only| C[Walkthrough]
-  B -->|any AC still unverified after 2 attempts| D[Stop and flag blocker]
+  B -->|any AC still unverified after 2 attempts| D[Remediate and rerun verify-ac]
   C --> E[Commit]
   E --> F[Draft PR]
 ```

--- a/.groom/walkthroughs/issue-5-verify-ac.md
+++ b/.groom/walkthroughs/issue-5-verify-ac.md
@@ -1,0 +1,63 @@
+# Walkthrough — Issue #5
+
+## Merge Claim
+
+`/autopilot` now treats acceptance-criteria verification as a hard gate before commit, and `/pr-fix` now re-checks linked issue acceptance criteria during self-review.
+
+## Why Now
+
+Before this branch, the delivery lane could copy issue acceptance criteria into a PR body without ever verifying that the implementation still satisfied them. The `verify-ac` skill existed, but the pipeline did not require it.
+
+## Before
+
+```mermaid
+graph TD
+  A[Dogfood QA passes] --> B[Walkthrough]
+  B --> C[Commit]
+  C --> D[Draft PR]
+```
+
+Evidence:
+- `grep -n 'Dogfood\\|verify-ac\\|Commit' core/autopilot/SKILL.md` showed no `verify-ac` gate between dogfood and commit.
+- `grep -n 'verify-ac' core/pr-fix/SKILL.md core/pr-fix/references/workflow.md` returned no matches.
+
+## What Changed
+
+```mermaid
+graph TD
+  A[Dogfood QA passes] --> B[Verify ACs via verify-ac]
+  B -->|all ACs verified or partial only| C[Walkthrough]
+  B -->|any AC still unverified after 2 attempts| D[Stop and flag blocker]
+  C --> E[Commit]
+  E --> F[Draft PR]
+```
+
+```mermaid
+sequenceDiagram
+  participant AP as /autopilot
+  participant VA as verify-ac
+  participant PF as /pr-fix self-review
+  AP->>VA: verify linked issue acceptance criteria
+  VA-->>AP: VERIFIED / PARTIAL / UNVERIFIED
+  AP-->>AP: block commit if any AC remains UNVERIFIED
+  PF->>VA: rerun AC verification during self-review
+  VA-->>PF: secondary check evidence
+```
+
+## After
+
+Evidence:
+- `grep -n 'Dogfood\\|Verify ACs\\|verify-ac\\|Commit' core/autopilot/SKILL.md`
+- `grep -n 'verify-ac\\|Acceptance Criteria\\|self-review complete' core/pr-fix/SKILL.md core/pr-fix/references/workflow.md`
+- `python3 core/skill-creator/scripts/quick_validate.py core/autopilot`
+- `python3 core/skill-creator/scripts/quick_validate.py core/pr-fix`
+
+## Persistent Verification
+
+- `grep -n 'Dogfood\\|Verify ACs\\|verify-ac\\|Commit' core/autopilot/SKILL.md`
+- `python3 core/skill-creator/scripts/quick_validate.py core/autopilot`
+- `python3 core/skill-creator/scripts/quick_validate.py core/pr-fix`
+
+## Residual Risk
+
+This branch updates workflow contracts, not executable orchestration code. The protection is therefore documentation- and structure-level, not runtime-enforced automation.

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -109,6 +109,11 @@ The point is single ownership. One issue should map to one active autopilot lane
     - Optional accelerator: use an `ousterhout` persona/agent if the harness provides one
 11. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
    Iterate until no P0/P1 issues remain. **Do not open a PR until QA passes.**
+11a. **Verify ACs** — Invoke `verify-ac` against the linked issue's `## Acceptance Criteria`.
+   - Honor explicit AC tags (`[test]`, `[command]`, `[behavioral]`) when present; otherwise let `verify-ac` choose the narrowest credible strategy from the diff and repo context
+   - Retry `UNVERIFIED` checks once (2 attempts total)
+   - If any AC remains `UNVERIFIED` after attempt 2: flag the blocker to the user and stop before commit/ship
+   - `PARTIAL` may proceed only if no AC is `UNVERIFIED`, but it must be reported in the final handoff and PR body
 12. **Walkthrough** — Run `/pr-walkthrough` and produce the mandatory walkthrough package for the branch. Every PR needs an artifact, even if the change is internal or architectural.
 13. **Commit** — Create semantic commits for all remaining changes:
     - Categorize files: commit, gitignore, delete, consolidate

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -112,7 +112,8 @@ The point is single ownership. One issue should map to one active autopilot lane
 11a. **Verify ACs** — Invoke `verify-ac` against the linked issue's `## Acceptance Criteria`.
    - Honor explicit AC tags (`[test]`, `[command]`, `[behavioral]`) when present; otherwise let `verify-ac` choose the narrowest credible strategy from the diff and repo context
    - Retry `UNVERIFIED` checks once (2 attempts total)
-   - If any AC remains `UNVERIFIED` after attempt 2: flag the blocker to the user and stop before commit/ship
+   - If any AC remains `UNVERIFIED` after attempt 2: keep remediating the code, tests, or docs and rerun `verify-ac`; do not commit or ship while the gate is failing
+   - Escalate to the user only when further progress is genuinely blocked after reasonable remediation attempts
    - `PARTIAL` may proceed only if no AC is `UNVERIFIED`, but it must be reported in the final handoff and PR body
 12. **Walkthrough** — Run `/pr-walkthrough` and produce the mandatory walkthrough package for the branch. Every PR needs an artifact, even if the change is internal or architectural.
 13. **Commit** — Create semantic commits for all remaining changes:

--- a/core/pr-fix/references/workflow.md
+++ b/core/pr-fix/references/workflow.md
@@ -65,6 +65,11 @@ Look for:
 
 Fix what you find. Re-run the relevant verification before moving on.
 
+If the PR links an issue with `## Acceptance Criteria`, run `verify-ac` as a secondary check before leaving self-review:
+- treat `UNVERIFIED` criteria as a blocker to resolve or defer explicitly before signaling the branch is clean
+- treat `PARTIAL` as advisory evidence to report in the PR, not a hard stop by default
+- never mark self-review complete while acceptance-criteria drift is still unexplained
+
 ## 5. Build the Review Inventory
 
 Read [reconciliation-ledger.md](./reconciliation-ledger.md) and use the inventory script.


### PR DESCRIPTION
## Why This Matters
- Problem: `/autopilot` could move from dogfood QA to commit without ever machine-checking the linked issue's acceptance criteria, which made ACs in the PR body easy to copy but easy to drift from reality.
- Value: This adds an explicit acceptance-criteria gate to the delivery lane and makes `/pr-fix` re-check that same contract during self-review.
- Why now: `verify-ac` already exists in the repo, but until the orchestration skills require it, the verification layer is optional in practice.
- Issue: Closes #5

## Trade-offs / Risks
- Value gained: The pipeline now names the exact stop condition for AC drift and tells operators when they must keep remediating before commit.
- Cost / risk incurred: This is still a documentation-level workflow contract, not executable orchestration code, so compliance depends on agents following the skill.
- Why this is still the right trade: This repo is a skill library; the authoritative behavior lives in the skill text, so tightening that contract is the correct delivery surface.
- Reviewer watch-outs: Pressure-test whether `PARTIAL` handling in `autopilot` is the right threshold and whether `pr-fix` should stay advisory rather than hard-blocking.

## What Changed
This branch turns `verify-ac` from an available reference skill into an explicit part of the delivery workflow. `autopilot` now hard-gates before commit when any linked acceptance criterion remains unverified after two attempts, requiring remediation and re-verification before the lane can move forward, and `pr-fix` now treats acceptance-criteria verification as part of self-review.

### Base Branch
```mermaid
graph TD
  A[Dogfood QA passes] --> B[Walkthrough]
  B --> C[Commit]
  C --> D[Draft PR]
```

### This PR
```mermaid
graph TD
  A[Dogfood QA passes] --> B[Verify ACs]
  B -->|all VERIFIED or PARTIAL only| C[Walkthrough]
  B -->|any UNVERIFIED after 2 attempts| D[Remediate and rerun verify-ac]
  C --> E[Commit]
  E --> F[Draft PR]
```

### Architecture / State Change
```mermaid
sequenceDiagram
  participant AP as /autopilot
  participant VA as verify-ac
  participant PF as /pr-fix
  AP->>VA: verify linked issue acceptance criteria
  VA-->>AP: VERIFIED / PARTIAL / UNVERIFIED
  AP-->>AP: keep remediating until no AC remains UNVERIFIED before commit
  PF->>VA: rerun AC verification during self-review
  VA-->>PF: advisory verification evidence
```

Why this is better:
- It makes acceptance-criteria compliance a named gate in the pipeline instead of an implied reviewer expectation.
- It reuses the existing `verify-ac` deep module rather than inventing new heuristic wording inside each orchestrator.
- It gives reviewers a clearer merge case: dogfood QA checks user flow, `verify-ac` checks issue intent.

<details>
<summary>Intent Reference</summary>

## Intent Reference
Issue [#5](https://github.com/phrazzld/agent-skills/issues/5) requires a new pre-commit verification step in `/autopilot` and a secondary `verify-ac` check in `/pr-fix` self-review.

Intent contract summary:
- add a hard verification gate before commit in `/autopilot`
- do not allow the lane to commit while any AC remains `UNVERIFIED`
- re-check linked issue ACs during `/pr-fix` self-review so review cleanup catches intent drift

</details>

<details>
<summary>Changes</summary>

## Changes
- Updated `core/autopilot/SKILL.md` to add `11a. Verify ACs` between dogfood QA and walkthrough/commit with explicit remediation and re-verification semantics for `UNVERIFIED` ACs.
- Updated `core/pr-fix/references/workflow.md` so self-review now includes `verify-ac` when the PR links an issue with acceptance criteria.
- Added `.groom/walkthroughs/issue-5-verify-ac.md` as the branch walkthrough artifact.
- Appended `.groom/retro.md` with the pattern learned from this integration.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: No doc churn.
- Downside: `verify-ac` remains optional in the main delivery lane.
- Why rejected: It leaves the exact problem in place.

### Option B — Mention `verify-ac` only in `/pr-fix`
- Upside: Smaller diff.
- Downside: The lane could still commit and open a PR before acceptance criteria were checked.
- Why rejected: The issue is specifically about `/autopilot` missing a hard gate.

### Option C — Current approach
- Upside: Adds the hard gate where the lane commits work, while also reusing the same check during review cleanup.
- Downside: Still relies on agents following skill text rather than executable enforcement.
- Why chosen: In this repo, the skill contract is the implementation surface.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given `/autopilot` completes dogfood QA, when it proceeds, then it invokes `verify-ac` before committing.
- [x] Given any AC is `UNVERIFIED` after 2 attempts, when `verify-ac` reports failure, then autopilot keeps remediating, flags the user only if genuinely blocked, and does not commit.
- [x] Given all ACs are `VERIFIED`, when `verify-ac` completes, then autopilot proceeds to the commit step.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
grep -q 'verify-ac' core/autopilot/SKILL.md
grep -n 'Dogfood\|Verify ACs\|verify-ac\|Commit' core/autopilot/SKILL.md
python3 core/skill-creator/scripts/quick_validate.py core/autopilot
python3 core/skill-creator/scripts/quick_validate.py core/pr-fix
```

Expected results:
- `verify-ac` appears in the autopilot workflow between dogfood QA and commit.
- both modified skills validate successfully.

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: Diagram-led terminal walkthrough
- Artifact: [.groom/walkthroughs/issue-5-verify-ac.md](https://github.com/phrazzld/agent-skills/blob/codex/issue-5-verify-ac-autopilot/.groom/walkthroughs/issue-5-verify-ac.md)
- Claim: `/autopilot` now blocks commit on unresolved AC verification while requiring remediation/re-verification, and `/pr-fix` now re-checks linked issue ACs during self-review.
- Before / After scope: Delivery-pipeline skill contract and review-cleanup workflow contract.
- Persistent verification: `python3 core/skill-creator/scripts/quick_validate.py core/autopilot` and `python3 core/skill-creator/scripts/quick_validate.py core/pr-fix`
- Residual gap: The workflow is enforced by skill contract text, not by executable runtime orchestration.

</details>

<details>
<summary>Before / After</summary>

## Before / After
Before: the skill library defined dogfood QA as the last explicit gate before walkthrough/commit, and `/pr-fix` had no acceptance-criteria recheck during self-review.

After: the library names `verify-ac` as the acceptance-criteria gate before commit in `/autopilot` and as a secondary self-review check in `/pr-fix`.

No screenshots are needed because the change is internal to workflow instructions.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `python3 core/skill-creator/scripts/quick_validate.py core/autopilot`
- `python3 core/skill-creator/scripts/quick_validate.py core/pr-fix`
- `grep -n 'Dogfood\|Verify ACs\|verify-ac\|Commit' core/autopilot/SKILL.md`

Gap:
- No executable orchestration tests exist in this repo; the regression protection is skill validation plus workflow-structure assertions.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: High
- Strongest evidence: The workflow text now contains the exact blocking semantics requested by the issue, and both modified skills validate cleanly.
- Remaining uncertainty: This does not add runtime enforcement beyond the skill contract itself.
- What could still go wrong after merge: A future edit could drift the contract again unless a stronger structural test is added later.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive walkthrough documenting acceptance criteria verification workflow.
  * Added retro entry documenting Issue #5.

* **Process Updates**
  * Acceptance criteria verification is now a required pre-commit gate.
  * Added secondary self-review checks for linked acceptance criteria.
  * Updated workflow guidance for handling verified, partial, and unverified criteria states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->