### PR TITLE
feat: add agent-backlog, simplify pr-walkthrough, fix pr-fix paths

### DIFF
--- a/core/agent-backlog/SKILL.md
+++ b/core/agent-backlog/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: agent-backlog
+description: |
+  Design, audit, and overhaul product backlogs for AI-agent delivery.
+  Use when: grooming a backlog, reducing issue sprawl, rewriting tickets to be agent-executable,
+  running a full backlog overhaul.
+  Keywords: backlog, groom, issues, agent-ready, overhaul, prioritize.
+disable-model-invocation: true
+---
+
+# Agent Backlog
+
+## Overview
+
+Use this skill to turn a messy backlog into a small, prioritized, agent-executable roadmap.
+Treat each issue as both a planning artifact and an execution prompt.
+
+## Core Stance
+
+- Reduce before adding.
+- Keep one canonical issue per intent.
+- Separate roadmap items from intake noise.
+- Prefer deep, outcome-shaped issues over many shallow tickets.
+- Write issues so a strong coding agent can execute them without hidden context.
+
+## Workflow
+
+For end-to-end overhaul, read `references/overhaul-workflow.md`.
+
+## Routing
+
+- General backlog strategy, ordering, pruning, and refinement:
+  Read `references/backlog-doctrine.md`
+- GitHub Issues, issue forms, labels, milestones, sub-issues, dependencies, and Projects:
+  Read `references/github-issues.md`
+- Writing or rewriting agent-ready issue bodies, acceptance criteria, boundaries, and verification:
+  Read `references/agent-issue-writing.md`
+- Running a full backlog overhaul:
+  Read `references/overhaul-workflow.md`
+
+## Collaboration
+
+- Use `groom` when the session is interactive and exploratory.
+- Use `github-cli-hygiene` for GitHub writes through `gh`.
+- Follow any repo-local issue standards before posting or editing issues.

--- a/core/agent-backlog/references/agent-issue-writing.md
+++ b/core/agent-backlog/references/agent-issue-writing.md
@@ -1,0 +1,132 @@
+# Agent-Ready Issue Writing
+
+## Principle
+
+Treat the issue as a prompt for a senior coding agent.
+Give the agent the goal, the local context, the quality bar, and the boundaries.
+Do not replace thinking with a brittle step-by-step script.
+
+## What to include
+
+### Problem
+
+State what is wrong or missing, with concrete evidence when available.
+
+### Outcome
+
+State what should be true when the issue is done.
+
+### Context
+
+Include only the context needed to make good decisions:
+- user workflow
+- architecture seam
+- existing patterns
+- relevant linked issues or docs
+
+### Acceptance criteria
+
+Write them so they can map to tests, commands, or visible behaviors.
+Good tags:
+- `[behavioral]`
+- `[test]`
+- `[command]`
+
+### Boundaries
+
+Say what should not change. This is often more valuable than extra implementation steps.
+
+### Verification
+
+Provide runnable commands when possible.
+
+### Touchpoints
+
+List likely files, modules, routes, tests, or data paths when known. These are starting points, not
+prisons.
+
+## What to avoid
+
+- vague requests like “clean this up”
+- giant multi-outcome tickets
+- hidden dependencies in comments only
+- instructions that describe exact shell steps instead of the desired result
+- “etc”, “as needed”, or other scope leak phrases
+- acceptance criteria that cannot be observed or tested
+
+## Type-specific guidance
+
+### Bug
+
+Include:
+- repro
+- expected vs actual
+- impact
+- regression clues if known
+
+### Feature
+
+Include:
+- user or operator value
+- triggering surface
+- rendering or API constraints
+- deterministic facts the model must not invent
+
+### Refactor
+
+Include:
+- invariants to preserve
+- code smells or coupling to remove
+- tests or checks that must stay green
+
+### Research
+
+Include:
+- the decision to make
+- what evidence to gather
+- the expected output artifact
+- what counts as sufficient confidence
+
+## Recommended issue skeleton
+
+```md
+## Problem
+
+## Outcome
+
+## Context
+
+## Acceptance Criteria
+- [behavioral] Given ...
+- [test] Given ...
+- [command] When `...`, then ...
+
+## Touchpoints
+- `path/to/file`
+
+## Verification
+```bash
+pnpm test ...
+pnpm typecheck
+```
+
+## Boundaries
+
+## Related
+```
+
+## AI-agent modification
+
+Optimize for first-pass execution:
+- prefer one issue per coherent diff
+- keep prompts goal-oriented, not step-prescriptive
+- include deterministic constraints explicitly
+- separate exploration from implementation when uncertainty is high
+- rewrite oversized issues before assigning them
+
+## Sources
+
+- https://developers.openai.com/api/docs/guides/prompt-engineering
+- https://developers.openai.com/api/docs/guides/function-calling
+- https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview
+- https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/troubleshoot-copilot-coding-agent

