### PR TITLE
feat: add ux-polish skill

### DIFF
--- a/.groom/walkthroughs/ux-polish-skill.md
+++ b/.groom/walkthroughs/ux-polish-skill.md
@@ -1,0 +1,68 @@
+# Walkthrough — ux-polish skill
+
+## Merge Claim
+
+`/ux-polish` now gives the repo a dedicated workflow for small, meaningful UX improvements, sitting between broad design work and large simplification work.
+
+## Why Now
+
+Before this branch, the closest fits were `/design`, `ui-skills`, and `/simplify`. Those covered system design, passive UI constraints, and large refactors, but there was no explicit lane for "find one narrow UX friction point and ship the fix."
+
+## Before
+
+```mermaid
+graph TD
+  A["User wants a small UX improvement"] --> B["Reach for /design"]
+  A --> C["Reach for ui-skills"]
+  A --> D["Reach for /simplify"]
+  B --> E["Broader exploration than needed"]
+  C --> F["Constraints, but no workflow"]
+  D --> G["Too architecture-heavy for micro polish"]
+```
+
+Evidence:
+- `rg -n "ux-polish|small UX|micro polish" README.md core` returned no existing workflow skill.
+- `core/design/SKILL.md` focuses on exploration, audit, tokens, and system-level implementation.
+- `core/ui-skills/SKILL.md` provides constraints, not a scoped polish workflow.
+- `core/simplify/SKILL.md` targets one high-leverage architectural refactor per PR.
+
+## What Changed
+
+```mermaid
+graph TD
+  A["User wants a small UX improvement"] --> B["Run /ux-polish"]
+  B --> C["Audit one route, flow, or component"]
+  C --> D["Score candidates with polish rubric"]
+  D --> E["Ship one coherent UX polish pass"]
+  E --> F["Verify with expert-panel review and visual QA"]
+```
+
+```mermaid
+graph TD
+  A["/ux-polish SKILL.md"] --> B["Guardrails for narrow scope"]
+  A --> C["Workflow tied to ui-skills and design"]
+  C --> D["Use ui-skills for implementation constraints"]
+  C --> E["Escalate to /design when polish becomes system design"]
+  A --> F["references/polish-rubric.md"]
+  F --> G["Rank impact, proof path, accessibility, and risk"]
+  H["README skill index"] --> I["Expose the new command"]
+```
+
+## After
+
+Evidence:
+- `core/ux-polish/SKILL.md`
+- `core/ux-polish/references/polish-rubric.md`
+- `README.md`
+- `python3 core/skill-builder/scripts/validate_skill.py core/ux-polish`
+- `python3 core/skill-creator/scripts/package_skill.py core/ux-polish /tmp/agent-skills-packages`
+- `./scripts/sync.sh all`
+
+## Persistent Verification
+
+- `python3 core/skill-builder/scripts/validate_skill.py core/ux-polish`
+- `python3 core/skill-creator/scripts/package_skill.py core/ux-polish /tmp/agent-skills-packages`
+
+## Residual Risk
+
+This branch adds documentation-driven workflow guidance, not executable product code. The risk is mainly overlap with adjacent skills, which is mitigated by the explicit "out of scope" section and the handoff rules to `ui-skills`, `/design`, and `/simplify`.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Domains: bitcoin, btcpay, bun, docs, landing, lightning, observability, onboardi
 | Skill | Mode | Description |
 |-------|------|-------------|
 | `/design` | Model+User | Full design system: tokens, exploration, Vercel patterns |
+| `/ux-polish` | DMI | Narrow UX refinement: pick one small, meaningful friction point and ship the fix with QA |
 | `/visual-qa` | Model+User | Pre-commit visual regression |
 | `ui-skills` | Reference | Opinionated UI constraints |
 | `/visualize` | DMI | Visual HTML deliverables |

