### PR TITLE
feat: add standup skill and project meta

### DIFF
--- a/.groom/plan-2026-03-11.md
+++ b/.groom/plan-2026-03-11.md
@@ -1,0 +1,62 @@
+# Grooming Plan — 2026-03-11
+
+## Themes Explored
+- **Delivery Pipeline Gaps**: CI polling token waste, PR reply protocol, multi-repo sweep
+- **Skill Quality**: description audit, trigger phrase compliance, 1024-char limit
+- **Bug Fix Hardening**: test-first parallel subagent race (from Twitter thread)
+- **Language/Platform Packs**: Go (5 repos), Convex (5 repos)
+- **Backlog Triage**: 6 bookmark issues closed, 1 rewritten
+
+## Discovery Method
+Three parallel mining agents scanned:
+- Claude Code sessions (heaviest projects, skill invocation frequency, user corrections)
+- Codex sessions (14K shell commands in March, 458 PR reply reinventions, 82 CI polls/session)
+- 30+ repo CLAUDE.md/AGENTS.md files (cross-repo pattern deduplication)
+
+Plus web research on Claude Code skill best practices (March 2026).
+
+## Issues Created
+- #24: Audit skill descriptions (rewritten, score: ~80/100)
+- #31: Deterministic CI poll script (score: ~85/100)
+- #32: Codify PR review reply protocol (score: ~80/100)
+- #33: Multi-repo PR sweep (score: ~80/100)
+- #34: Parallel subagent bug fix race (score: ~75/100)
+- #35: Go language pack (score: ~80/100)
+- #36: Convex platform pack (score: ~80/100)
+
+## Reduced / Closed / Merged
+- **Keep**: #6, #7, #8 (properly labeled from prior groom)
+- **Merged**: none
+- **Deferred**: none
+- **Closed**: #13 (bookmark), #25 (/simplify exists), #26 (wrong repo), #27 (/tune-repo covers), #28 (project-local), #11 (superseded by existing skills)
+
+## Research Findings Worth Preserving
+
+### Session Mining (Highest Signal)
+- `/respond` invoked 67 times standalone — correctly absorbed into pr-fix, but discoverability gap
+- CI polling: 82 polls + 32 sleeps in one session. Deterministic script saves massive tokens.
+- PR reply protocol reinvented 458+ times. Classification/Severity/Decision format is stable.
+- "What's next?" is the #1 session opener (75 sessions). Not actionable as a skill (shape → autopilot covers the flow).
+- 184 sessions hit context limits. Compaction handles this adequately.
+
+### Cross-Repo Analysis
+- Go conventions duplicated in 5 repos → Go pack
+- Convex patterns duplicated in 5 repos → Convex pack
+- Swift conventions in 3 repos → deferred (smaller footprint)
+- Date/time footguns (UTC vs local) → not a skill, add to common gotchas docs if needed
+- Incident → rule pipeline → partially covered by /distill, explicit enough
+
+### Skill Best Practices Research (March 2026)
+- Descriptions are the #1 selection lever; hard 1024-char limit
+- Plugins are now the native distribution layer (vs sync.sh) — worth evaluating later
+- CLAUDE.md should be 50-100 lines with @imports — our global is ~180 lines
+- Hooks > CLAUDE.md rules for enforcement (deterministic > probabilistic)
+
+## Retro Patterns Applied
+- "Skills become real gates only when delivery workflows name exact stop conditions" — applied to CI poll script (deterministic gate) and PR reply protocol (format contract)
+
+## Deferred Topics
+- **Plugin distribution**: Evaluate `claude install` vs sync.sh. Blocked on cross-harness support (plugins are Claude Code only; we need Codex/Gemini/Pi too).
+- **Swift pack**: 3 repos, lighter footprint than Go/Convex. Revisit when actively working in Swift repos.
+- **Global CLAUDE.md splitting**: ~180 lines, should be 50-100 with @imports. Not urgent.
+- **Monorepo patterns**: No skill covers cross-subproject invariant enforcement. Low priority.