--- a/core/agent-backlog/references/backlog-doctrine.md
+++ b/core/agent-backlog/references/backlog-doctrine.md
@@ -1,0 +1,89 @@
+# Backlog Doctrine
+
+## What the backlog is for
+
+Treat the backlog as the current plan, not as storage for every idea. A good backlog is ordered,
+transparent, and actively maintained. It should make the next decisions obvious.
+
+## Core rules
+
+- Keep the backlog small enough to read end-to-end.
+- Reduce before adding.
+- Prefer one canonical issue per outcome.
+- Split discovery from delivery.
+- Order work by user value, risk reduction, learning, and enablement.
+- Keep active work narrow. High WIP destroys prioritization.
+
+## Healthy item shapes
+
+### Epic
+
+Use for a multi-issue initiative with a clear product outcome. The epic should explain why the
+theme matters, what success looks like, and which child issues carry execution.
+
+### Feature
+
+Use for a user-visible capability or operator-facing behavior change. The feature should be
+valuable on its own and not just a mechanical subtask.
+
+### Bug
+
+Use when the current behavior is wrong. State the failure, repro, expected behavior, and user or
+business impact.
+
+### Task / Refactor / Research
+
+Use only when the work is not a feature or bug. Keep these issue types outcome-linked:
+- `task`: enabling work with a clear downstream payoff
+- `refactor`: complexity reduction with preserved behavior
+- `research`: a decision-seeking investigation with a deliverable
+
+## Ordering guidance
+
+Move items up when they:
+- unblock or de-risk other work
+- fix trust, correctness, or safety failures
+- improve a critical user path
+- create leverage across multiple future issues
+
+Move items down when they:
+- are polish without evidence
+- duplicate a broader surviving issue
+- depend on undefined architecture
+- represent “maybe someday” ideas with no current owner
+
+## Cadence
+
+- Triage new intake quickly into keep, merge, defer, or close.
+- Re-read the active backlog regularly enough to remove stale assumptions.
+- Run pruning passes, not just addition passes.
+- Update the canonical issue body when the plan changes. Do not bury the truth in comments.
+
+## Smells
+
+- 5 tickets that all mean the same thing
+- “Polish” issues that should be sub-points in a deeper issue
+- implementation tasks with no user or system outcome
+- giant omnibus tickets with unclear done criteria
+- issues that require tribal knowledge to start
+- “investigate” tickets with no decision target
+
+## Definition of ready
+
+Before an issue is execution-ready, verify:
+- the problem is specific
+- the outcome is explicit
+- dependencies are visible
+- scope boundaries are present
+- verification is executable
+- the issue can be completed in one coherent pass or should be split
+
+## AI-agent adaptation
+
+See `agent-issue-writing.md` for agent-specific issue shaping.
+
+## Sources
+
+- https://scrumguides.org/scrum-guide
+- https://www.atlassian.com/agile/project-management/backlog-refinement-meeting
+- https://www.atlassian.com/agile/project-management/product-backlog

--- a/core/agent-backlog/references/github-issues.md
+++ b/core/agent-backlog/references/github-issues.md
@@ -1,0 +1,81 @@
+# GitHub Issues
+
+## Use the platform primitives for what they are good at
+
+- Issues: canonical units of work and decision
+- Sub-issues: parent-child decomposition for epics and large initiatives
+- Dependencies: sequencing when one issue blocks another
+- Labels: taxonomy for slicing and filtering
+- Milestones: timebox or release grouping
+- Projects: workflow, roadmap, and portfolio views
+- Issue forms / templates: structured intake and consistent issue bodies
+
+## Recommended structure
+
+### Intake
+
+Use issue forms or templates so new bugs and requests arrive with the minimum facts needed for
+triage. Keep forms short enough that people complete them, but structured enough that duplicate and
+incomplete reports are obvious.
+
+### Classification
+
+Use a small stable label taxonomy:
+- priority
+- type
+- horizon or status
+- domain
+- effort
+
+Avoid label sprawl. If a label does not improve routing, filtering, or reporting, remove it.
+
+### Hierarchy
+
+Use sub-issues for real decomposition, not for ornamental checklists. A parent issue should capture
+the outcome and child issues should each produce a coherent slice of value or enabling work.
+
+### Planning
+
+Use milestones for release or sprint buckets. Use Projects for views across those buckets:
+- triage inbox
+- active work
+- next up
+- later / parking lot
+- roadmap
+
+Keep the issue body as the source of truth. Comments are for iteration, not for replacing the plan.
+
+## GitHub-specific best practices
+
+- Prefer editing the original issue body over scattering new requirements in comments.
+- Use custom project fields when labels become overloaded for reporting.
+- Keep issue forms aligned with the fields you actually triage on.
+- Use dependencies when order matters; do not rely on implied sequencing.
+- Close duplicates in favor of the canonical issue and link both directions.
+
+## Suggested project fields
+
+If you use GitHub Projects, prefer fields like:
+- status
+- priority
+- horizon
+- effort
+- domain
+- target milestone or release
+- owner
+- risk
+
+## AI-agent adaptation
+
+See `agent-issue-writing.md` for agent-specific issue shaping.
+
+## Sources
+
+- https://docs.github.com/issues/tracking-your-work-with-issues/about-issues
+- https://docs.github.com/issues/planning-and-tracking-with-projects/learning-about-projects/about-projects
+- https://docs.github.com/issues/tracking-your-work-with-issues/using-issues/creating-a-sub-issue
+- https://docs.github.com/issues/tracking-your-work-with-issues/using-issues/creating-issue-dependencies
+- https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates
+- https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms
+- https://docs.github.com/issues/planning-and-tracking-with-projects/learning-about-projects/best-practices-for-projects
+- https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/troubleshoot-copilot-coding-agent

