### PR TITLE
feat: platform-native-first groom check + /moonshot skill

### DIFF
--- a/core/groom/SKILL.md
+++ b/core/groom/SKILL.md
@@ -71,6 +71,8 @@ not an archive of every bug, nit, brainstorm, review comment, or screenshot.
 
 **Reference architecture first.** Always search for existing implementations before designing from scratch.
 
+**Platform-native first.** Before keeping any integration issue, verify the target platform doesn't already offer the capability natively.
+
 **Model diversity for architecture.** Use thinktank + CLI agents for diverse perspectives on design decisions.
 
 ## Org-Wide Standards

--- a/core/groom/references/architecture-fitness.md
+++ b/core/groom/references/architecture-fitness.md
@@ -82,6 +82,20 @@ Find:
 4. What tech stack choices do successful projects in this domain make?
 ```
 
+### Existing Tool / Platform Check
+
+Before preserving any backlog item, ask: **"Does an existing platform feature, integration, or CLI command already solve this?"**
+
+Examples of things that don't need custom code:
+- Error tracking → Sentry already files GitHub issues
+- CI/CD orchestration → GitHub Actions, platform-native workflows
+- Webhook delivery → platform-native webhook support (GitHub, Stripe, etc.)
+- Log aggregation → Fly.io built-in logs, `fly logs`
+- Secret management → platform-native secrets (Fly secrets, GitHub secrets)
+- Deployment → `fly deploy`, `mix release`, platform CLIs
+
+If an existing tool handles it, the backlog item should be closed with a pointer to the existing solution, not kept as planned work.
+
 ### For Codex / Codebase Analysis
 
 ```text

--- a/core/groom/references/synthesis-workflow.md
+++ b/core/groom/references/synthesis-workflow.md
@@ -9,11 +9,12 @@ exploration into a reduced, coherent backlog.
 
 Reduce the backlog before creating anything new.
 
-Use five buckets:
+Use six buckets:
 - **Keep** — current, high-leverage, aligned with locked themes, scores >= 70
 - **Merge** — overlapping issues collapsed into one canonical issue
 - **Demote** — valid idea, but outside the active window → move to `.groom/BACKLOG.md`
 - **Close** — stale, duplicate, vague, obsolete, or better captured elsewhere
+- **Redundant** — proposes building what an existing platform feature, integration, or CLI already handles. Close with an explanation of the existing solution (e.g., "Sentry already files issues for this", "GitHub Actions handles this natively")
 - **Promote** — idea from `.groom/BACKLOG.md` that now warrants an active issue
 
 Guidance:

--- a/core/moonshot/SKILL.md
+++ b/core/moonshot/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: moonshot
+description: |
+  Identify the single highest-leverage, most innovative addition to the project.
+  Forces divergent thinking beyond the current roadmap. One answer, fully argued.
+  Use when: "what should we build next", "what's the biggest opportunity",
+  "step back and think big", "what's missing", "surprise me".
+  Trigger: /moonshot, "biggest opportunity", "what would you build".
+disable-model-invocation: true
+---
+
+# /moonshot
+
+Stop. Step back from the backlog, the roadmap, the current sprint. Answer one question:
+
+> **What's the single smartest, most radically innovative, accretive, useful, and
+> compelling addition you could make to this project at this point?**
+
+## Rules
+
+1. **Exactly one answer.** Not a list. Not options. One thing, fully committed.
+2. **Argue it.** Why THIS over everything else? What makes it the inflection point?
+3. **Be bold.** This is not incremental improvement. This is the move that changes the trajectory.
+4. **Be concrete.** Name the feature, the architecture, the integration — not a vague direction.
+5. **Be honest.** If the project needs something unglamorous, say that. Innovation includes knowing when the highest leverage is boring infrastructure.
+
+## Process
+
+### 1. Deep Immersion
+
+Before answering, build a complete mental model:
+
+- Read the full codebase structure (`.glance.md` files, READMEs, CLAUDE.md)
+- Read the backlog (GitHub issues, `.groom/BACKLOG.md`)
+- Read recent git history (last 30 commits minimum)
+- Read any project.md, retro files, or ADRs
+- Understand the user, the product, the market context
+
+### 2. Divergent Search
+
+Generate at least 10 candidates internally. For each, evaluate:
+
+- **Leverage**: How much value per unit of effort?
+- **Innovation**: Does this exist elsewhere? Is this a novel combination?
+- **Accretion**: Does this compound? Does it make future work easier/better?
+- **Usefulness**: Does this solve a real problem or create real capability?
+- **Timing**: Why now? What makes this the right moment?
+
+### 3. Convergent Selection
+
+Pick one. Kill your darlings. The answer should survive this gauntlet:
+
+- "If we could only ship one more thing, would this be it?"
+- "Will this still matter in 6 months?"
+- "Does this unlock things that are currently impossible, not just inconvenient?"
+- "Is this the kind of thing that makes people say 'why didn't we do this sooner'?"
+
+### 4. The Pitch
+
+Present your answer as:
+
+```
+## The Move
+
+[One sentence: what it is]
+
+## Why This, Why Now
+
+[2-3 paragraphs: the argument. What changes. What it unlocks.
+Why the timing is right. Why everything else is less important.]
+
+## What It Looks Like
+
+[Concrete description: architecture, UX, integration points.
+Enough detail to judge feasibility.]
+
+## What It Costs
+
+[Honest effort estimate. What gets displaced. What risks exist.]
+
+## The Unlock
+
+[What becomes possible AFTER this ships that isn't possible today?]
+```
+
+## Anti-Patterns
+
+- Listing 5 ideas and asking the user to pick (that's `/groom`)
+- Proposing something the project already does
+- Vague directional advice ("invest in testing", "improve DX")
+- Safe, incremental, obvious next steps (that's the backlog)
+- Ignoring constraints (team size, tech stack, market position)
+
+## Composability
+
+After `/moonshot`, the user may:
+- `/groom` — to fit the moonshot into the backlog
+- `/shape` — to plan the moonshot in detail
+- `/research thinktank` — to stress-test the idea
+- `/autopilot` — to just build it


### PR DESCRIPTION
## Summary

- **Platform-native-first check** added to groom's architecture fitness references — before keeping any integration issue, verify the target platform doesn't already offer the capability natively
- **`/moonshot` skill** (new, DMI) — forces divergent strategic thinking with one committed answer to "what's the single highest-leverage addition to the project?" Deep immersion → divergent search → convergent selection → structured pitch

## Test plan

- [ ] `/moonshot` appears in skill list and is invocable
- [ ] `/moonshot` is DMI (no budget cost, user-only)
- [ ] `sync.sh claude` includes moonshot in sync count
- [ ] Groom skill references platform-native-first in architecture fitness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to prefer platform-native capabilities before creating integrations.
  * Added a section to verify existing tools/platform features or CLIs can resolve backlog items.
  * Updated backlog categorization to include a "Redundant" bucket for items resolved by existing capabilities.
  * Added a new "moonshot" skill document outlining a single-answer, multi-stage process for proposing bold, high-impact features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->