--- a/core/ux-polish/SKILL.md
+++ b/core/ux-polish/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: ux-polish
+description: |
+  Find and ship the smallest UX improvement that meaningfully reduces friction in a working product.
+  Use when a flow basically works but feels rough: unclear affordances, weak feedback, awkward spacing,
+  fragile empty/loading/error states, poor focus order, or mobile hit-target issues. Not for rebrands,
+  broad redesigns, or architecture refactors. Keywords: /ux-polish, polish this flow, tighten UX,
+  small UX win, reduce friction, micro-interaction, empty state, loading state, error state.
+disable-model-invocation: true
+argument-hint: "[route, flow, or component]"
+---
+
+# /ux-polish
+
+Make one narrow UX improvement users will actually notice.
+
+## Role
+
+Product-minded frontend editor. Find the smallest change that removes real user friction without turning the task into a redesign.
+
+## Objective
+
+For the whole repo or `$ARGUMENTS`, answer four questions with evidence:
+
+1. Which user journey or surface is under review?
+2. What specific friction is most likely costing clarity, trust, speed, or completion?
+3. Which narrowly scoped polish pass removes that friction without reopening system design?
+4. How will you prove the experience is better after the change?
+
+Then implement the winning polish pass, verify it visually and behaviorally, and ship it.
+
+## Guardrails
+
+- Work inside one route, flow, or tightly related interaction surface
+- Prefer one coherent polish pass over a bag of unrelated nits
+- Bias toward clarity, feedback, accessibility, and ergonomic wins users feel immediately
+- If the best fix requires new IA, new flows, or a broader aesthetic system change, stop and hand off to `../design/SKILL.md`
+- Invoke `../ui-skills/SKILL.md` before touching UI code; if its preferred delegation path is unavailable, apply the same constraints manually and say so
+
+## Workflow
+
+1. **Establish the surface** — Read the nearest `AGENTS.md`, `CLAUDE.md`, and `README`, then inspect the route, component, copy, and current states for the target flow. Capture the exact entrypoint, happy path, and failure, empty, and loading states.
+2. **Name the friction** — Describe the highest-leverage problem in plain language: what confuses users, slows them down, or makes the UI feel less trustworthy. Ignore ornamental tweaks that do not change user outcomes.
+3. **Score candidates** — Read `references/polish-rubric.md`. Generate several micro-polish options, then rank them by user impact, scope fit, reversibility, accessibility, and proof path.
+4. **Choose one polish pass** — Pick the single best improvement or one tiny cluster that solves the same root problem. State what is in scope, what is out of scope, and what behavior must stay unchanged.
+5. **Implement with constraints** — Apply `ui-skills` rules: accessible primitives, local feedback, no decorative animation, no gratuitous gradients, proper touch targets, balanced typography, and safe viewport usage. Use `../design/SKILL.md` only for targeted taste checks or when design debt clearly blocks the polish.
+6. **Review like a designer** — Run the `ui-skills` expert-panel review on the affected surface. If the average is below 90, refine and re-review before continuing.
+7. **Verify what users see** — Run `../visual-qa/SKILL.md` for the affected route or component surface. Fix all P0 and P1 issues. Also verify the functional state that changed: keyboard path, empty/error/loading handling, or mobile tap target behavior.
+8. **Ship the small win** — Update docs only if behavior or expectations changed. If the repo is already in a PR workflow, invoke `../pr/SKILL.md`; otherwise report the change, evidence, and the next highest-leverage polish item left behind.
+
+## Good Targets
+
+- Empty states with no clear next action
+- Error or validation feedback that is missing, vague, or far from the action
+- Loading states that feel jumpy, blank, or misleading
+- Ambiguous buttons, labels, CTA copy, or hierarchy
+- Small mobile ergonomics issues: hit targets, density, or safe-area problems
+- Focus, keyboard, or screen-reader polish that removes friction without re-architecting the flow
+
+## Out of Scope
+
+- Rebrands, visual overhauls, or net-new design systems
+- Information architecture changes spanning multiple flows
+- Large refactors better handled by `/simplify`
+- New feature work disguised as polish
+- Animation or ornament added without clear UX benefit
+
+## Output
+
+Default deliverable:
+
+- Surface and user journey audited
+- Candidate polish options with rubric scores
+- Chosen polish pass and scope boundary
+- Verification evidence: expert-panel result plus visual and behavioral checks
+- Remaining follow-up polish ideas, if any
+
+## References
+
+- `references/polish-rubric.md`

