### PR TITLE
feat: architecture-first groom, module size enforcement, mandatory simplify

### DIFF
--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -105,8 +105,8 @@ The point is single ownership. One issue should map to one active autopilot lane
 8. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa --fix`. Fix P0/P1 before proceeding.
 9. **Agentic QA** — If diff touches prompts, model routing, tool schemas, or agent instructions, run `/llm-infrastructure` and inspect trace/eval coverage before shipping.
 10. **Refine** — `/pr-fix --refactor`, update docs inline, then run simplification pass:
-    - Preferred accelerator (if native in current harness): `/simplify`
-    - Portable fallback (required): manual module-depth review + simplification edits using Ousterhout checks: shallow modules, information leakage, pass-throughs, and compatibility shims with no active contract
+    - **Mandatory when diff >200 LOC net:** run `/simplify` — no exceptions
+    - For smaller diffs: manual module-depth review + simplification edits using Ousterhout checks: shallow modules, information leakage, pass-throughs, and compatibility shims with no active contract
     - Optional accelerator: use an `ousterhout` persona/agent if the harness provides one
 11. **Dogfood QA** — Run automated QA against local dev server (see Dogfood QA section below).
    Iterate until no P0/P1 issues remain. **Do not open a PR until QA passes.**

--- a/core/build/SKILL.md
+++ b/core/build/SKILL.md
@@ -114,9 +114,10 @@ Don't use when: single module, sequential dependencies dominate.
 
 ## Post-Implementation
 
-1. `code-simplifier:code-simplifier` agent for clarity
-2. `ousterhout` agent for module depth review
-3. Commit simplifications separately
+1. Run `/simplify` — mandatory before PR when diff >200 LOC net
+2. `code-simplifier:code-simplifier` agent for clarity
+3. `ousterhout` agent for module depth review
+4. Commit simplifications separately
 
 ## Visual QA (Frontend Changes)
 

--- a/core/check-quality/SKILL.md
+++ b/core/check-quality/SKILL.md
@@ -78,6 +78,14 @@ grep -q '"strict": true' tsconfig.json 2>/dev/null && echo "V Strict mode" || ec
 # Design tokens (heuristic only; confirm by reading the theme files)
 rg -n "(@theme|--(color|space|spacing|radius|font|shadow)-|tailwind\\.config|globals\\.css|app\\.css|tokens\\.(ts|js|json)|theme\\.(ts|js)|components/ui|src/components/ui)" . -g '!node_modules' >/dev/null 2>&1 && echo "V Design system detected (heuristic)" || echo "- No obvious design system"
 rg -n "(guardrails/.+(token|theme|color|spacing|radius)|no-raw-(color|hex|spacing|radius)|semantic-token|token-(usage|enforce)|design-token)" . -g '!node_modules' >/dev/null 2>&1 && echo "V Token guardrails (heuristic)" || echo "- No token guardrails"
+
+# Module size (Ousterhout deep module awareness)
+echo "--- Module Size ---"
+for f in $(find . -name '*.ex' -o -name '*.go' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.py' | grep -v node_modules | grep -v _build | grep -v deps); do
+  lines=$(wc -l < "$f")
+  [ "$lines" -gt 500 ] && echo "! $f: ${lines} LOC (review candidate)"
+done
+echo "---"
 ```
 
 Spawn `security-sentinel` agent for vulnerability analysis.
@@ -102,6 +110,7 @@ Prioritize findings:
 | No coverage in PRs | P2 |
 | No custom guardrails | P2 |
 | Design system without token guardrails | P2 |
+| Module >500 LOC without deep-module justification | P2 |
 | Tool upgrades | P3 |
 
 ### 3. Fix
@@ -188,6 +197,7 @@ Coverage is diagnostic, not a goal. 60% meaningful > 95% testing implementation 
 
 ## References
 
+- `references/module-size-guidance.md` -- LOC thresholds and Ousterhout deep module distinction
 - `references/lefthook-config.md` -- Hook configurations
 - `references/github-actions.md` -- CI workflows
 - `references/vitest-config.md` -- Test configuration

--- a/core/check-quality/references/module-size-guidance.md
+++ b/core/check-quality/references/module-size-guidance.md
@@ -1,0 +1,42 @@
+# Module Size Guidance
+
+## Thresholds
+
+| LOC | Action |
+|-----|--------|
+| >500 | Review candidate — is this a deep module or a tangled mess? |
+| >1000 | Strong signal for decomposition unless justified |
+| >200 net growth in one PR | Mandatory `/simplify` pass |
+
+## Deep Module vs Tangled Mess
+
+Per Ousterhout: a deep module has a simple interface hiding significant implementation.
+Large LOC is fine when the module:
+
+1. **Has a small public API** — few exports, few parameters per function
+2. **Hides complexity** — callers don't need to understand internals
+3. **Has clear boundaries** — minimal coupling to other modules
+4. **Is cohesive** — all the code serves a single responsibility
+
+Large LOC is a problem when:
+
+1. **Wide interface** — many exports, many parameters, many config options
+2. **Leaky abstractions** — callers must understand internal state
+3. **Mixed concerns** — business logic + I/O + formatting in one file
+4. **High coupling** — changes ripple to many other modules
+
+## Language-Specific Lint Tools
+
+| Language | Tool | Config |
+|----------|------|--------|
+| Elixir | Credo | `max_function_count`, `max_line_count` checks |
+| Go | golangci-lint | `funlen`, `cyclop`, `gocognit` linters |
+| TypeScript/JS | eslint | `max-lines` rule (per file), `max-lines-per-function` |
+| Python | pylint | `max-module-lines`, `max-args` |
+
+## When NOT to Flag
+
+- Generated code (protobuf, GraphQL codegen, migrations)
+- Test files (test suites naturally grow with coverage)
+- Configuration files
+- Single-responsibility deep modules with small interfaces