--- a/core/agent-backlog/references/overhaul-workflow.md
+++ b/core/agent-backlog/references/overhaul-workflow.md
@@ -1,0 +1,76 @@
+# Backlog Overhaul Workflow
+
+## Inputs
+
+- current product focus or `project.md`
+- open issues, labels, milestones, and project views
+- recent user pain, bugs, or usage evidence
+- implementation retros or failed attempts
+
+## Phase 1: Audit
+
+Collect:
+- open issue count
+- issue distribution by priority, type, horizon, and domain
+- duplicates and near-duplicates
+- missing milestones or weak labels
+- oversized issues
+- stale now/next items
+
+## Phase 2: Theme
+
+Group issues by product intent, not by title wording.
+Ask:
+- what are the real user-facing problems?
+- which issues are foundations vs leaf polish?
+- where is the roadmap fragmented across many shallow tickets?
+
+## Phase 3: Reduce
+
+Default moves:
+- merge duplicates into a canonical issue
+- close superseded items
+- move nit-level concerns under a deeper issue
+- split only when a child issue can execute independently
+
+## Phase 4: Rewrite
+
+For each surviving issue:
+- tighten title
+- clarify problem and desired outcome
+- add direct context and likely touchpoints
+- rewrite acceptance criteria in observable form
+- add verification and boundaries
+- align labels, milestone, and dependencies
+
+## Phase 5: Rebuild hierarchy
+
+Create or update:
+- epics for multi-issue outcomes
+- sub-issues for independent execution slices
+- dependencies for sequencing
+
+Do not use an epic when one good issue will do.
+
+## Phase 6: Publish
+
+After edits:
+- post a short note when closing or superseding an issue
+- link the canonical replacement
+- keep the roadmap legible from the issue list view alone
+
+## Heuristics
+
+- one issue should usually map to one coherent PR
+- prefer fewer better issues over more weaker issues
+- active horizon should stay intentionally small
+- “later” should be curated, not a graveyard
+
+## Deliverable
+
+A successful overhaul leaves:
+- a readable roadmap
+- minimal duplication
+- explicit sequencing
+- agent-executable issue bodies
+- a smaller active set than before

--- a/core/design/references/aesthetics-guidelines.md
+++ b/core/design/references/aesthetics-guidelines.md
@@ -14,7 +14,7 @@ Choose fonts that are beautiful, unique, and interesting. Pair a distinctive dis
 
 ## Color & Theme
 
-Commit to a cohesive aesthetic. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+Commit to a cohesive aesthetic. Dominant colors with sharp accents outperform timid, evenly-distributed palettes. Draw from IDE themes (Dracula, Nord, Solarized, Tokyo Night) and cultural aesthetics (Japanese minimalism, Bauhaus, Art Nouveau, Swiss design) for unexpected palette inspiration.
 
 **Vary your approach:**
 - High-contrast monochrome

--- a/core/design/references/frontend-design.md
+++ b/core/design/references/frontend-design.md
@@ -28,7 +28,7 @@ Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
 
 Focus on:
 - **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
-- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes. Draw from IDE themes (Dracula, Nord, Solarized, Tokyo Night) and cultural aesthetics (Japanese minimalism, Bauhaus, Art Nouveau, Swiss design) for unexpected palette inspiration.
 - **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
 - **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
 - **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.

--- a/core/pr-fix/SKILL.md
+++ b/core/pr-fix/SKILL.md
@@ -67,11 +67,13 @@ Read [references/workflow.md](./references/workflow.md) and execute the phases i
 
 ## Required Tooling
 
-Use the inventory script during review reconciliation:
+Use the shared inventory script bundled with this skill during review reconciliation. Resolve `<pr-fix-skill-dir>` to the directory containing this `SKILL.md` in the installed skills tree or source tree, not the target repo:
 
 ```bash
-python3 scripts/review_inventory.py $PR > /tmp/pr-fix-review-inventory.json
+python3 <pr-fix-skill-dir>/scripts/review_inventory.py "$PR" > /tmp/pr-fix-review-inventory.json
 ```
+
+If you are not running from the PR's repo checkout, also pass `--repo owner/name`.
 
 That inventory is mandatory and is the source of truth for review cleanup.
 

--- a/core/pr-fix/references/reconciliation-ledger.md
+++ b/core/pr-fix/references/reconciliation-ledger.md
@@ -17,8 +17,10 @@ The goal is not "counts are zero right now." The goal is:
 Use the inventory script first:
 
 ```bash
-python3 scripts/review_inventory.py $PR > /tmp/pr-fix-review-inventory.json
+python3 <pr-fix-skill-dir>/scripts/review_inventory.py "$PR" > /tmp/pr-fix-review-inventory.json
 ```
+
+Resolve `<pr-fix-skill-dir>` to the directory containing this skill, not the target repo. If you are running from outside the PR repo checkout, add `--repo owner/name`.
 
 The script gathers:
 - review threads

--- a/core/pr-fix/references/workflow.md
+++ b/core/pr-fix/references/workflow.md
@@ -77,8 +77,10 @@ If the PR links an issue with `## Acceptance Criteria`, run `verify-ac` as a sec
 Read [reconciliation-ledger.md](./reconciliation-ledger.md) and use the inventory script.
 
 ```bash
-python3 scripts/review_inventory.py $PR > /tmp/pr-fix-review-inventory.json
+python3 <pr-fix-skill-dir>/scripts/review_inventory.py "$PR" > /tmp/pr-fix-review-inventory.json
 ```
+
+Resolve `<pr-fix-skill-dir>` to the directory containing this skill, not the target repo. If your current working directory is not the PR repo, add `--repo owner/name`.
 
 From that inventory, build a working ledger of actionable items across:
 - GraphQL review threads