--- a/core/ux-polish/references/polish-rubric.md
+++ b/core/ux-polish/references/polish-rubric.md
@@ -1,0 +1,65 @@
+# Polish Rubric
+
+Use this to choose one small UX fix that has outsized user value.
+
+## Good Candidate Types
+
+- **Clarity** — labels, CTA text, hierarchy, affordance, destructive-action framing
+- **Feedback** — success, error, validation, loading, progress, or save-state visibility
+- **Recovery** — empty states, retry paths, inline guidance, next actions after failure
+- **Ergonomics** — touch targets, density, spacing, safe-area handling, focus order
+- **Accessibility** — non-color feedback, keyboard reachability, screen-reader-visible status
+
+## Scoring
+
+Score each candidate from `0-3` on the first five dimensions. Subtract risk at the end.
+
+| Dimension | 0 | 1 | 2 | 3 |
+|-----------|---|---|---|---|
+| **User impact** | Cosmetic only | Nice improvement | Noticeably reduces friction | Removes likely confusion or failure on a meaningful path |
+| **Frequency / importance** | Rare edge case | Occasional path | Common path or key state | High-traffic or high-stakes path |
+| **Scope fit** | Multi-flow redesign | Large surface | One route with spillover | One route, component, or interaction seam |
+| **Proof path** | Hard to verify | Subjective only | Visual or behavioral proof exists | Can verify visually and behaviorally today |
+| **Accessibility / ergonomics** | No clear gain | Minor gain | Fixes a real usability gap | Fixes a gap likely affecting completion or confidence |
+| **Risk / churn** | 0 = trivial | 1 = moderate | 2 = meaningful | 3 = likely to reopen design or behavior assumptions |
+
+`total = impact + frequency + scope fit + proof path + accessibility - risk`
+
+Prefer the highest-scoring candidate that stays inside one coherent user surface.
+If nothing scores at least `8`, the area may not be worth a dedicated polish pass.
+
+## Selection Rules
+
+- Reject "grab bag" polish lists unless every item solves the same root friction
+- Prefer fixes at decision points, state transitions, and recovery moments over decorative cleanup
+- Prefer user-facing clarity over animation, ornament, or generic modernization
+- If repeated inconsistencies point to missing tokens, component debt, or broader visual drift, escalate to `../design/SKILL.md`
+- If the root problem is tangled state, pass-through logic, or module sprawl, escalate to `../simplify/SKILL.md`
+
+## Grounded Heuristics
+
+Use current platform guidance as the tie-breaker:
+
+- Keep errors identifiable and close to the relevant action or field
+- Make status changes perceivable without relying on color alone
+- Ensure interactive targets are generous enough for touch use
+- Give empty and failure states one clear next step
+- Prefer immediate local feedback over delayed or detached messaging
+
+These heuristics align with current W3C accessibility guidance and platform layout guidance.
+
+## Worthy Wins
+
+- Move validation copy under the offending field and focus it after submit
+- Replace a blank loading gap with a structural skeleton that preserves layout
+- Add a clear empty-state CTA instead of passive copy
+- Expand a cramped mobile action target and add safe-area padding
+- Clarify destructive actions with explicit consequence language and an alert dialog
+
+## Anti-Patterns
+
+- "Make it feel more premium"
+- Tweaking unrelated spacing issues across five pages
+- Adding animation because the screen feels static
+- Introducing a new component or feature and calling it polish
+- Using polish to avoid naming the real architectural problem


### PR DESCRIPTION
## Reviewer Evidence
- Start here: [walkthrough artifact](../blob/codex/add-ux-polish-skill/.groom/walkthroughs/ux-polish-skill.md)
- Direct video download: Not applicable; this PR uses a diagram-led walkthrough
- Walkthrough notes: [ux-polish walkthrough](../blob/codex/add-ux-polish-skill/.groom/walkthroughs/ux-polish-skill.md)
- Fast claim: This branch adds a dedicated `/ux-polish` lane for small, high-leverage UX improvements so agents stop overreaching into `/design` or `/simplify` for micro polish work.

## Why This Matters
- Problem: The repo had strong skills for design systems, passive UI constraints, and large simplification passes, but no explicit workflow for one narrow UX polish win.
- Value: Agents now have a clear command for finding and shipping a small UX improvement with scope control, scoring, and verification.
- Why now: The gap showed up directly in the request, and the new skill fits the existing skill taxonomy cleanly.
- Issue: None; direct user-requested skill addition.

## Trade-offs / Risks
- Value gained: Better routing for small UX tasks, less ambiguity between system design, passive constraints, and architecture work.
- Cost / risk incurred: Another command in the skill surface, plus some conceptual overlap with `/design`, `ui-skills`, and `/simplify`.
- Why this is still the right trade: The new skill is intentionally narrow and explicitly hands off broader work to those adjacent skills.
- Reviewer watch-outs: Pressure-test whether the scope boundary is crisp enough and whether the rubric favors meaningful UX wins over cosmetic churn.

## What Changed
This branch adds a new DMI workflow skill, `/ux-polish`, that mirrors the shape of `/simplify` but narrows the task to one meaningful UX friction point. It also adds a rubric reference for scoring candidate polish items and indexes the command in the README so the new lane is visible in the Design & Visual section.

### Base Branch
```mermaid
graph TD
  A[Need a small UX improvement] --> B[/design]
  A --> C[ui-skills]
  A --> D[/simplify]
  B --> E[Too broad for micro polish]
  C --> F[Constraints only]
  D --> G[Architecture-first refactor lane]
```

### This PR
```mermaid
graph TD
  A[Need a small UX improvement] --> B[/ux-polish]
  B --> C[Audit one route flow or component]
  C --> D[Score candidates with polish rubric]
  D --> E[Pick one coherent polish pass]
  E --> F[Verify with expert panel and visual QA]
```