--- a/core/groom/SKILL.md
+++ b/core/groom/SKILL.md
@@ -54,6 +54,20 @@ not an archive of every bug, nit, brainstorm, review comment, or screenshot.
 **Use judgment, not quotas.** The point is coherence and execution bandwidth, not
 hitting an exact issue count.
 
+**Code is a liability.** Every line fights for its life. Prefer deletion over addition.
+
+**Never afraid to break compatibility** for a more elegant design.
+
+**Never afraid of esoteric technology** if it's the best fit.
+
+**Never afraid to throw away code** that's too much complexity for too little value.
+
+**Architecture before issues.** Don't create issues that deepen a broken architecture.
+
+**Reference architecture first.** Always search for existing implementations before designing from scratch.
+
+**Model diversity for architecture.** Use thinktank + CLI agents for diverse perspectives on design decisions.
+
 ## Org-Wide Standards
 
 All issues MUST comply with `groom/references/org-standards.md`.
@@ -63,11 +77,12 @@ Load that file before creating any issues.
 
 Run `/groom` in six phases:
 
-1. **Context** — load or update `project.md`, check repo context freshness, read retro, capture user pain, audit backlog health
-2. **Discovery** — launch parallel lanes and synthesize 3-5 strategic themes
-3. **Research** — do web, cross-repo, and codebase research before scoping
-4. **Exploration** — pitch options, recommend one, discuss, validate, then lock direction
-5. **Synthesis** — reduce the backlog first, then create only missing strategic issues
+1. **Ground** — load or update `project.md`, check repo context freshness, read retro, capture user pain, audit backlog health, compute health metrics (LOC per module, fix-to-feature ratio, test-to-code ratio, backlog size)
+2. **Architecture Critique** — three parallel tracks: reference architecture search, domain skill invocation, multi-model thinktank. See `references/architecture-fitness.md`
+2.5. **Present Options** — synthesize tracks A-C into 2-3 architectural options (incremental to radical), ask user what range of change is acceptable
+3. **Research** — web, cross-repo, and codebase research, scoped to the direction chosen in 2.5
+4. **Exploration** — pitch options, recommend one, discuss, validate with thinktank, then lock direction
+5. **Synthesis** — reduce the backlog first (close issues that deepen the wrong architecture), then create only missing strategic issues
 6. **Artifact** — save a dated grooming plan and visual summary when useful
 
 Synthesis default:
@@ -79,7 +94,8 @@ Synthesis default:
 ## References
 
 ### Workflow
-- `references/interactive-workflow.md` — full Phase 1-4 flow
+- `references/interactive-workflow.md` — full Phase 1-4 flow (includes architecture critique phases)
+- `references/architecture-fitness.md` — health metrics, domain skill routing, reference search prompts, thinktank templates
 - `references/synthesis-workflow.md` — backlog reduction, issue creation, summaries, plan artifact, visual output
 
 ### Standards

--- a/core/groom/SKILL.md
+++ b/core/groom/SKILL.md
@@ -42,17 +42,22 @@ in the same turn. Do not stop at recommendations unless the user explicitly asks
 **Intent-first backlog.** Every issue must carry a clear Intent Contract that downstream
 build/PR workflows can reference.
 
-**Backlog is strategy, not storage.** Keep the backlog small, current, and legible.
-Rough target: a couple dozen active issues, not 100+.
+**Backlog is strategy, not storage.** GitHub issues are the active plan — 20-30 max,
+every one groomed to score >= 70, every one execution-ready or clearly blocked.
+Ideas beyond the active window live in `.groom/BACKLOG.md`.
 
-**Slash before adding.** When the backlog sprawls, default to merge/close/defer/rewrite
-until the remaining set reflects the highest-priority themes.
+**Two-tier system.** GitHub = commitments. `.groom/BACKLOG.md` = ideas, someday/maybes,
+deferred themes, research prompts. Groom sessions read BACKLOG.md for promotion
+candidates and write back demoted ideas. See `references/backlog-doctrine.md`.
+
+**100% groomed or it doesn't belong.** If an issue can't pass `/issue lint` >= 70,
+it's either not ready (fix it) or not real (move to BACKLOG.md or close).
+
+**Slash before adding.** When the backlog exceeds 30 open issues, default to
+merge/close/demote-to-BACKLOG.md until it's back under the cap.
 
 **One roadmap, not many.** The backlog should read like the project's current plan,
 not an archive of every bug, nit, brainstorm, review comment, or screenshot.