--- a/core/pr-walkthrough/SKILL.md
+++ b/core/pr-walkthrough/SKILL.md
@@ -1,164 +1,115 @@
 ---
 name: pr-walkthrough
 description: |
-  Create the mandatory walkthrough package for a pull request. Designs the script,
-  chooses the renderer (browser, terminal, diagram, or Remotion), captures before/after
-  evidence, and links one persistent verification check to the story being told.
-  Use when: opening a PR, preparing reviewer evidence, recording a demo, or proving why
-  a branch should merge. Keywords: walkthrough, demo video, QA walkthrough, before/after,
-  reviewer evidence, PR artifact.
+  Capture visual evidence for a PR and attach it to the PR body. Takes screenshots,
+  records browser GIFs, captures terminal output — then uploads to the PR.
+  No markdown walkthrough files. The artifact IS the evidence.
+  Use when: opening a PR, preparing reviewer evidence, recording a demo, proving a merge claim.
+  Keywords: walkthrough, demo, screenshot, GIF, before/after, reviewer evidence, PR artifact.
 disable-model-invocation: true
 argument-hint: "[PR-number-or-branch]"
 ---
 
 # /pr-walkthrough
 
-Generate the truth artifact for a PR.
+Capture and attach real evidence to a PR. No markdown busywork.
 
 ## Objective
 
-For every PR, produce one walkthrough package:
+Produce visual artifacts that prove the merge claim. Attach them to the PR body.
+The PR description IS the narrative. This skill produces the proof.
 
-- walkthrough spec
-- walkthrough artifact
-- evidence bundle
-- persistent verification link
+## What This Skill Produces
 
-The walkthrough is mandatory for all PRs. The renderer changes by PR type. The contract does not.
-Plain prose does not satisfy the contract. Every walkthrough must contain observable evidence from real execution.
-The walkthrough exists to prove the merge claim to a skeptical reviewer. It is evidence, not decoration.
+1. **Screenshots** — before/after of the changed surface
+2. **GIFs/recordings** — browser interactions, state transitions, workflows
+3. **Terminal captures** — test results, command output, type-check proof
+4. **PR body update** — `## Reviewer Evidence` with embedded/linked artifacts
 
-## Deliverables
-
-Every run must leave behind:
-
-1. A script that explains:
-   - what was wrong or missing before
-   - what changed on this branch
-   - what is true after
-   - why the change matters
-   - what test now protects it
-2. A primary artifact:
-   - screenshot bundle
-   - browser recording
-   - terminal walkthrough
-   - Remotion-rendered narrated video
-   - mixed media walkthrough
-3. Evidence references for each major claim
-4. A PR body `## Walkthrough` section linking the artifact and the protecting check
-5. A top-level `## Reviewer Evidence` block that gets reviewers to the proof in one click
-
-At least one artifact must come from real branch execution.
-A markdown note with no capture, no command output, no screenshot, and no recording is a walkthrough failure.
-
-If a repo-hosted artifact is needed, it must use a PR- or branch-unique path. Shared filenames are forbidden.
+What this skill does NOT produce: markdown walkthrough files, prose evidence bundles,
+or any committed `.md` files in `walkthrough/` directories. Those are redundant with the PR body.
 
 ## Workflow
 
-### 1. Read the merge case
+### 1. Understand the claim
 
-Read the issue, diff, draft PR body, changed tests, and current QA evidence.
+Read the diff, PR body, and changed tests. Identify:
+- What surface changed (UI, CLI, API, infra)?
+- What's the merge claim? ("new feature", "bug fix", "refactor with parity")
+- Is it demoable? (Default: yes for anything user-visible)
 
-Do not script from the diff alone. The walkthrough must explain significance, not just motion.
+### 2. Choose capture method
 
-### 2. Pick the renderer
+| Change type | Primary capture | Tool |
+|-------------|----------------|------|
+| UI/UX feature or fix | Screenshots + GIF of interaction | `claude-in-chrome` or `agent-browser` |
+| Motion/animation/transition | Browser GIF recording | `mcp__claude-in-chrome__gif_creator` |
+| Static visual delta | Before/after screenshots | `mcp__claude-in-chrome__computer` (screenshot) |
+| CLI/terminal behavior | Terminal output capture | `Bash` with output saved to `/tmp` |
+| Internal/infra refactor | Test suite output + app happy-path screenshot | Both |
+| Behavioral parity claim | App screencast proving the flow still works | Browser GIF + terminal |
 
-Use the renderer selection in `references/walkthrough-contract.md`.
-If multiple surfaces matter, use a mixed walkthrough.
-If a polished Remotion cut adds value, treat it as a non-blocking pass after the deterministic evidence flow is already strong.
-If the claim involves motion, state transitions, or user interaction, a screencast or browser recording is mandatory.
-If the claim is internal or architectural, a terminal capture of the proving commands or runtime behavior is mandatory; diagrams support the proof but do not replace execution evidence.
-If the PR says behavior is unchanged, the app still works, or a user flow still functions after an internal refactor, terminal evidence alone is not enough. Record a real end-to-end happy path in the app and pair it with the terminal/runtime proof.
+### 3. Capture evidence
 
-### 3. Write the walkthrough spec
+Run the app on the branch. Capture real execution.
 