### Architecture / State Change
```mermaid
graph TD
  A[core/ux-polish/SKILL.md] --> B[Narrow workflow and guardrails]
  A --> C[Compose adjacent skills]
  C --> D[ui-skills constraints and expert review]
  C --> E[/design handoff for broader design debt]
  C --> F[/simplify handoff for architecture problems]
  A --> G[references/polish-rubric.md]
  H[README] --> I[Command discoverability]
```

Why this is better:
- It gives agents a purpose-built lane for small UX wins instead of forcing an awkward choice between overly broad neighboring skills.
- It keeps the command surface honest by defining good targets, out-of-scope work, and explicit escalation points.
- It codifies a repeatable rubric so “polish” means user-visible friction reduction, not random visual tinkering.

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Source: direct user request in this session
- Intent: create a new skill similar to `/simplify` but focused on narrowly scoped UX polish items that meaningfully improve the experience
- Required composition: `ui-skills`, `design`, and `skill-creator`

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `core/ux-polish/SKILL.md` with role, objective, guardrails, workflow, target list, and output contract
- Added `core/ux-polish/references/polish-rubric.md` to score candidates on impact, scope fit, proof path, accessibility, and risk
- Added `.groom/walkthroughs/ux-polish-skill.md` as the PR walkthrough artifact
- Indexed `/ux-polish` in `README.md`

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Add a new skill similar in shape to `/simplify`
- [x] Keep the skill focused on small, meaningful UX polish items
- [x] Compose `ui-skills` and `/design` rather than duplicating them
- [x] Keep the skill lean, with detail moved into a reference file
- [x] Validate and package the skill successfully
- [x] Sync core skills after adding the new command

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: No new command surface
- Downside: Agents keep reaching for adjacent skills that are either too broad or not workflow-oriented
- Why rejected: The gap is real and the request was explicit

### Option B — Fold this into `/design`
- Upside: Fewer top-level commands
- Downside: Dilutes `/design` with a micro-polish workflow that is much narrower than its current system-design charter
- Why rejected: `/design` already has a large surface and is not the right entrypoint for small UX wins

### Option C — Current approach
- Upside: Keeps a narrow, DMI-only workflow with clear handoff rules to adjacent skills
- Downside: Adds one more command to the catalog
- Why chosen: The scope is crisp enough to justify a dedicated lane

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- `python3 core/skill-builder/scripts/validate_skill.py core/ux-polish`
- `python3 core/skill-creator/scripts/package_skill.py core/ux-polish /tmp/agent-skills-packages`
- `./scripts/sync.sh all`
- `gh pr status` and `gh pr list --state open --search "ux-polish repo:phrazzld/agent-skills" --json number,title,headRefName,url`

Notes:
- `visual-qa` not applicable; no frontend product surface changed
- `dogfood` not applicable; this repo does not ship a local app to exercise

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: Diagram-led walkthrough
- Artifact: [ux-polish walkthrough](../blob/codex/add-ux-polish-skill/.groom/walkthroughs/ux-polish-skill.md)
- Claim: The repo now has a dedicated, narrowly scoped workflow for small UX polish work
- Before / After scope: Skill routing before and after this new command, plus the rubric/reference structure added on this branch
- Persistent verification: `python3 core/skill-builder/scripts/validate_skill.py core/ux-polish`
- Residual gap: This is a docs-and-workflow change, so protection is structural validation rather than runtime behavior tests

</details>

<details>
<summary>Before / After</summary>

## Before / After
Before: the nearest options were `/design`, `ui-skills`, and `/simplify`, none of which owned the “one small UX win” problem cleanly.

After: `/ux-polish` now owns that lane with explicit guardrails, a scoring rubric, and verification expectations.

Screenshots are not applicable because this PR adds skill documentation, not product UI.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- Structural validation via `python3 core/skill-builder/scripts/validate_skill.py core/ux-polish`
- Packaging validation via `python3 core/skill-creator/scripts/package_skill.py core/ux-polish /tmp/agent-skills-packages`

Gap:
- This repo does not have an executable test suite for skill behavior; validation is metadata- and packaging-level.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: High
- Strongest evidence: clean validator run, successful packaging, successful core skill sync, and a tightly scoped four-file diff
- Remaining uncertainty: reviewers may want sharper wording around overlap with adjacent skills
- What could still go wrong after merge: if the scope boundary feels too fuzzy in practice, agents may still bounce between `/ux-polish` and `/design`

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive UX polish skill documentation with workflow guides and process definitions
  * Includes evaluation framework with multi-dimensional scoring rubric for prioritizing improvements
  * Provides verification procedures and reference materials for implementation guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->