-
-**Use judgment, not quotas.** The point is coherence and execution bandwidth, not
-hitting an exact issue count.
 
 **Code is a liability.** Every line fights for its life. Prefer deletion over addition.
 
@@ -77,13 +82,13 @@ Load that file before creating any issues.
 
 Run `/groom` in six phases:
 
-1. **Ground** — load or update `project.md`, check repo context freshness, read retro, capture user pain, audit backlog health, compute health metrics (LOC per module, fix-to-feature ratio, test-to-code ratio, backlog size)
+1. **Ground** — load or update `project.md`, load `.groom/BACKLOG.md`, check repo context freshness, read retro, capture user pain, audit backlog health (enforce 20-30 cap), compute health metrics
 2. **Architecture Critique** — three parallel tracks: reference architecture search, domain skill invocation, multi-model thinktank. See `references/architecture-fitness.md`
 2.5. **Present Options** — synthesize tracks A-C into 2-3 architectural options (incremental to radical), ask user what range of change is acceptable
 3. **Research** — web, cross-repo, and codebase research, scoped to the direction chosen in 2.5
 4. **Exploration** — pitch options, recommend one, discuss, validate with thinktank, then lock direction
-5. **Synthesis** — reduce the backlog first (close issues that deepen the wrong architecture), then create only missing strategic issues
-6. **Artifact** — save a dated grooming plan and visual summary when useful
+5. **Synthesis** — reduce GitHub backlog to cap (demote to BACKLOG.md, close, merge), then promote from BACKLOG.md or create for missing gaps. Every surviving issue must score >= 70.
+6. **Artifact** — save a dated grooming plan, update `.groom/BACKLOG.md`, visual summary when useful
 
 Synthesis default:
 - issue edits, issue creation, issue closure, and label/milestone cleanup are part of the normal `/groom` deliverable
@@ -104,7 +109,7 @@ Synthesis default:
 - `references/project-baseline.md` — baseline project standards
 
 ### Backlog Doctrine (absorbed from agent-backlog)
-- `references/backlog-doctrine.md` — ordering, shaping, cadence, smells, definition of ready
+- `references/backlog-doctrine.md` — two-tier system (GitHub active + BACKLOG.md icebox), ordering, cap enforcement, cadence, smells
 - `references/github-issues.md` — platform primitives, hierarchy, intake, planning
 - `references/agent-issue-writing.md` — writing agent-executable issue bodies, type-specific guidance
 - `references/overhaul-workflow.md` — full backlog rebuild: audit, theme, reduce, rewrite, hierarchy
@@ -115,9 +120,11 @@ Synthesis default:
 
 Default stance:
 - explore before scoping