-Use the contract in `references/walkthrough-contract.md`.
-Use its default script beats as the canonical sequence.
-Every scene must map to observable evidence.
+**For UI changes:**
+1. Launch the app (`npm start`, `npm run dev`, etc.)
+2. Open in browser via `claude-in-chrome` or `agent-browser`
+3. Screenshot the before state (if on main) or the after state (if on branch)
+4. For interactions: use `gif_creator` to record the flow
+5. Save artifacts to `/tmp/pr-evidence/`
 
-### 4. Capture evidence first
+**For terminal/infra changes:**
+1. Run the proving commands (tests, type-check, build)
+2. Capture output to `/tmp/pr-evidence/`
+3. If the PR claims "still works," also screenshot the running app
 
-Before recording the final walkthrough:
+**For before/after:**
+- If main is available, capture main state first, then branch state
+- If not, describe the before state in the PR body and capture the after
 
-- collect before/after screenshots, clips, command output, or diagrams
-- capture the happy path
-- if the PR claims behavioral parity, capture that happy path in the real app, not only in logs or tests
-- capture one key edge, failure, or invariant when it materially affects confidence
-- identify the single automated check that best protects this change
-- identify the minimum regression suite that proves the branch did not break adjacent behavior
-- verify the capture path is rendering the real app shell and styles before you trust any screenshot or recording
+### 4. Attach to PR
 
-The walkthrough artifact is not enough on its own. The evidence must stand on its own if the video is skipped.
-But the inverse is also true: a text-only summary is not enough if the PR claim depends on observable behavior.
+Upload artifacts and update the PR body with a `## Reviewer Evidence` section.
 
-### 5. Produce the artifact
+**For GitHub PRs:**
+- Use `gh pr comment` with uploaded images when possible
+- Use `gh pr edit --body` to add the evidence section
+- For video/GIF: upload via browser automation to GitHub, or commit to a
+  PR-scoped path only as a last resort
 
-Preferred order:
+**PR body format:**
+```
+## Reviewer Evidence
 
-1. screenshot bundle when the claim is static and there is no meaningful action to demonstrate
-2. deterministic browser or terminal walkthrough when an action, transition, or workflow matters
-3. mixed walkthrough when the change is internal but the merge claim includes user-visible behavioral parity
-4. optional polished Remotion cut with narration or music
+[screenshot or GIF embedded here]
 
-Store scratch and canonical media in `/tmp` or another ignored ephemeral location by default. Only commit artifacts when the repo explicitly wants tracked evidence or when no other durable delivery works.
+- **Claim:** [one sentence]
+- **Proof:** [what the artifact shows]
+- **Tests:** `[command]` — [result summary]
+- **Gap:** [what's not automated, if any]
+```
 
-Never block a PR on a cinematic pass if the deterministic walkthrough is already strong and truthful.
-Never record a motionless video just because "video" sounds richer than screenshots.
-If you choose video, the recording must show the actual action being performed and the resulting state change or interaction.
-When the claim is "still works" after a refactor, the deterministic walkthrough is not strong enough unless the artifact also shows the real flow still working.
+### 5. Verify links work
 
-### 6. Tie it to persistent verification
-
-Every walkthrough must name the test, smoke check, or CI job that now protects the path it demonstrates.
-
-If no durable automated check exists:
-
-- add one when feasible
-- otherwise call out the gap explicitly and make fixing it the next quality task
-- and do not pretend the walkthrough alone proves regression safety
-
-### 7. Update the PR body
-
-Add a top-level `## Reviewer Evidence` section before the narrative when the PR has user-visible evidence.
-
-For private repositories:
-
-- do not use `raw.githubusercontent.com/...` image links in PR bodies or comments
-- do not use bare repo-relative asset paths like `walkthrough/screenshots/foo.png`
-- prefer GitHub-uploaded attachments for screenshots and video when you can upload through the web UI or browser automation
-- otherwise use GitHub's documented private-repo-safe pattern: `../blob/<ref>/path/to/image.png?raw=true`
-- for repo-hosted video fallback, use an explicit direct-download link such as `../blob/<ref>/path/to/video.mp4?raw=1`
-- if the branch has multiple committed artifacts, use a PR- or branch-scoped entrypoint such as `walkthrough/pr-<N>/reviewer-evidence.md` or `walkthrough/<branch-slug>/reviewer-evidence.md`
-- never use a repo-global shared filename like `walkthrough/reviewer-evidence.md`
-
-Add a `## Walkthrough` section that includes:
-
-- renderer used
-- artifact link
-- core claim the walkthrough proves
-- before/after scope covered
-- persistent check protecting the path
-- residual gap, if any
+After updating the PR body, fetch the PR and confirm media renders.
+Broken image links are a walkthrough failure.
 
 ## Rules
 
