### PR TITLE
docs: harden delivery evidence, artifact hygiene, and completion gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,3 +186,12 @@ See `skill-builder` (absorption lifecycle) and `skill-creator` (umbrella creatio
 - **Budget-aware** — use DMI for user-only workflows to keep budget free
 - **References auto-load** — `user-invocable: false` skills provide ambient context
 - **Agent-agnostic** — skills work across Claude, Codex, Gemini, Pi
+
+## Artifact Hygiene
+
+Workflow skills must not create merge-conflict bait.
+
+- Default scratch output goes to `/tmp` or another ignored ephemeral directory, not repo-relative shared paths.
+- If a durable repo-hosted artifact is truly required, it must use a PR- or branch-unique path such as `walkthrough/pr-123/...` or `walkthrough/<branch-slug>/...`.
+- Never require stable shared filenames for PR-local evidence, QA reports, screenshots, or videos.
+- Commit artifacts only when the repo explicitly wants them versioned. Otherwise prefer PR bodies, comments, attachments, or temp files.

--- a/core/dogfood/SKILL.md
+++ b/core/dogfood/SKILL.md
@@ -20,13 +20,14 @@ Only the **Target URL** is required. Everything else has sensible defaults -- us
 |-----------|---------|-----------------|
 | **Target URL** | _(required)_ | `vercel.com`, `http://localhost:3000` |
 | **Session name** | Slugified domain (e.g., `vercel.com` -> `vercel-com`) | `--session my-session` |
-| **Output directory** | `./dogfood-output/` | `Output directory: /tmp/qa` |
+| **Output directory** | `/tmp/dogfood/{session}-{timestamp}/` | `Output directory: /tmp/qa` |
 | **Scope** | Full app | `Focus on the billing page` |
 | **Authentication** | None | `Sign in to user@example.com` |
 
 If the user says something like "dogfood vercel.com", start immediately with defaults. Do not ask clarifying questions unless authentication is mentioned but credentials are missing.
 
 Always use `agent-browser` directly -- never `npx agent-browser`. The direct binary uses the fast Rust client. `npx` routes through Node.js and is significantly slower.
+Dogfood outputs are scratch QA artifacts by default. Do not commit them unless the user explicitly asks or the repo has a dedicated ignored artifact location.
 
 ## Workflow
 
@@ -202,6 +203,7 @@ agent-browser --session {SESSION} close
 - **Be thorough but use judgment.** You are not following a test script -- you are exploring like a real user would. If something feels off, investigate.
 - **Write findings incrementally.** Append each issue to the report as you discover it. If the session is interrupted, findings are preserved. Never batch all issues for the end.
 - **Never delete output files.** Do not `rm` screenshots, videos, or the report mid-session. Do not close the session and restart. Work forward, not backward.
+- **Keep outputs ephemeral by default.** Use `/tmp` or another ignored location unless the user explicitly wants a durable checked-in report. Shared repo-relative output dirs create avoidable merge conflicts.
 - **Never read the target app's source code.** You are testing as a user, not auditing code. Do not read HTML, JS, or config files of the app under test. All findings must come from what you observe in the browser.
 - **Check the console.** Many issues are invisible in the UI but show up as JS errors or failed requests.
 - **Test like a user, not a robot.** Try common workflows end-to-end. Click things a real user would click. Enter realistic data.

--- a/core/pr-fix/SKILL.md
+++ b/core/pr-fix/SKILL.md
@@ -24,6 +24,7 @@ Take PR `$ARGUMENTS` (or the current branch PR) to this state:
 - every actionable review item handled
 - no open review threads
 - no misleading "PR Unblocked" comment while review automation can still add findings
+- durable PR evidence still truthful after the last fix or push
 
 ## Latitude
 
@@ -37,6 +38,7 @@ Take PR `$ARGUMENTS` (or the current branch PR) to this state:
 2. **Reply per item.** Aggregate "covered above" comments are not enough for actionable review findings.
 3. **Settle async reviewers before signaling success.** After every push, `gh pr ready`, or any action that can retrigger bots, rerun the review inventory after reviewer activity settles.
 4. **No quality-gate downgrades.** Fix the code or the tests. Do not weaken thresholds.
+5. **Evidence must stay current.** If a fix changes behavior, verification, or review confidence, refresh the walkthrough and reviewer evidence before signaling success.
 
 ## Dependency Order
 
@@ -82,6 +84,7 @@ Do not post `PR Unblocked` if any of these are still true:
 - any actionable PR review comment lacks a direct reply
 - any actionable review thread remains unresolved
 - the post-settlement inventory changed and has not been reconciled
+- the PR walkthrough or reviewer evidence is stale, text-only, or no longer proves the current branch state
 
 ## Retry Policy
 

--- a/core/pr-fix/references/workflow.md
+++ b/core/pr-fix/references/workflow.md
@@ -64,6 +64,7 @@ Look for:
 - semantic mismatches between names, comments, and behavior
 
 Fix what you find. Re-run the relevant verification before moving on.
+If the branch already has walkthrough or reviewer evidence, check whether self-review changes invalidated it. If so, plan to refresh the artifact before signaling success.
 
 If the PR links an issue with `## Acceptance Criteria`, run `verify-ac` as a secondary check before leaving self-review:
 - treat `UNVERIFIED` criteria as a blocker to resolve or defer explicitly before signaling the branch is clean
@@ -122,6 +123,7 @@ git push --force-with-lease
 ```
 
 After any push, rerun the review inventory and reconcile again. Do not assume previously closed gaps stayed closed.
+After any push that changes behavior, update or regenerate the walkthrough artifact if the old evidence is no longer truthful.
 
 If a review fix breaks CI, go back to step 3.
 
@@ -166,6 +168,9 @@ Refresh:
 - `What Changed`
 - `Before / After`
 - `Walkthrough`
+- `Reviewer Evidence`
+
+Do not leave a text-only or stale walkthrough artifact attached to a branch that has changed since it was recorded.
 
 ## 11. Signal
 

--- a/core/pr-walkthrough/SKILL.md
+++ b/core/pr-walkthrough/SKILL.md
@@ -25,6 +25,8 @@ For every PR, produce one walkthrough package:
 - persistent verification link
 
 The walkthrough is mandatory for all PRs. The renderer changes by PR type. The contract does not.
+Plain prose does not satisfy the contract. Every walkthrough must contain observable evidence from real execution.
+The walkthrough exists to prove the merge claim to a skeptical reviewer. It is evidence, not decoration.
 
 ## Deliverables
 
@@ -46,6 +48,11 @@ Every run must leave behind:
 4. A PR body `## Walkthrough` section linking the artifact and the protecting check
 5. A top-level `## Reviewer Evidence` block that gets reviewers to the proof in one click
 
+At least one artifact must come from real branch execution.
+A markdown note with no capture, no command output, no screenshot, and no recording is a walkthrough failure.
+
+If a repo-hosted artifact is needed, it must use a PR- or branch-unique path. Shared filenames are forbidden.
+
 ## Workflow
 
 ### 1. Read the merge case
@@ -59,6 +66,9 @@ Do not script from the diff alone. The walkthrough must explain significance, no
 Use the renderer selection in `references/walkthrough-contract.md`.
 If multiple surfaces matter, use a mixed walkthrough.
 If a polished Remotion cut adds value, treat it as a non-blocking pass after the deterministic evidence flow is already strong.
+If the claim involves motion, state transitions, or user interaction, a screencast or browser recording is mandatory.
+If the claim is internal or architectural, a terminal capture of the proving commands or runtime behavior is mandatory; diagrams support the proof but do not replace execution evidence.
+If the PR says behavior is unchanged, the app still works, or a user flow still functions after an internal refactor, terminal evidence alone is not enough. Record a real end-to-end happy path in the app and pair it with the terminal/runtime proof.
 
 ### 3. Write the walkthrough spec
 
@@ -72,10 +82,14 @@ Before recording the final walkthrough:
 
 - collect before/after screenshots, clips, command output, or diagrams
 - capture the happy path
+- if the PR claims behavioral parity, capture that happy path in the real app, not only in logs or tests
 - capture one key edge, failure, or invariant when it materially affects confidence
 - identify the single automated check that best protects this change
+- identify the minimum regression suite that proves the branch did not break adjacent behavior
+- verify the capture path is rendering the real app shell and styles before you trust any screenshot or recording
 
 The walkthrough artifact is not enough on its own. The evidence must stand on its own if the video is skipped.
+But the inverse is also true: a text-only summary is not enough if the PR claim depends on observable behavior.
 
 ### 5. Produce the artifact
 
@@ -83,11 +97,15 @@ Preferred order:
 
 1. screenshot bundle when the claim is static and there is no meaningful action to demonstrate
 2. deterministic browser or terminal walkthrough when an action, transition, or workflow matters
-2. optional polished Remotion cut with narration or music
+3. mixed walkthrough when the change is internal but the merge claim includes user-visible behavioral parity
+4. optional polished Remotion cut with narration or music
+
+Store scratch and canonical media in `/tmp` or another ignored ephemeral location by default. Only commit artifacts when the repo explicitly wants tracked evidence or when no other durable delivery works.
 
 Never block a PR on a cinematic pass if the deterministic walkthrough is already strong and truthful.
 Never record a motionless video just because "video" sounds richer than screenshots.
 If you choose video, the recording must show the actual action being performed and the resulting state change or interaction.
+When the claim is "still works" after a refactor, the deterministic walkthrough is not strong enough unless the artifact also shows the real flow still working.
 
 ### 6. Tie it to persistent verification
 
@@ -97,6 +115,7 @@ If no durable automated check exists:
 
 - add one when feasible
 - otherwise call out the gap explicitly and make fixing it the next quality task
+- and do not pretend the walkthrough alone proves regression safety
 
 ### 7. Update the PR body
 
@@ -109,7 +128,8 @@ For private repositories:
 - prefer GitHub-uploaded attachments for screenshots and video when you can upload through the web UI or browser automation
 - otherwise use GitHub's documented private-repo-safe pattern: `../blob/<ref>/path/to/image.png?raw=true`
 - for repo-hosted video fallback, use an explicit direct-download link such as `../blob/<ref>/path/to/video.mp4?raw=1`
-- add a committed `walkthrough/reviewer-evidence.md` entrypoint when the branch has multiple artifacts
+- if the branch has multiple committed artifacts, use a PR- or branch-scoped entrypoint such as `walkthrough/pr-<N>/reviewer-evidence.md` or `walkthrough/<branch-slug>/reviewer-evidence.md`
+- never use a repo-global shared filename like `walkthrough/reviewer-evidence.md`
 
 Add a `## Walkthrough` section that includes:
 
@@ -125,11 +145,19 @@ Add a `## Walkthrough` section that includes:
 - All PRs get a walkthrough. No exceptions.
 - The artifact must strengthen reviewer confidence, not just advertise polish.
 - Prefer deterministic evidence over high-production ambiguity.
+- A text walkthrough with no observable artifact is invalid.
+- Claims about real behavior must be backed by real execution captures, not inferred from reading code.
+- An unstyled screenshot from a renderer harness is a capture failure until proven otherwise, not valid product evidence.
+- For user-visible flows, default to screencast plus screenshots unless the proof is truly static.
+- For non-UI work, default to terminal capture plus diagrams unless a stronger renderer is warranted.
+- For internal refactors that claim no functional regression, default to mixed evidence: a short real-app screencast of the critical happy path plus terminal/runtime proof.
 - If nothing moves, use screenshots instead of video.
 - If something important does move, record the real action and its result. Do not ship idle footage that is visually indistinguishable from a screenshot.
 - Remotion is encouraged for high-value communication, not as a substitute for proof.
 - If the PR changes nothing user-visible, narrate invariants, architecture, and verification instead.
+- If the PR claims a user-visible path still works, the artifact must show that path working. Terminal logs, tests, and diagrams support that claim but do not substitute for it.
 - In private repos, attachment URLs or GitHub-relative blob links are part of the artifact quality bar. Broken media links are a walkthrough failure.
+- Shared repo artifact paths are a workflow bug. Evidence must be ephemeral by default or uniquely scoped when committed.
 
 ## References
 

--- a/core/pr-walkthrough/references/walkthrough-contract.md
+++ b/core/pr-walkthrough/references/walkthrough-contract.md
@@ -8,6 +8,9 @@ Every PR needs one walkthrough package that answers five questions:
 4. What evidence proves that claim?
 5. What persistent check protects the path going forward?
 
+The package must include observable proof from real execution. Narrative alone is not enough.
+Its purpose is reviewer confidence: prove the branch claim with the smallest truthful artifact that a skeptical reviewer can trust.
+
 ## Evaluation Rubric
 
 Judge every walkthrough against this rubric:
@@ -18,6 +21,7 @@ Judge every walkthrough against this rubric:
 | Baseline | Does it show the real before state instead of hand-waving it? |
 | Delta | Does it make the branch delta legible? |
 | Proof | Does each major claim map to evidence? |
+| Behavioral proof | If the PR claims the app still works, does it show the app working? |
 | Protection | Does it link the story to a durable automated check? |
 | Residual risk | Does it say what is still not proven? |
 
@@ -29,7 +33,8 @@ Judge every walkthrough against this rubric:
 | Static UI delta or non-interactive visual proof | Screenshot bundle | before/after screenshots, annotations, protecting check |
 | CLI or developer workflow | Terminal walkthrough | commands, expected output, before/after behavior |
 | Backend or API change | Terminal plus diagrams | request/response traces, data/state change, regression test |
-| Infra, CI, architecture, refactor | Diagram-led walkthrough | old vs new flow, invariants preserved, proof commands |
+| Infra, CI, architecture, refactor | Terminal walkthrough plus diagrams | old vs new flow, invariants preserved, proof commands, runtime or test output |
+| Internal refactor with a behavioral-parity claim | Mixed: app screencast plus terminal walkthrough | real happy path in the app, proof commands, runtime/test output, residual gap |
 | Broad launch or stakeholder update | Remotion video | narration, diagrams, screenshots, optional music/voiceover |
 
 Use mixed media when one renderer is insufficient.
@@ -55,6 +60,8 @@ Use this script unless the PR needs a stronger variant:
 8. **Merge case**
    Close with why shipping this branch is worth it.
 
+If the PR claims behavioral parity after a refactor, the "After" scene must include a real app flow, not only terminal output.
+
 ## Evidence Mapping
 
 For each scene, capture at least one of:
@@ -67,6 +74,8 @@ For each scene, capture at least one of:
 - data diff
 
 If a scene has no evidence, cut or rewrite the claim.
+If the whole walkthrough has no observable execution evidence, it fails review.
+If the walkthrough claims the app still functions, one scene must show the real app functioning.
 
 ## Media Delivery Rules
 
@@ -78,13 +87,17 @@ Preferred order:
 2. GitHub-relative blob links for private-repo screenshots: `../blob/<ref>/path/to/image.png?raw=true`
 3. Explicit direct-download blob links for repo-hosted video fallback: `../blob/<ref>/path/to/video.mp4?raw=1`
 
+When repo-hosted artifacts are unavoidable, use PR- or branch-unique paths such as `walkthrough/pr-123/...` or `walkthrough/<branch-slug>/...`.
+Scratch output should live in `/tmp` or another ignored ephemeral location.
+
 Avoid:
 
 - `raw.githubusercontent.com/...` in private-repo PR bodies or comments
 - bare repo-relative asset paths like `walkthrough/screenshots/foo.png` in PR bodies or comments
+- shared filenames like `walkthrough/reviewer-evidence.md` for PR-local evidence
 - plain blob links to `.mp4` files that dump reviewers into the code viewer without warning
 
-If the branch has more than one artifact, add a committed `walkthrough/reviewer-evidence.md` file and link it from the top of the PR.
+If the branch has more than one committed artifact, add a PR- or branch-scoped reviewer-evidence entrypoint and link it from the top of the PR.
 
 ## Motion Rule
 
@@ -92,6 +105,16 @@ If the branch has more than one artifact, add a committed `walkthrough/reviewer-
 - If the truth can be understood from a still frame, prefer screenshots.
 - A video that shows no action is a failed artifact, not a richer screenshot.
 - If recording a flow, perform the real action in the recording and hold long enough to show the resulting state.
+- If motion is part of the claim, screenshots alone are not enough.
+- If the claim is internal, commands and their outputs must still be captured from a real run.
+
+## Behavioral Parity Rule
+
+- "No regression", "behavior unchanged", "still works", and similar claims are behavioral claims.
+- Behavioral claims require behavioral proof.
+- For internal or architectural refactors, terminal evidence is necessary but not sufficient when the PR also claims the product still functions.
+- In those cases, record a short real end-to-end happy path in the app and pair it with the structural/runtime proof.
+- If no practical way exists to capture that flow, stop and surface the missing harness or automation as a blocker instead of pretending the claim is proven.
 
 ## PR Body Template
 
@@ -100,7 +123,7 @@ Every PR should include a section like this:
 ```md
 ## Reviewer Evidence
 
-- Start here: [walkthrough/reviewer-evidence.md or attachment comment]
+- Start here: [PR-scoped reviewer evidence file or attachment comment]
 - Direct video download: [artifact]
 - Walkthrough notes: [artifact]
 - Fast claim: [one sentence]
@@ -125,3 +148,11 @@ The walkthrough should produce or reinforce one durable protection:
 - regression test for bug fixes
 
 If the walkthrough reveals a path that matters and nothing protects it, that is a quality finding.
+
+## Evidence Quality Bar
+
+- A text memo is support material, not the artifact.
+- The artifact must prove the branch claim with real execution on the branch under review.
+- The artifact must also show the regression guardrails that were actually run.
+- If the branch claim includes functional parity, the artifact must show functional parity directly.
+- If the branch changes behavior and no durable artifact can be produced, stop and surface the blocker instead of shipping.

--- a/core/pr/references/pr-body-template.md
+++ b/core/pr/references/pr-body-template.md
@@ -110,13 +110,17 @@ Put the proof before the prose when the PR has user-visible evidence.
 - Link the video in a way that does not drop reviewers into a confusing code viewer
 - Surface 1-3 screenshots inline when they materially help
 - State the merge claim in one sentence
+- Include at least one durable artifact from real branch execution
+- Do not treat a markdown note or prose summary as sufficient reviewer evidence
 
 For private repositories:
 
 - prefer GitHub-uploaded attachments for screenshots and video
+- if repo-hosted evidence is necessary, use a PR- or branch-unique path such as `walkthrough/pr-123/...`
 - fallback screenshot syntax in PR bodies/comments: `../blob/<ref>/path/to/image.png?raw=true`
 - fallback repo-hosted video link: `../blob/<ref>/path/to/video.mp4?raw=1`
 - do not use `raw.githubusercontent.com/...` or bare asset paths like `walkthrough/screenshots/foo.png`
+- do not use shared filenames like `walkthrough/reviewer-evidence.md` for PR-local evidence
 
 ### `## Why This Matters`
 
@@ -184,6 +188,7 @@ This is the proof package for the PR.
 - Before / After scope
 - Persistent verification
 - Residual gap
+- Observable artifact from actual execution on this branch
 
 For the script and rubric, load `../../pr-walkthrough/references/walkthrough-contract.md`.
 
@@ -225,8 +230,10 @@ For Mermaid syntax examples and GitHub rendering constraints, load
 
 - Do not bury the value proposition below a long diff recap.
 - Do not bury the reviewer evidence below the narrative when the branch has user-visible proof.
+- Do not present prose-only reviewer evidence as proof.
 - Do not present risks only as a footnote.
 - Do not use a single diagram when before/after comparison is the actual point.
 - Do not force screenshots for purely internal changes, but do provide text before/after.
 - Do use `<details>` to keep the PR readable when sections get long.
 - Do make the walkthrough point to one durable automated check, not just a polished artifact.
+- Do keep repo-hosted PR artifacts uniquely scoped to the PR or branch. Shared artifact paths create needless merge conflicts.

--- a/core/simplify/SKILL.md
+++ b/core/simplify/SKILL.md
@@ -29,6 +29,7 @@ For the whole repo or `$ARGUMENTS`, answer four questions with evidence:
 4. Which one refactor removes the most complexity per unit of risk right now?
 
 Then implement that refactor, verify behavior, and open or update a draft PR via `../pr/SKILL.md`.
+Local code changes plus a summary are not a completed `/simplify` run.
 
 ## Latitude
 
@@ -36,6 +37,8 @@ Then implement that refactor, verify behavior, and open or update a draft PR via
 - Read code, docs, tests, ADRs, and bounded git history before proposing changes
 - Prefer deletion, consolidation, and stronger module boundaries over new abstractions
 - Use an `ousterhout` reviewer/persona if available; otherwise apply the same checks manually
+- Treat the PR lane as part of the task, not optional follow-up work
+- If `../pr/SKILL.md` blocks on missing evidence, duplicate PRs, auth, or another concrete prerequisite, resolve it when feasible; otherwise report that explicit blocker instead of silently stopping short of the PR step
 - If no safe, high-impact, single-PR simplification exists, say so explicitly instead of inventing churn
 
 ## Workflow
@@ -46,7 +49,7 @@ Then implement that refactor, verify behavior, and open or update a draft PR via
 4. **Evaluate trade-offs** — Read `references/refactor-rubric.md`. Score the options on module depth, information hiding, operational simplicity, migration cost, behavior risk, and single-PR feasibility.
 5. **Choose one refactor** — Pick the change that maximizes complexity removed per unit of risk and fits in one pull request. Name what will be deleted, what will be consolidated, and what behavior must remain unchanged.
 6. **Implement with proof** — Before edits, write down the module invariants and external contract that must remain stable. Add or adjust tests against that contract where behavior risk is non-trivial. Make the refactor. Update docs if architecture or workflow meaningfully changes. Verify with the tightest commands that cover the affected surface.
-7. **Ship** — After boundary simplification and verification are complete, invoke `../pr/SKILL.md` and follow its workflow. The PR should explain the current shape, the first-principles alternatives considered, why this refactor won, and the follow-up work left behind.
+7. **Ship** — After boundary simplification and verification are complete, invoke `../pr/SKILL.md` and follow its workflow all the way through opening or updating the PR. Do not stop after local verification or a narrative summary. The PR should explain the current shape, the first-principles alternatives considered, why this refactor won, and the follow-up work left behind.
 8. **Codify leftovers** — If the best future architecture cannot fit in one PR, create focused follow-up issues or record the roadmap in the PR body.
 
 ## Output
@@ -58,7 +61,7 @@ Default deliverable:
 - Trade-off evaluation
 - Chosen single-PR simplification
 - Verification evidence
-- PR URL
+- PR URL, or the explicit blocker returned by `../pr/SKILL.md`
 
 ## References
 

--- a/core/visual-qa/SKILL.md
+++ b/core/visual-qa/SKILL.md
@@ -215,6 +215,8 @@ After quality gates pass, run visual QA:
 - Fix P0/P1 issues, note P2s in PR body
 ```
 
+Scratch screenshots should stay in `/tmp` or another ignored location. Do not commit visual QA media unless the user explicitly asks for durable repo-hosted evidence, and if you must commit it, use a PR- or branch-unique path.
+
 ## Output
 
 Findings list with severities, screenshot paths, and fix status.


### PR DESCRIPTION
## Reviewer Evidence

- Diff is 9 files, all documentation/skill instructions — no runtime code
- Fast claim: delivery skills now require real execution evidence and ephemeral artifact paths, closing gaps where prose-only walkthroughs and shared filenames created false confidence and merge conflicts

## Why This Matters

- **Problem:** Walkthrough skills accepted prose-only summaries as "evidence." Artifact paths used shared filenames that caused merge conflicts on parallel branches. `/simplify` could stop after local verification without opening the PR. `/pr-fix` didn't require refreshing stale evidence after code changes.
- **Value:** Every delivery skill now enforces observable execution evidence, ephemeral-by-default artifacts, and completion through to the PR lane.
- **Why now:** These gaps surfaced across multiple recent sessions — each one individually small, collectively undermining reviewer trust in the delivery pipeline.

## Trade-offs / Risks

- **Value gained:** Stronger reviewer confidence; fewer false "done" signals; no merge conflicts on scratch artifacts
- **Cost / risk incurred:** Stricter walkthrough requirements may slow down first-pass PR creation
- **Why this is still the right trade:** A walkthrough that doesn't prove its claim is waste, not efficiency
- **Reviewer watch-outs:** Check that the behavioral parity rule doesn't create unreasonable burden for trivial refactors

## What Changed

Nine files across six skills hardened to close evidence, artifact, and completion gaps in the delivery pipeline.

### Base Branch
```mermaid
graph TD
  A[PR Walkthrough] --> B["Prose summary accepted as evidence"]
  C[Artifacts] --> D["Shared filenames → merge conflicts"]
  E["/simplify"] --> F["Stops after local verification"]
  G["/pr-fix"] --> H["Stale evidence after fixes"]
```

### This PR
```mermaid
graph TD
  A[PR Walkthrough] --> B["Real execution evidence required"]
  C[Artifacts] --> D["Ephemeral by default, PR-scoped if committed"]
  E["/simplify"] --> F["Must open/update PR or report blocker"]
  G["/pr-fix"] --> H["Evidence refreshed after behavior-changing fixes"]
```

<details>
<summary>Changes</summary>

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md` | Add artifact hygiene section |
| `core/pr-walkthrough/SKILL.md` | Require observable execution evidence; behavioral parity rule; PR-scoped artifact paths |
| `core/pr-walkthrough/references/walkthrough-contract.md` | Evidence quality bar; behavioral parity rule; motion rule updates; media delivery scoping |
| `core/pr-fix/SKILL.md` | Evidence freshness gate; stale walkthrough as ship-blocker |
| `core/pr-fix/references/workflow.md` | Refresh walkthrough after behavior-changing pushes |
| `core/pr/references/pr-body-template.md` | Require durable artifact; no prose-only evidence; no shared filenames |
| `core/simplify/SKILL.md` | Must complete through PR lane or report explicit blocker |
| `core/dogfood/SKILL.md` | Ephemeral output default; don't commit scratch QA |
| `core/visual-qa/SKILL.md` | Scratch screenshots to `/tmp`; PR-scoped if committed |

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered

### Option A — Do nothing
- Upside: No change
- Downside: Prose-only walkthroughs continue passing review; shared artifacts keep causing conflicts
- Why rejected: Erodes trust in the delivery pipeline

### Option B — Automated evidence validation hook
- Upside: Machine-enforced
- Downside: Hard to define "real evidence" programmatically; high false-positive risk
- Why rejected: Premature — codify the rules first, automate later if needed

### Option C — Documentation hardening (chosen)
- Upside: Immediate effect on all agent sessions; zero runtime risk
- Downside: Relies on agent compliance, not enforcement
- Why chosen: Right first step; enforcement can follow once the rules stabilize

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence

- **Confidence:** High — documentation-only, internally consistent
- **Strongest evidence:** All changes reinforce the same principle (real evidence > prose) across multiple skill touchpoints
- **Remaining uncertainty:** None for a docs change
- **What could go wrong:** Agents may need a few sessions to fully internalize the stricter rules

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced PR evidence and artifact hygiene guidelines across workflows
  * Updated walkthrough requirements to include observable proof from real execution
  * Clarified artifact storage practices and PR/branch-unique scoping for durable artifacts
  * Added emphasis on keeping PR evidence current and truthful after changes
  * Improved temporary artifact handling and cleanliness recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->