-- reduce before adding
+- reduce before adding (demote to BACKLOG.md, don't just close)
 - keep one canonical issue where several shallow issues would otherwise survive
+- promote from BACKLOG.md before inventing new issues
 - create new issues only for genuine roadmap gaps
+- end every session with GitHub backlog at 20-30 issues, 100% groomed
 
 ## Modes
 

--- a/core/groom/references/architecture-fitness.md
+++ b/core/groom/references/architecture-fitness.md
@@ -1,0 +1,151 @@
+# Architecture Fitness
+
+Reference for Phase 2 (Architecture Critique) and Phase 2.5 (Present Options) of `/groom`.
+
+## Health Metrics Collection
+
+Run before architecture critique to ground the discussion in data:
+
+```bash
+# LOC per module (top 20 largest)
+find . -name '*.ex' -o -name '*.go' -o -name '*.ts' -o -name '*.py' \
+  | grep -v node_modules | grep -v _build | grep -v deps \
+  | while read f; do echo "$(wc -l < "$f") $f"; done \
+  | sort -rn | head -20
+
+# Fix-to-feature ratio (last 100 commits)
+FIX=$(git log --oneline -100 | grep -c '^[a-f0-9]* fix')
+FEAT=$(git log --oneline -100 | grep -c '^[a-f0-9]* feat')
+echo "Fix:Feature = $FIX:$FEAT"
+
+# Test-to-code ratio
+TEST_LOC=$(find . \( -name '*_test.*' -o -name '*.test.*' -o -name '*_spec.*' \) \
+  | grep -v node_modules | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}')
+CODE_LOC=$(find . \( -name '*.ex' -o -name '*.go' -o -name '*.ts' -o -name '*.py' \) \
+  | grep -v node_modules | grep -v test | grep -v spec \
+  | xargs wc -l 2>/dev/null | tail -1 | awk '{print $1}')
+echo "Test:Code = ${TEST_LOC:-0}:${CODE_LOC:-0}"
+
+# LOC growth rate (last 7 days)
+ADDED=$(git log --since="7 days ago" --numstat --format="" | awk '{s+=$1} END {print s+0}')
+REMOVED=$(git log --since="7 days ago" --numstat --format="" | awk '{s+=$2} END {print s+0}')
+echo "7-day delta: +$ADDED -$REMOVED (net $((ADDED - REMOVED)))"
+
+# Backlog size
+gh issue list --state open --json number --jq 'length'
+```
+
+### Red Flag Thresholds
+
+| Metric | Healthy | Warning | Critical |
+|--------|---------|---------|----------|
+| Fix:Feature ratio | <1:2 | 1:1 | >2:1 |
+| LOC growth (7d) | <500 net | 500-2000 | >2000 |
+| Largest module | <500 LOC | 500-1000 | >1000 |
+| Open issues | <30 | 30-60 | >60 |
+
+## Domain Skill Routing Table
+
+Detect project domain from `project.md` and codebase signals, then invoke relevant skills:
+
+| Domain Signal | Skills to Invoke |
+|---------------|-----------------|
+| AI/LLM features, prompts, evals | `/llm-infrastructure` |
+| Agent harness, dispatch, sprites | `/harness-engineering` |
+| Quality infra, CI/CD, hooks | `/check-quality` |
+| External APIs, webhooks | `/external-integration-patterns` |
+| Frontend UI, components | `/design`, `/visual-qa` |
+| Database, migrations | `/database` |
+| Payments, subscriptions | `/business-model-preferences` |
+| CLI tools | `/cli-reference` |
+| Context/prompt engineering | `/context-engineering` |
+
+Each skill audits the codebase through its lens. Aggregate findings as architectural concerns.
+
+## Reference Architecture Search Prompts
+
+### For Gemini / Web Search
+
+```text
+We're building: {one-paragraph project description from project.md}
+Current stack: {languages, frameworks, key dependencies}
+Current scale: {LOC, modules, team size}
+
+Find:
+1. Open-source projects solving the same problem
+2. Blog posts / conference talks about this domain's architecture
+3. Framework-level solutions (e.g., OTP for concurrency, Rails for CRUD)
+4. What tech stack choices do successful projects in this domain make?
+```
+
+### For Codex / Codebase Analysis
+
+```text
+Analyze this codebase's architecture:
+1. What design patterns are in use?
+2. Where does complexity concentrate?
+3. What would a senior engineer change first?
+4. Are there framework/language features being underused?
+5. Are there libraries being used that the language/runtime already handles?
+```
+
+## Thinktank Prompt Template
+
+```text
+## Project Context
+{project.md content}
+
+## Architecture
+{CLAUDE.md architecture section or docs/architecture.md}
+
+## Health Metrics
+{output from health metrics collection}
+
+## Questions for the Council
+
+1. Is the tech stack right for this problem domain?
+2. Are we over-engineering? Under-engineering?
+3. What would you do differently if starting from scratch today?
+4. What's the single biggest architectural risk?
+5. Name one thing to kill and one thing to double down on.
+6. Are there well-known frameworks/patterns we're reinventing?
+7. Rate the current architecture 1-10 and justify.
+```
+
+## Option Presentation Format
+
+Present 2-3 options after synthesizing tracks A-C:
+
+```markdown
+## Architectural Options
+
+### Option 1: Incremental Tuning
+- Keep current architecture
+- Fix: [specific issues from critique]
+- Risk: [what stays broken]
+- Effort: [low/medium]
+
+### Option 2: Targeted Restructuring
+- Change: [one major dimension — language, framework, pattern]
+- Because: [evidence from reference search / thinktank]
+- Risk: [migration cost, learning curve]
+- Effort: [medium/high]
+
+### Option 3: Radical Restructuring
+- Throw away: [what to delete]
+- Replace with: [target architecture from references]
+- Because: [multiple models recommend, reference arch is proven]
+- Risk: [timeline, unknown unknowns]
+- Effort: [high]
+
+### Recommendation
+[Which option and why, grounded in evidence]
+```
+
+### When to Always Include the Radical Option
+
+- LOC grew >3x in a sprint without proportional value
+- Fix-to-feature ratio exceeds 2:1
+- Multiple thinktank models independently recommend a different approach
+- Reference architectures show a fundamentally simpler path
+- Health metrics show critical thresholds on 2+ dimensions

--- a/core/groom/references/backlog-doctrine.md
+++ b/core/groom/references/backlog-doctrine.md
@@ -1,18 +1,36 @@
 # Backlog Doctrine
 
-## What the backlog is for
+## Two-Tier Backlog
 
-Treat the backlog as the current plan, not as storage for every idea. A good backlog is ordered,
-transparent, and actively maintained. It should make the next decisions obvious.
+GitHub issues are the **active plan** — the work you're committing to execute.
+`.groom/BACKLOG.md` is the **idea icebox** — everything else worth remembering.
+
+| Tier | Location | Cap | Grooming Standard |
+|------|----------|-----|-------------------|
+| Active | GitHub Issues | 20-30 | 100% score >= 70, all labeled, all execution-ready |
+| Icebox | `.groom/BACKLOG.md` | Unlimited | Categorized, dated, pruned each groom session |
+
+Ideas flow between tiers during `/groom` sessions:
+- **Promote:** BACKLOG.md → GitHub issue (idea becomes priority)
+- **Demote:** GitHub issue → BACKLOG.md (issue loses priority, close with link)
+- **Archive:** BACKLOG.md → strikethrough (idea is done, obsolete, or absorbed)
+- **Discard:** either tier → gone (idea has no remaining value)
+
+## What the active backlog is for
+
+The GitHub backlog is the current plan, not storage for every idea. A good backlog
+is ordered, transparent, and actively maintained. It should make the next decisions obvious.
 
 ## Core rules
 
-- Keep the backlog small enough to read end-to-end.
+- **Hard cap: 20-30 open issues.** Over cap triggers reduction, not addition.
+- **100% groomed.** Every issue scores >= 70 on `/issue lint` or gets fixed/demoted.
 - Reduce before adding.
 - Prefer one canonical issue per outcome.
 - Split discovery from delivery.
 - Order work by user value, risk reduction, learning, and enablement.
 - Keep active work narrow. High WIP destroys prioritization.
+- Ideas that aren't execution-ready live in `.groom/BACKLOG.md`, not GitHub.
 
 ## Healthy item shapes
 
@@ -54,10 +72,11 @@ Move items down when they:
 
 ## Cadence
 
-- Triage new intake quickly into keep, merge, defer, or close.
+- Triage new intake quickly into keep, merge, demote, or close.
 - Re-read the active backlog regularly enough to remove stale assumptions.
 - Run pruning passes, not just addition passes.
 - Update the canonical issue body when the plan changes. Do not bury the truth in comments.
+- Review `.groom/BACKLOG.md` every groom session — promote, archive, or leave.
 
 ## Smells
 
@@ -67,6 +86,9 @@ Move items down when they:
 - giant omnibus tickets with unclear done criteria
 - issues that require tribal knowledge to start
 - “investigate” tickets with no decision target
+- >30 open issues (backlog is storage, not strategy)
+- issues scoring < 70 sitting open for weeks (ungroomed noise)
+- BACKLOG.md not updated in 3+ groom sessions (icebox is rotting)
 
 ## Definition of ready
 

--- a/core/groom/references/backlog-health.md
+++ b/core/groom/references/backlog-health.md
@@ -57,6 +57,31 @@ Check for:
 - Issues with no type label
 - Issues missing horizon label
 
+### 6. BACKLOG.md Status
+
+```bash
+if [ -f .groom/BACKLOG.md ]; then
+  echo "BACKLOG.md exists"
+  grep -c '^\- \*\*' .groom/BACKLOG.md 2>/dev/null || echo "0 entries"
+  head -3 .groom/BACKLOG.md | grep -o 'Last groomed: .*' || echo "Last groomed: unknown"
+else
+  echo "No .groom/BACKLOG.md (will create on first groom session)"
+fi
+```
+
+### 7. Cap Enforcement
+
+```bash
+OPEN=$(gh issue list --state open --json number --jq 'length')
+if [ "$OPEN" -gt 30 ]; then
+  echo "OVER CAP: $OPEN open issues (cap: 30). Reduction required."
+elif [ "$OPEN" -gt 20 ]; then
+  echo "AT CAP: $OPEN open issues (target: 20-30). Monitor."
+else
+  echo "UNDER CAP: $OPEN open issues. Room for $(( 20 - OPEN )) more."
+fi
+```
+
 ## Output
 
 ```
@@ -64,7 +89,7 @@ BACKLOG HEALTH: {repo}
 ======================
 
 Overview:
-  Total open: 20
+  Total open: 20 (cap: 20-30) ✓
   Ready for execution (score >= 70): 12 (60%)
   Needs enrichment (score 50-69): 3 (15%)
   Incomplete (score < 50): 5 (25%)
@@ -93,9 +118,16 @@ Label Issues:
   Missing type: #31
   Legacy labels: #15 (priority/p0 -> p0)
 
+BACKLOG.md:
+  Status: exists / missing
+  High Potential: N ideas
+  Someday/Maybe: N ideas
+  Last groomed: {date}
+
 Recommendations:
   1. Close or update 3 stale issues
   2. Enrich 5 incomplete issues (/issue lint --all --fix)
   3. Migrate 1 legacy label
   4. Add priority to 2 unlabeled issues
+  5. Demote N issues to BACKLOG.md (over cap / below grooming threshold)
 ```

--- a/core/groom/references/interactive-workflow.md
+++ b/core/groom/references/interactive-workflow.md
@@ -1,7 +1,7 @@
 # Interactive Workflow
 
-Use this reference for the full interactive `/groom` flow through context,
-discovery, research, and exploration.
+Use this reference for the full interactive `/groom` flow through ground,
+architecture critique, research, and exploration.
 
 ## Phase 1: Context
 
@@ -36,7 +36,7 @@ Verify that codebase context artifacts are current:
 [ -f docs/context/ROUTING.md ] && echo "Routing table exists" || echo "No routing table"
 [ -f docs/context/DRIFT-WATCHLIST.md ] && echo "Drift watchlist exists" || echo "No drift watchlist"
 [ -f CLAUDE.md ] && echo "CLAUDE.md exists" || echo "No CLAUDE.md"
-[ -f AGENTS.md ] && echo "AGENTS.md exists" || echo "No AGENTS.md"
+[ -L AGENTS.md ] && echo "AGENTS.md is symlink (good)" || { [ -f AGENTS.md ] && echo "X AGENTS.md is a regular file — should be symlink to CLAUDE.md (drift risk)" || echo "No AGENTS.md"; }
 ```
 
 If stale or missing, recommend `/tune-repo`. Do not block grooming.
@@ -81,18 +81,55 @@ Also evaluate backlog budget:
 If the backlog sprawls, declare:
 `This is now a reduction session. Default action is keep/merge/defer/close, not add.`
 
-## Phase 2: Discovery
+### Step 6: Compute Health Metrics
 
-Launch parallel discovery lanes:
+Gather quantitative project health signals. See `architecture-fitness.md` for full
+metrics collection script and red flag thresholds.
 
-| Agent | Focus |
-|-------|-------|
-| Product strategist | gaps vs vision, user value opportunities |
-| Technical archaeologist | code health, architectural debt, improvement patterns |
-| Domain auditors | `/audit --all` |
-| Growth analyst | acquisition, activation, retention opportunities |
+Key metrics to capture:
+- LOC per module (top 20 largest files)
+- Fix-to-feature ratio (last 100 commits)
+- Test-to-code ratio
+- LOC growth rate (last 7 days)
+- Open issue count
 
-Synthesize findings into 3-5 strategic themes with evidence.
+Store as `{health_metrics}` for Phase 2 context.
+
+## Phase 2: Architecture Critique
+
+Three parallel investigation tracks. This is the immune system — it catches broken
+trajectories before issues deepen them. See `architecture-fitness.md` for full
+prompts, routing tables, and templates.
+
+### Track A: Reference Architecture Search
+
+Launch 2-3 sub-agents to find similar projects:
+
+- Gemini CLI: "We're building [project description from project.md]. Find open-source repos, articles, frameworks solving similar problems."
+- Web search: "[domain] open-source [tech stack alternatives]"
+- Codex: scan codebase for architectural patterns, compare to industry standard
+
+For each reference found, capture:
+- Design choices and tech stack
+- What worked, what to adopt/avoid
+- Scale and maturity signals
+
+### Track B: Domain Skill Invocation
+
+Detect project domain from `project.md` and codebase, then invoke relevant skills
+per the routing table in `architecture-fitness.md`.
+
+Each skill audits the current codebase through its lens. Aggregate findings as
+architectural concerns.
+
+### Track C: Multi-Model Architecture Thinktank
+
+Invoke `/research thinktank` with project context + architecture docs + health metrics.
+Use the thinktank prompt template from `architecture-fitness.md`.
+
+Also invoke CLI agents (`pi`, `gemini`, `codex`) for harness-diverse perspectives.
+
+Synthesize findings from all three tracks into 3-5 strategic themes with evidence.
 
 Present a Mermaid dependency map:
 
@@ -106,9 +143,31 @@ graph LR
 
 Then ask which themes to explore.
 
-## Phase 3: Research
+## Phase 2.5: Present Options
+
+Synthesize findings from tracks A-C into 2-3 architectural options:
+
+1. **Incremental tuning** — keep current architecture, fix specific issues
+2. **Targeted restructuring** — change one major dimension (language, framework, pattern)
+3. **Radical restructuring** — throw it away and rebuild (only when evidence supports it)
+
+Always include the radical option when:
+- LOC grew >3x in a sprint without proportional value
+- Fix-to-feature ratio exceeds 2:1
+- Multiple models independently recommend a different approach
+- Reference architectures show a fundamentally simpler path
+
+See `architecture-fitness.md` for option presentation format.
+
+Ask: **"What range of change is acceptable this session?"**
+
+This sets the scope for Phases 3-5 (grooming within the chosen architectural direction).
+
+## Phase 3: Research (scoped by Phase 2.5)
 
 For each theme the user wants to explore, do research before scoping.
+Research is now scoped to the architectural direction chosen in Phase 2.5.
+If radical restructuring was chosen, research the target architecture deeply.
 
 ### Research lanes
 

--- a/core/groom/references/interactive-workflow.md
+++ b/core/groom/references/interactive-workflow.md
@@ -53,6 +53,21 @@ Extract:
 
 Present: "From past implementations, I see these patterns: [summary]"
 
+### Step 3b: Load BACKLOG.md
+
+Check for `.groom/BACKLOG.md`:
+
+```bash
+[ -f .groom/BACKLOG.md ] && echo "BACKLOG.md exists ($(wc -l < .groom/BACKLOG.md) lines)" || echo "No .groom/BACKLOG.md"
+```
+
+**If exists:** Read it. Note "High Potential" items as promotion candidates.
+Present: "BACKLOG.md has N high-potential ideas and N someday/maybes. Last groomed: {date}."
+
+**If doesn't exist:** Will create during Phase 5 synthesis if any ideas get deferred.
+
+Store as `{backlog_md}` for use during synthesis.
+
 ### Step 4: Capture What's On Your Mind
 
 Ask:
@@ -72,14 +87,18 @@ Run the health dashboard procedure from `references/backlog-health.md`.
 
 Present: "Here's where we stand: X open issues, Y ready for execution, Z need enrichment."
 
-Also evaluate backlog budget:
-- Is the open issue count still legible?
+Also evaluate backlog budget against the hard cap:
+- **Cap check:** >30 open issues → this is a reduction session, no new issues until under cap
+- **Grooming check:** any issue scoring < 70 → must be enriched, rewritten, or demoted
 - Do issues cluster around a few strategic themes?
 - Is there duplicate/refactor/screenshot-only noise?
-- Are there ideas better kept in docs/notes than as open issues?
+- Are there ideas better kept in `.groom/BACKLOG.md` than as open issues?
 
-If the backlog sprawls, declare:
-`This is now a reduction session. Default action is keep/merge/defer/close, not add.`
+If over cap, declare:
+`Over the 30-issue cap (N open). This is a reduction session. Default action is keep/merge/demote/close, not add.`
+
+If any issues score < 70:
+`N issues below grooming threshold. Every GitHub issue must score >= 70 or be demoted to BACKLOG.md.`
 
 ### Step 6: Compute Health Metrics
 

--- a/core/groom/references/synthesis-workflow.md
+++ b/core/groom/references/synthesis-workflow.md
@@ -9,41 +9,80 @@ exploration into a reduced, coherent backlog.
 
 Reduce the backlog before creating anything new.
 
-Use four buckets:
-- **Keep** — current, high-leverage, aligned with locked themes
+Use five buckets:
+- **Keep** — current, high-leverage, aligned with locked themes, scores >= 70
 - **Merge** — overlapping issues collapsed into one canonical issue
-- **Defer** — valid, but outside the current strategic window
+- **Demote** — valid idea, but outside the active window → move to `.groom/BACKLOG.md`
 - **Close** — stale, duplicate, vague, obsolete, or better captured elsewhere
+- **Promote** — idea from `.groom/BACKLOG.md` that now warrants an active issue
 
 Guidance:
 - prefer one deep canonical issue over several shallow siblings
-- screenshot-only or vibe-only issues are not backlog-ready; rewrite or close
+- screenshot-only or vibe-only issues are not backlog-ready; rewrite or demote
 - refactor issues without clear strategic leverage usually merge into a parent
-- future ideas without active priority usually move to docs/notes, not stay open
+- future ideas without active priority → demote to BACKLOG.md, not open issues
+- **hard cap: 20-30 open issues.** If over, demote lowest-priority until under cap
 
 Present the reduction proposal before creating net-new issues:
 
 ```markdown
 ## Backlog Reduction Proposal
 
-### Keep
+### Keep (N issues)
 - #N — why it survives
 
 ### Merge
 - #N + #N -> #N canonical issue
 
-### Defer
-- #N — why later
+### Demote to BACKLOG.md
+- #N — "reason" (will close issue, add entry to BACKLOG.md)
 
 ### Close
-- #N — why it leaves the backlog
+- #N — why it leaves entirely
+
+### Promote from BACKLOG.md
+- "idea title" — why it's now active (will create issue, remove from BACKLOG.md)
 ```
 
-The outcome should be a backlog that can be scanned in minutes and understood as the current roadmap.
+**Post-reduction invariant:** GitHub backlog has 20-30 issues, all scoring >= 70.
+Every deferred idea has a home in `.groom/BACKLOG.md`, not lost.
+
+### Step 1b: Update BACKLOG.md
+
+After the reduction proposal is approved:
+
+1. **Demoted issues** → close on GitHub with comment "Moved to .groom/BACKLOG.md", add entry to BACKLOG.md with original issue context
+2. **Promoted ideas** → remove from BACKLOG.md (they'll become issues in Step 2)
+3. **Stale BACKLOG.md entries** → review and prune ideas that are no longer relevant
+4. **New ideas from session** → add to BACKLOG.md if not making the active cut
+
+BACKLOG.md format:
+
+```markdown
+# Backlog Ideas
+
+Last groomed: {date}
+
+## High Potential (promote next session if capacity)
+- **idea title** — one-line context. Source: #{issue} / user / audit / thinktank.
+- ...
+
+## Someday / Maybe
+- **idea title** — one-line context. Source: ...
+- ...
+
+## Research Prompts
+- **question** — what we'd need to learn before this becomes actionable
+- ...
+
+## Archived This Session
+- ~~idea title~~ — why removed (done, obsolete, absorbed into #N)
+```
 
 ### Step 2: Create Issues Only For Missing Strategic Gaps
 
 Create issues only when they fill a real gap in the reduced roadmap.
+Check `.groom/BACKLOG.md` "High Potential" section first — promote before inventing.
 
 Use the org-standards format:
 - Problem
@@ -97,8 +136,18 @@ GROOM SUMMARY
 
 Themes Explored: [list]
 Directions Locked: [list]
-Backlog Before: N open
-Backlog After: N open
+
+GitHub Backlog:
+  Before: N open → After: N open (cap: 20-30)
+  Demoted to BACKLOG.md: N
+  Promoted from BACKLOG.md: N
+  Merged: N
+  Closed: N
+
+BACKLOG.md:
+  High Potential: N ideas
+  Someday/Maybe: N ideas
+  Archived this session: N
 
 Issues by Priority:
 - P0 (Critical): N
@@ -107,9 +156,9 @@ Issues by Priority:
 - P3 (Nice to Have): N
 
 Readiness Scores:
+- All issues scored >= 70 ✓ (REQUIRED)
 - Excellent (90-100): N
 - Good (70-89): N
-- All issues scored >= 70 ✓
 
 Recommended Execution Order:
 1. [P0] ...
@@ -120,9 +169,9 @@ View all: gh issue list --state open
 ```
 
 Add one verdict:
-- `Backlog is focused`
-- `Backlog still too large`
-- `Backlog reduced but needs one more slash pass`
+- `Backlog is focused` (20-30 issues, 100% groomed)
+- `Backlog over cap` (>30 — needs another slash pass)
+- `BACKLOG.md needs triage` (too many High Potential items without clear priority)
 
 ## Phase 6: Plan Artifact
 
@@ -137,14 +186,12 @@ Write `.groom/plan-{date}.md`:
 ## Issues Created
 - #N: [title] (score: X/100)
 
-## Reduced / Closed / Merged
+## Reduced / Closed / Merged / Demoted
 - keep: [list]
 - merged: [list]
-- deferred: [list]
+- demoted to BACKLOG.md: [list]
 - closed: [list]
-
-## Deferred
-- [topic]: [why deferred, when to revisit]
+- promoted from BACKLOG.md: [list]
 
 ## Research Findings
 [Key findings from Phase 3 worth preserving]


### PR DESCRIPTION
## What Changed

Strengthens the groom → build → ship pipeline with three coordinated improvements:

1. **Architecture-first grooming** — Before scoping issues, groom now runs a three-track architecture critique (reference search + domain skills + thinktank), presents 2-3 options (incremental → radical), and scopes all issues within the chosen direction. Stops grooming from deepening a broken architecture.

2. **Module size enforcement** — `check-quality` now flags files >500 LOC as P2 and surfaces them during audits. New `module-size-guidance.md` explains the deep module vs tangled mess distinction so agents don't blindly decompose cohesive code.

3. **Mandatory simplify pass** — `/simplify` is now a required step (not optional) in both `build` and `autopilot` when the diff exceeds 200 LOC net.

## Why This Matters

The previous groom flow created issues in a discovery-first order — find themes, then scope work. But discovery without architecture critique meant issues could deepen a wrong trajectory. The new Phase 2 architecture critique acts as an immune system, catching broken directions before they get more issues filed against them.

Module size and simplify enforcement closes the loop on the other end: even well-groomed issues can produce bloated implementations without a quality gate on output size.

## Trade-offs / Risks

- **Groom sessions are now longer** — architecture critique adds real upfront time. Acceptable trade-off: catching a wrong architecture in groom is cheaper than catching it after 5 PRs.
- **Phase 2.5 requires user input** — the "what range of change is acceptable?" prompt blocks async groom. This is intentional; direction should not be assumed.
- **Radical option is always presented when evidence supports it** — some users may find this uncomfortable. The threshold criteria are explicit to avoid false alarms.

## Reviewer Evidence

<details>
<summary>Files changed</summary>

| File | Change |
|------|--------|
| `core/groom/SKILL.md` | Phase redesign: Ground → Architecture Critique → 2.5 Present Options → Research |
| `core/groom/references/interactive-workflow.md` | Full workflow updated for new phases |
| `core/groom/references/architecture-fitness.md` | **New** — health metrics, domain routing table, thinktank template, option format |
| `core/check-quality/SKILL.md` | Module size check added, P2 threshold added |
| `core/check-quality/references/module-size-guidance.md` | **New** — LOC thresholds, deep module distinction, language lint tools |
| `core/autopilot/SKILL.md` | `/simplify` made mandatory for >200 LOC net |
| `core/build/SKILL.md` | `/simplify` added as step 1 in post-implementation |

</details>

<details>
<summary>Architecture fitness reference (key excerpt)</summary>

Health metric thresholds:
- Fix:Feature > 2:1 → Critical
- LOC growth (7d) > 2000 → Critical  
- Largest module > 1000 LOC → Critical
- Open issues > 60 → Critical

Domain skill routing: `/llm-infrastructure` for AI features, `/harness-engineering` for agent dispatch, `/check-quality` for CI, etc.

Thinktank questions: Is the stack right? Over/under-engineered? What to kill? What to double down on? Rate 1-10.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mandatory code simplification when net diff > 200 LOC.
  * Module-size checks flagging files >500 LOC.
  * Two-tier backlog workflow with promote/demote flows and hard cap enforcement.

* **Documentation**
  * Detailed module-size guidance and thresholds.
  * Architecture-fitness reference with health metrics and red-flag criteria.
  * Expanded grooming and synthesis workflow docs, backlog health/status guidance, and artifact rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->