--- a/core/standup/SKILL.md
+++ b/core/standup/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: standup
+description: |
+  Generate a daily standup report from the last 24 hours of GitHub activity
+  across all repos and orgs. Pulls PRs authored/reviewed, issues engaged,
+  commits pushed, and open PRs needing attention. Synthesizes into
+  Yesterday / Today / Blockers format.
+  Use when: writing standup, daily update, what did I do yesterday,
+  status report, daily sync, team update.
+  Keywords: standup, daily, status, yesterday, update, sync, report.
+allowed-tools: Bash, Read
+---
+
+# Standup
+
+Generate a concise daily standup from GitHub activity across all repos and orgs.
+
+## Workflow
+
+### 1. Gather Activity
+
+Run the gather script to pull last 24h of GitHub activity:
+
+```bash
+bash "$(dirname "$0")/scripts/gather.sh"
+```
+
+The script uses `gh` CLI to collect:
+- PRs authored (with state: open/merged)
+- PRs reviewed (others' PRs only)
+- Issues engaged (commented on)
+- Commits pushed (via events API)
+- Open PRs that may need attention
+
+### 2. Synthesize Standup
+
+From the raw data, produce a standup in this format:
+
+```
+## Yesterday
+- [grouped by theme/repo, not raw PR list]
+- Focus on outcomes and impact, not mechanics
+
+## Today
+- Infer from open PRs, open issues, and in-progress work
+- Mention PRs awaiting review or CI
+
+## Blockers
+- PRs with no reviews, stale open issues
+- Or "None" if clear
+```
+
+### 3. Output Rules
+
+- Group related PRs into narrative lines (e.g. "Hardened conductor lifecycle across 3 PRs")
+- Lead with the *what* and *why*, not PR numbers
+- Keep it to 5-8 bullets for Yesterday, 3-5 for Today
+- Include PR links inline for reference but don't let them dominate
+- If activity spans many repos, organize by project/theme not by repo
+- Mention review work separately — "Reviewed X PRs on [project]"

--- a/core/standup/scripts/gather.sh
+++ b/core/standup/scripts/gather.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Gather last 24h GitHub activity for standup generation.
+# Outputs JSON sections that the LLM synthesizes into a standup.
+set -euo pipefail
+
+SINCE="${1:-$(date -u -v-24H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)}"
+USER=$(gh api /user --jq '.login')
+
+echo "=== STANDUP DATA (since $SINCE for @$USER) ==="
+
+# --- PRs authored ---
+echo ""
+echo "## PRs Authored"
+gh search prs --author="@me" --created=">=$SINCE" \
+  --json repository,title,state,url --limit 50 \
+  --jq '.[] | "- [\(.state)] \(.repository.nameWithOwner): \(.title) (\(.url))"' 2>/dev/null || echo "(none)"
+
+# --- PRs reviewed (exclude self-authored) ---
+echo ""
+echo "## PRs Reviewed (others' PRs)"
+gh search prs --reviewed-by="@me" --updated=">=$SINCE" \
+  --json repository,title,state,url,author --limit 50 \
+  --jq "[.[] | select(.author.login != \"$USER\")] | .[] | \"- [\(.state)] \(.repository.nameWithOwner): \(.title) (\(.url))\"" 2>/dev/null || echo "(none)"
+
+# --- Issues commented on ---
+echo ""
+echo "## Issues Engaged"
+gh search issues --commenter="@me" --updated=">=$SINCE" \
+  --json repository,title,state,url --limit 30 \
+  --jq '.[] | "- [\(.state)] \(.repository.nameWithOwner): \(.title) (\(.url))"' 2>/dev/null || echo "(none)"
+
+# --- Push events (commits) from events API ---
+echo ""
+echo "## Commits Pushed"
+gh api "/users/$USER/events?per_page=100" \
+  --jq "[.[] | select(.type == \"PushEvent\" and .created_at >= \"$SINCE\") | {repo: .repo.name, commits: [.payload.commits[] | .message | split(\"\n\")[0]]}] | .[] | \"- \(.repo): \" + (.commits | join(\"; \"))" 2>/dev/null || echo "(none)"
+
+# --- Open PRs needing attention (authored, open, no recent review) ---
+echo ""
+echo "## Open PRs (may need attention)"
+gh search prs --author="@me" --state=open \
+  --json repository,title,url,updatedAt --limit 20 \
+  --jq '.[] | "- \(.repository.nameWithOwner): \(.title) (\(.url))"' 2>/dev/null || echo "(none)"
+
+echo ""
+echo "=== END STANDUP DATA ==="

--- a/project.md
+++ b/project.md
@@ -1,0 +1,74 @@
+# Project: agent-skills
+
+## Vision
+Portable skill library that makes AI coding agents reliably excellent across any harness.
+
+**North Star:** Every recurring workflow pattern a senior engineer uses is captured as a tested,
+composable skill — so any agent (Claude, Codex, Gemini, Pi) can execute it first-try.
+**Target User:** Senior+ engineers running multi-agent workflows across multiple repos.
+**Current Focus:** Sharpen existing skills — definitions, triggers, quality gates — over adding new ones.
+**Key Differentiators:** Agent-agnostic (works across harnesses), budget-aware (O(umbrellas) not O(skills)),
+research-backed (web + multi-model validation before codifying).
+
+## Domain Glossary
+
+| Term | Definition |
+|------|-----------|
+| Skill | A markdown-first module (SKILL.md + optional references/) that gives agents domain expertise |
+| Core skill | Universal skill synced to all harness config dirs |
+| Pack | Domain-specific skill bundle loaded per-project (e.g., payments, growth) |
+| Harness | An AI agent runtime (Claude Code, Codex, Gemini CLI, Pi) |
+| Umbrella | A skill that absorbs related sub-skills as references, saving budget |
+| DMI | Disable-model-invocation — user-only skills that cost zero budget |
+| Budget | ~16K char Claude Code description limit; skills consume budget per mode |
+| Ralph | Autonomous issue-to-merged-PR loop |
+| Delivery pipeline | groom → shape → autopilot → pr-fix → pr-polish → merge |
+
+## Active Focus
+
+- **Milestone:** Skill Quality — sharpen definitions, triggers, and gate semantics
+- **Key Issues:** #6, #7 (pipeline hardening), existing skills needing refinement
+- **Theme:** Make every skill precise enough that agents invoke it correctly first-try
+
+## Quality Bar
+
+- [ ] Every skill has clear trigger conditions (when to invoke, when NOT to)
+- [ ] Skills compose — orchestrators call primitives, never reimplement
+- [ ] Agent-agnostic — no Claude-specific assumptions leak into skill bodies
+- [ ] Budget stays within 16K limit with room for growth
+- [ ] Retro patterns flow back into skill definitions
+
+## Patterns to Follow
+
+### Progressive Disclosure
+```
+description (budget cost) → SKILL.md body → references/ (on-demand)
+```
+
+### Umbrella Absorption
+```
+core/{umbrella}/
+├── SKILL.md          # Routing table (budget cost)
+└── references/
+    ├── sub-cap-1.md  # Former standalone, loaded on demand
+    └── sub-cap-2.md  # Zero additional budget cost
+```
+
+### AC Tags for Machine Verification
+```markdown
+- [ ] [test] Given X, when Y, then Z
+- [ ] [command] Given X, when `cmd`, then output matches
+- [ ] [behavioral] Given X, when user does Y, then Z
+```
+
+## Lessons Learned
+
+| Decision | Outcome | Lesson |
+|----------|---------|--------|
+| verify-ac as standalone | Worked but wasn't used | Skills become gates only when delivery workflows name exact stop conditions |
+| Effort predictions | Accurate (retro confirms) | Effort/s and effort/m calibration is reliable for this repo |
+| Umbrella pattern (research/) | 4→1 budget savings | Progressive disclosure works; add sub-caps at zero cost |
+
+---
+*Last updated: 2026-03-11*
+*Updated during: /groom session*


### PR DESCRIPTION
## Reviewer Evidence

- New skill: `core/standup/` with SKILL.md and `scripts/gather.sh`
- New project meta: `project.md` and `.groom/plan-2026-03-11.md`
- Fast claim: adds daily standup generation from GitHub activity, plus project context artifacts from recent grooming session

## Why This Matters

- **Problem:** Writing daily standups requires manually checking GitHub across multiple repos and orgs. Project context (vision, glossary, focus) lived only in conversations and CLAUDE.md, not in a purpose-built format.
- **Value:** `/standup` generates Yesterday/Today/Blockers from real GitHub data in seconds. `project.md` gives agents and humans a shared understanding of the project's direction.
- **Why now:** Standup was being reinvented every session. The grooming plan and project.md capture the March 11 session output that would otherwise be lost.

## Trade-offs / Risks

- **Value gained:** Repeatable standup generation; durable project context
- **Cost / risk incurred:** One new core skill consuming budget; `gather.sh` depends on `gh` CLI and macOS `date -v` syntax (with Linux fallback)
- **Why this is still the right trade:** Standup is a daily workflow — high reuse justifies budget cost
- **Reviewer watch-outs:** `gather.sh` uses GitHub events API which has a 90-day retention limit; macOS/Linux date portability

## What Changed

Two new artifacts: a standup skill that gathers GitHub activity via `gh` CLI and synthesizes it into standup format, and project meta files from the March 11 grooming session.

### Base Branch
```mermaid
graph TD
  A["User wants standup"] --> B["Manually check GitHub"]
  B --> C["Write standup from memory"]
```

### This PR
```mermaid
graph TD
  A["User runs /standup"] --> B["gather.sh pulls 24h activity via gh CLI"]
  B --> C["LLM synthesizes into Yesterday/Today/Blockers"]
```

<details>
<summary>Changes</summary>

## Changes

| File | Change |
|------|--------|
| `core/standup/SKILL.md` | New skill: standup generation workflow and output rules |
| `core/standup/scripts/gather.sh` | Shell script gathering PRs, reviews, issues, commits via `gh` |
| `project.md` | Project vision, glossary, active focus, quality bar, lessons learned |
| `.groom/plan-2026-03-11.md` | Grooming session record: themes, issues created, discovery method |

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence

- **Confidence:** High — new files only, no modifications to existing code
- **Strongest evidence:** `gather.sh` uses standard `gh` CLI patterns; SKILL.md follows repo conventions
- **Remaining uncertainty:** Events API rate limits on heavy activity days
- **What could go wrong:** Minor — `gather.sh` output format may need tuning after real usage

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