-- All PRs get a walkthrough. No exceptions.
-- The artifact must strengthen reviewer confidence, not just advertise polish.
-- Prefer deterministic evidence over high-production ambiguity.
-- A text walkthrough with no observable artifact is invalid.
-- Claims about real behavior must be backed by real execution captures, not inferred from reading code.
-- An unstyled screenshot from a renderer harness is a capture failure until proven otherwise, not valid product evidence.
-- For user-visible flows, default to screencast plus screenshots unless the proof is truly static.
-- For non-UI work, default to terminal capture plus diagrams unless a stronger renderer is warranted.
-- For internal refactors that claim no functional regression, default to mixed evidence: a short real-app screencast of the critical happy path plus terminal/runtime proof.
-- If nothing moves, use screenshots instead of video.
-- If something important does move, record the real action and its result. Do not ship idle footage that is visually indistinguishable from a screenshot.
-- Remotion is encouraged for high-value communication, not as a substitute for proof.
-- If the PR changes nothing user-visible, narrate invariants, architecture, and verification instead.
-- If the PR claims a user-visible path still works, the artifact must show that path working. Terminal logs, tests, and diagrams support that claim but do not substitute for it.
-- In private repos, attachment URLs or GitHub-relative blob links are part of the artifact quality bar. Broken media links are a walkthrough failure.
-- Shared repo artifact paths are a workflow bug. Evidence must be ephemeral by default or uniquely scoped when committed.
+- Never generate markdown files as the walkthrough deliverable
+- Every walkthrough must include at least one real capture (screenshot, GIF, or terminal output)
+- The PR body is the walkthrough. Attach evidence there, not in committed files
+- Prefer screenshots for static proofs, GIFs for interactions
+- Don't record video of motionless screens — use screenshots instead
+- For UX changes, default to a GIF demo unless it's purely static
+- For parity claims ("still works"), show it working
+- Store scratch in `/tmp/pr-evidence/` — never commit walkthrough artifacts unless no other delivery works
+- If you can't capture the real surface, say so. Don't fake it with prose
+- If no automated check protects the demonstrated path, surface it as a quality finding, not just a gap note
+- In private repos: use GitHub attachments or `../blob/<ref>/path.png?raw=true` for images. Never use `raw.githubusercontent.com` links or bare repo-relative asset paths
 
 ## References
 
-- `references/walkthrough-contract.md` - renderer selection, script rubric, and PR section template
+- `references/walkthrough-contract.md` — renderer selection rubric, evidence quality bar

--- a/core/pr-walkthrough/references/walkthrough-contract.md
+++ b/core/pr-walkthrough/references/walkthrough-contract.md
@@ -1,6 +1,8 @@
 # Walkthrough Contract
 
-Every PR needs one walkthrough package that answers five questions:
+The walkthrough proves the merge claim with the smallest truthful artifact a skeptical reviewer can trust.
+
+## Five Questions
 
 1. What was wrong, missing, risky, or expensive before this branch?
 2. What changed?
@@ -8,151 +10,43 @@ Every PR needs one walkthrough package that answers five questions:
 4. What evidence proves that claim?
 5. What persistent check protects the path going forward?
 
-The package must include observable proof from real execution. Narrative alone is not enough.
-Its purpose is reviewer confidence: prove the branch claim with the smallest truthful artifact that a skeptical reviewer can trust.
-
 ## Evaluation Rubric
-
-Judge every walkthrough against this rubric:
 
 | Dimension | Question |
 |-----------|----------|
 | Significance | Does it explain why the change matters now? |
-| Baseline | Does it show the real before state instead of hand-waving it? |
+| Baseline | Does it show the real before state? |
 | Delta | Does it make the branch delta legible? |
-| Proof | Does each major claim map to evidence? |
+| Proof | Does each major claim map to a capture? |
 | Behavioral proof | If the PR claims the app still works, does it show the app working? |
-| Protection | Does it link the story to a durable automated check? |
+| Protection | Does it link to a durable automated check? |
 | Residual risk | Does it say what is still not proven? |
 
 ## Renderer Selection
 
-| Situation | Best format | Evidence to include |
-|-----------|-------------|---------------------|
-| Frontend UX or workflow with meaningful interaction | Browser recording | before/after screenshots, happy path, one key edge case |
-| Static UI delta or non-interactive visual proof | Screenshot bundle | before/after screenshots, annotations, protecting check |
-| CLI or developer workflow | Terminal walkthrough | commands, expected output, before/after behavior |
-| Backend or API change | Terminal plus diagrams | request/response traces, data/state change, regression test |
-| Infra, CI, architecture, refactor | Terminal walkthrough plus diagrams | old vs new flow, invariants preserved, proof commands, runtime or test output |
-| Internal refactor with a behavioral-parity claim | Mixed: app screencast plus terminal walkthrough | real happy path in the app, proof commands, runtime/test output, residual gap |
-| Broad launch or stakeholder update | Remotion video | narration, diagrams, screenshots, optional music/voiceover |
-
-Use mixed media when one renderer is insufficient.
-
-## Default Script
-
-Use this script unless the PR needs a stronger variant:
-
-1. **Title**
-   The PR name and one-sentence merge claim.
-2. **Why now**
-   The pain, risk, or opportunity that justified the work.
-3. **Before**
-   Show the old behavior, system state, or workflow.
-4. **What changed**
-   Summarize the key branch delta in human terms.
-5. **After**
-   Show the new behavior, system state, or workflow.
-6. **Verification**
-   Run or cite the automated check that protects this path.
-7. **Residual risk**
-   State what remains unproven or intentionally deferred.
-8. **Merge case**
-   Close with why shipping this branch is worth it.
-
-If the PR claims behavioral parity after a refactor, the "After" scene must include a real app flow, not only terminal output.
-
-## Evidence Mapping
-
-For each scene, capture at least one of:
-
-- screenshot
-- browser clip
-- command output
-- test result
-- diagram
-- data diff
-
-If a scene has no evidence, cut or rewrite the claim.
-If the whole walkthrough has no observable execution evidence, it fails review.
-If the walkthrough claims the app still functions, one scene must show the real app functioning.
-
-## Media Delivery Rules
-
-The evidence must render or open cleanly for reviewers in the live PR.
-
-Preferred order:
-
-1. GitHub-uploaded attachments for screenshots and video
-2. GitHub-relative blob links for private-repo screenshots: `../blob/<ref>/path/to/image.png?raw=true`
-3. Explicit direct-download blob links for repo-hosted video fallback: `../blob/<ref>/path/to/video.mp4?raw=1`
-
-When repo-hosted artifacts are unavoidable, use PR- or branch-unique paths such as `walkthrough/pr-123/...` or `walkthrough/<branch-slug>/...`.
-Scratch output should live in `/tmp` or another ignored ephemeral location.
-
-Avoid:
-
-- `raw.githubusercontent.com/...` in private-repo PR bodies or comments
-- bare repo-relative asset paths like `walkthrough/screenshots/foo.png` in PR bodies or comments
-- shared filenames like `walkthrough/reviewer-evidence.md` for PR-local evidence
-- plain blob links to `.mp4` files that dump reviewers into the code viewer without warning
-
-If the branch has more than one committed artifact, add a PR- or branch-scoped reviewer-evidence entrypoint and link it from the top of the PR.
+| Situation | Capture method |
+|-----------|---------------|
+| Frontend UX with interaction | Browser GIF via `gif_creator` + before/after screenshots |
+| Static UI delta | Screenshot bundle |
+| CLI or developer workflow | Terminal output capture |
+| Backend or API change | Terminal output + request/response traces |
+| Infra, CI, architecture | Terminal output + optional diagrams |
+| Internal refactor with parity claim | App GIF (happy path) + terminal proof |
 
 ## Motion Rule
 
-- Use video only when motion is part of the proof: a user action, animation, state transition, navigation flow, drag/drop, async update, or other observable behavior.
-- If the truth can be understood from a still frame, prefer screenshots.
-- A video that shows no action is a failed artifact, not a richer screenshot.
-- If recording a flow, perform the real action in the recording and hold long enough to show the resulting state.
-- If motion is part of the claim, screenshots alone are not enough.
-- If the claim is internal, commands and their outputs must still be captured from a real run.
+- GIF/video only when motion is part of the proof
+- If the truth is visible in a still frame, screenshot
+- A recording of a motionless screen is a failed artifact
 
 ## Behavioral Parity Rule
 
-- "No regression", "behavior unchanged", "still works", and similar claims are behavioral claims.
-- Behavioral claims require behavioral proof.
-- For internal or architectural refactors, terminal evidence is necessary but not sufficient when the PR also claims the product still functions.
-- In those cases, record a short real end-to-end happy path in the app and pair it with the structural/runtime proof.
-- If no practical way exists to capture that flow, stop and surface the missing harness or automation as a blocker instead of pretending the claim is proven.
-
-## PR Body Template
-
-Every PR should include a section like this:
-
-```md
-## Reviewer Evidence
-
-- Start here: [PR-scoped reviewer evidence file or attachment comment]
-- Direct video download: [artifact]
-- Walkthrough notes: [artifact]
-- Fast claim: [one sentence]
-
-## Walkthrough
-
-- Renderer: Screenshot bundle | Browser walkthrough | Terminal walkthrough | Remotion walkthrough | Mixed
-- Artifact: [link to video or walkthrough bundle]
-- Claim: [the single sentence this walkthrough proves]
-- Before / After scope: [what surfaces are covered]
-- Persistent verification: `[exact test, smoke check, or CI job]`
-- Residual gap: [what still is not automated or not shown]
-```
-
-## Persistent Check Rule
-
-The walkthrough should produce or reinforce one durable protection:
-
-- E2E test for user flow changes
-- integration or contract test for API/backend changes
-- smoke test or CI assertion for infra/tooling changes
-- regression test for bug fixes
-
-If the walkthrough reveals a path that matters and nothing protects it, that is a quality finding.
+- "No regression" / "still works" = behavioral claim = needs behavioral proof
+- Terminal evidence alone is insufficient for parity claims on user-visible surfaces
+- Record the real happy path in the app
 
 ## Evidence Quality Bar
 
-- A text memo is support material, not the artifact.
-- The artifact must prove the branch claim with real execution on the branch under review.
-- The artifact must also show the regression guardrails that were actually run.
-- If the branch claim includes functional parity, the artifact must show functional parity directly.
-- If the branch changes behavior and no durable artifact can be produced, stop and surface the blocker instead of shipping.
+- A text memo is support material, not the artifact
+- The artifact must show real execution on the branch under review
+- If no durable artifact can be produced, surface the blocker — don't ship without proof

--- a/core/pr/SKILL.md
+++ b/core/pr/SKILL.md
@@ -19,6 +19,8 @@ Engineer shipping clean, well-documented PRs.
 ## Objective
 
 Create a live PR from current branch. Link to issue, make the significance obvious, give reviewers the value/trade-off context they need at a glance, and attach the walkthrough package that proves the merge case.
+If the change improves UX or any user-visible interaction, the PR must include a demo artifact a human can watch. Default to video for anything with motion, interaction, timing, or state change; only use stills when the improvement is genuinely static.
+That artifact should be an actual capture of the product surface whenever practical, not a reconstructed storyboard made from logs or screenshots.
 
 `/pr` opens or updates the review lane. It does not certify that the live PR is review-clean after async reviewer automation runs.
 
@@ -59,8 +61,12 @@ Keep `Reviewer Evidence`, `Why This Matters`, `Trade-offs / Risks`, and the open
    Fix all P0/P1 issues found. Iterate until clean. **Do not open a PR until this passes.**
    Include dogfood summary (issues found, fixed) in PR body under Manual QA section.
 6. **Walkthrough** — Run `/pr-walkthrough`. Every PR needs a walkthrough package, even when the change is not user-facing. Use browser, terminal, diagram, Remotion, or mixed media as appropriate.
+   - UX improvements are presumed demoable. Do not settle for prose-only evidence when a reviewer should be able to watch the improvement.
+   - For user-visible interaction changes, default to a real screencast or terminal recording. Only fall back to screenshots when there is no meaningful motion or timing to show.
+   - For CLI UX, treat the terminal as the product surface and record the real interaction.
+   - Demo quality matters. Keep overlays minimal, keep the changed surface readable, and do not let explanatory text obscure the thing being demonstrated.
 7. **Describe** — Title from issue, body follows [references/pr-body-template.md](./references/pr-body-template.md). Lead with significance/value/trade-offs, not the diff recap.
-8. **Before/After** — Use screenshots or evidence from visual QA, dogfood, and `/pr-walkthrough`. For non-UI changes, describe behavioral or architectural difference in text. If the PR body gets long, move heavy evidence into `<details>`.
+8. **Before/After** — Use screenshots or evidence from visual QA, dogfood, and `/pr-walkthrough`. For non-UI changes, describe behavioral or architectural difference in text. If the change is UX-facing, include a watchable artifact and treat static text as support material, not the main proof. If the PR body gets long, move heavy evidence into `<details>`.
    For private repos, screenshots in the PR body must use GitHub attachments or `../blob/<ref>/...?...raw=true`; never `raw.githubusercontent.com` or bare repo-relative asset paths.
 9. **Open / Update** — Use `gh pr create --assignee phrazzld --body-file <path>` for new PRs. Use `gh pr edit --body-file <path>` when the branch already has a PR.
 10. **Review Settlement Handoff** — If the final push, `gh pr ready`, or PR update triggered async reviewers:

--- a/core/pr/references/pr-body-template.md
+++ b/core/pr/references/pr-body-template.md
@@ -111,6 +111,8 @@ Put the proof before the prose when the PR has user-visible evidence.
 - Surface 1-3 screenshots inline when they materially help
 - State the merge claim in one sentence
 - Include at least one durable artifact from real branch execution
+- For UX work, include a watchable demo artifact unless the change is truly static
+- Prefer an actual capture of the changed surface over a reconstructed or narrated facsimile
 - Do not treat a markdown note or prose summary as sufficient reviewer evidence
 
 For private repositories:
@@ -189,6 +191,8 @@ This is the proof package for the PR.
 - Persistent verification
 - Residual gap
 - Observable artifact from actual execution on this branch
+- For UX work, default the artifact to a real video or terminal recording rather than prose or a static note
+- For UX work, ensure the artifact is readable at normal speed and does not bury the changed surface under explanatory overlays
 
 For the script and rubric, load `../../pr-walkthrough/references/walkthrough-contract.md`.
 


### PR DESCRIPTION
## Summary

- **New `agent-backlog` skill** (DMI) — backlog doctrine, agent-issue-writing, GitHub Issues structure, and overhaul workflow for AI-agent delivery. Consolidated scattered AI-agent modification sections into one reference.
- **`pr-walkthrough` simplification** — cut ~140 lines of repeated prose. Recovered two load-bearing rules (private-repo URL patterns, persistent-check escalation) that the initial cut dropped.
- **`pr-fix` path fix** — `review_inventory.py` references now use `<pr-fix-skill-dir>` placeholder so the script resolves from the skill directory, not the target repo.
- **Minor**: palette inspiration in design refs, UX demo guidance strengthened in `pr/SKILL.md` and `pr-body-template.md`.

## Review notes

**agent-backlog** was reviewed for context-engineering quality:
- Description trimmed for budget; DMI mode added (free budget slot)
- SKILL.md stays at routing level; depth deferred to 4 references
- AI-agent modification sections consolidated into `agent-issue-writing.md` (was scattered across 3 files)
- Known: some overlap with `groom` — Collaboration section explicitly defers interactive sessions to `groom`

**pr-walkthrough** was reviewed for complexity red flags:
- Old version repeated each core rule ~4× across sections; new version: 2× max
- Removed shallow abstractions (8-beat default script, evidence mapping, media delivery rules that restated SKILL.md)
- Kept evaluation rubric and five questions in the contract as its unique contribution
- Recovered private-repo URL pattern and persistent-check escalation that the simplification initially dropped

**pr-fix** path fix verified:
- `core/pr-fix/scripts/review_inventory.py` exists (8.7 KB, executable)
- All 3 referencing files updated consistently
- External dependencies (`safe-read.sh`, diagrams dir, visualize prompts) all exist

## Test plan

- [ ] `./scripts/sync.sh all` succeeds (verified locally — 65 skills synced across 5 harnesses)
- [ ] `/agent-backlog` routes correctly and loads references on demand
- [ ] `/pr-walkthrough` produces evidence-first walkthrough without markdown file busywork
- [ ] `/pr-fix` resolves `review_inventory.py` from skill dir, not target repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive backlog management guides covering skill documentation, issue standards, and organizational workflows.
  * Introduced standards for writing machine-actionable issues suitable for automated processing.
  * Enhanced design guidance with inspiration sources for color palettes and aesthetics.
  * Updated PR review workflows to require watchable demo artifacts for user-visible changes.
  * Streamlined evidence capture approach for PR verification with focus on visual proof.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->