### PR TITLE
feat: durable project.md format + readwise null safety

### DIFF
--- a/core/groom/references/interactive-workflow.md
+++ b/core/groom/references/interactive-workflow.md
@@ -10,14 +10,14 @@ architecture critique, research, and exploration.
 Check for `project.md` in project root:
 
 **If `project.md` exists:**
-1. Read and display current vision/focus
-2. Ask: "Is this still accurate? Any updates?"
-3. If updates, rewrite `project.md`
+1. Read and display current vision/principles
+2. Only update if vision, principles, philosophy, or domain language have genuinely changed
+3. Never inject ephemeral data (versions, issue numbers, sprint themes) — see `project-md-format.md`
 
 **If `project.md` doesn't exist (but `vision.md` does):**
 1. Read `vision.md`
 2. Migrate content into `project.md` format (see `project-md-format.md`)
-3. Interview for missing sections (domain glossary, quality bar, patterns)
+3. Interview for missing sections (principles, philosophy, domain glossary, quality bar)
 4. Write `project.md`, delete `vision.md`
 
 **If neither exists:**

--- a/core/groom/references/project-md-format.md
+++ b/core/groom/references/project-md-format.md
@@ -1,7 +1,11 @@
 # project.md Format Reference
 
 `project.md` lives in the project root. It captures **product context** that
-tune-repo artifacts don't cover: vision, users, priorities, domain language.
+tune-repo artifacts don't cover: vision, principles, philosophy, domain language.
+
+**Durability rule:** `project.md` should read correctly 6 months from now without
+updates. No version numbers, no issue references, no sprint snapshots. Those
+belong in GitHub milestones and `.groom/` artifacts.
 
 ## Relationship to Tune-Repo Artifacts
 
@@ -14,7 +18,7 @@ tune-repo artifacts don't cover: vision, users, priorities, domain language.
 | `docs/context/ROUTING.md` | `/tune-repo` | Trigger table for specialist routing |
 | `docs/context/*.md` | `/tune-repo` | Subsystem specifications |
 | `docs/adr/*.md` | `/tune-repo` | Architectural decision records |
-| **`project.md`** | **`/groom`** | **Vision, users, domain, quality bar** |
+| **`project.md`** | **`/groom`** | **Vision, principles, philosophy, domain, quality bar** |
 
 `project.md` fills the product gap. Together with tune-repo outputs, agents get
 everything they need: what the product is, who it's for, what matters, and how
@@ -28,10 +32,17 @@ the code is structured.
 ## Vision
 [One-liner: what this product is and who it's for]
 
-**North Star:** [Dream state — what success looks like in 2 years]
+**North Star:** [Dream state — what success looks like]
 **Target User:** [Specific persona]
-**Current Focus:** [Immediate priority this quarter]
 **Key Differentiators:** [What makes this different]
+
+## Principles
+- **[Name.]** [Durable design principle that guides decisions]
+- **[Name.]** [Another principle]
+
+## Philosophy
+- [Product philosophy — what matters, what doesn't, how to make tradeoffs]
+- [Engineering philosophy — what kind of code, what kind of UX]
 
 ## Domain Glossary
 
@@ -40,14 +51,6 @@ Terms agents must understand to work in this codebase.
 | Term | Definition |
 |------|-----------|
 | | |
-
-## Active Focus
-
-Current milestone and key issues driving work right now.
-
-- **Milestone:** [name] — [description]
-- **Key Issues:** #N, #N, #N
-- **Theme:** [what we're optimizing for right now]
 
 ## Quality Bar
 
@@ -80,6 +83,31 @@ Things we've tried that didn't work. Distilled from `.groom/retro/*.md`.
 *Updated during: /groom session*
 ```
 
+## What Belongs Here vs. Elsewhere
+
+| Content | Where it goes | Why |
+|---------|---------------|-----|
+| Vision, principles, philosophy | `project.md` | Durable — changes rarely |
+| Domain glossary | `project.md` | Durable — terms outlive sprints |
+| Quality bar | `project.md` | Durable — standards don't shift weekly |
+| Code patterns | `project.md` | Durable — conventions are stable |
+| Current sprint / milestone focus | GitHub milestones | Ephemeral — changes every sprint |
+| Active issue references (#N) | `.groom/plan-*.md` | Ephemeral — issues close |
+| Version numbers | `CHANGELOG.md` / tags | Ephemeral — versions ship |
+| Retro findings | `.groom/retro/*.md` | Ephemeral until distilled into Lessons Learned |
+
+## Anti-Patterns
+
+- **Version pinning:** "Current Focus: post-v3.4.0" — breaks on next release.
+- **Issue references in Vision:** "#187, #142" — meaningless once closed.
+- **Sprint snapshots:** "Active Focus: stability and polish" — stale in 2 weeks.
+- **Model counts:** "39+ models" — wrong after every registry update.
+
+Replace with durable equivalents:
+- "Current Focus: post-v3.4.0" → Principle: "Ship what matters."
+- "#187, #142" → GitHub milestone queries
+- "39+ models" → "many models"
+
 ## When to Create
 
 - `/groom` Phase 1 creates or updates `project.md`
@@ -95,5 +123,6 @@ Things we've tried that didn't work. Distilled from `.groom/retro/*.md`.
 
 ## Update Frequency
 
-Updated each `/groom` session. Between sessions, only "Active Focus" changes
-(when milestones shift or key issues close).
+Updated only when vision, principles, or domain language genuinely change.
+Sprint-level changes (milestones, active issues, themes) belong in GitHub
+and `.groom/plan-*.md`, not here.

--- a/core/readwise/SKILL.md
+++ b/core/readwise/SKILL.md
@@ -17,19 +17,15 @@ Query the user's Readwise Reader library for saved articles, highlights, and doc
 
 ## Authentication
 
-Token is in `$READWISE_ACCESS_TOKEN`. If not in env, source it:
+Source the token, then validate:
 ```bash
 eval "$(grep READWISE_ACCESS_TOKEN ~/.secrets)"
-```
-
-All requests use header: `Authorization: Token $READWISE_ACCESS_TOKEN`
-
-Validate before first use:
-```bash
 curl -s -o /dev/null -w "%{http_code}" https://readwise.io/api/v2/auth/ \
   -H "Authorization: Token $READWISE_ACCESS_TOKEN"
 # 204 = valid
 ```
+
+All requests use header: `Authorization: Token $READWISE_ACCESS_TOKEN`
 
 ## Core Operations
 
@@ -38,20 +34,20 @@ curl -s -o /dev/null -w "%{http_code}" https://readwise.io/api/v2/auth/ \
 No full-text search endpoint exists. Strategy: fetch documents, filter client-side.
 
 ```bash
-curl -s "https://readwise.io/api/v3/list/?category=article&location=later" \
+curl -s "https://readwise.io/api/v3/list/?limit=100" \
   -H "Authorization: Token $READWISE_ACCESS_TOKEN" \
-  | jq '[.results[] | select(.title + " " + (.summary // "") | test("TOPIC"; "i"))]
-        | .[] | {title, source_url, summary, reading_progress, word_count, saved_at}'
+  | jq '[.results[] | select(((.title // "") + " " + (.summary // "")) | test("TOPIC"; "i"))]
+        | .[] | {title: (.title // "(untitled)"), source_url, summary: (.summary // ""), reading_progress, word_count, saved_at}'
 ```
 
-For broader search, omit `category` and `location` filters. Search across `new`, `later`, and `archive`.
+Searches all locations by default. Add `&location=later` or `&category=article` to narrow.
 
 ### List Recent Saves
 
 ```bash
 curl -s "https://readwise.io/api/v3/list/?location=new&limit=20" \
   -H "Authorization: Token $READWISE_ACCESS_TOKEN" \
-  | jq '.results[] | {title, category, source_url, summary, saved_at, word_count}'
+  | jq '.results[] | {title: (.title // "(untitled)"), category, source_url, summary: (.summary // ""), saved_at, word_count}'
 ```
 
 ### List by Category
@@ -75,7 +71,7 @@ curl -s "https://readwise.io/api/v3/tags/" \
 ```bash
 curl -s "https://readwise.io/api/v3/list/?tag=TAG_NAME&limit=20" \
   -H "Authorization: Token $READWISE_ACCESS_TOKEN" \
-  | jq '.results[] | {title, source_url, summary}'
+  | jq '.results[] | {title: (.title // "(untitled)"), source_url, summary: (.summary // "")}'
 ```
 
 Up to 5 `tag` params allowed. Empty `tag=` finds untagged documents.
@@ -96,7 +92,7 @@ Highlights are documents with `parent_id` pointing to the source document.
 curl -s "https://readwise.io/api/v3/list/?category=highlight&limit=100" \
   -H "Authorization: Token $READWISE_ACCESS_TOKEN" \
   | jq '[.results[] | select(.parent_id == "DOCUMENT_ID")]
-        | .[] | {title, summary, notes}'
+        | .[] | {title: (.title // "(untitled)"), summary: (.summary // ""), notes: (.notes // "")}'
 ```
 
 ## Pagination


### PR DESCRIPTION
## Reviewer Evidence
- **Fast claim:** Skills-doc-only change. No tests needed. Merge on content review.
- **Walkthrough:** Diff-readable — three focused files, no logic changes.

## Why This Matters
- **Problem:** `project.md` was treated like a sprint dashboard — Active Focus, issue numbers, version snapshots. Agents reading a stale project.md got wrong context. The format encouraged ephemeral content that rots immediately.
- **Value:** `project.md` is now an identity document, not a status update. It captures vision, principles, and philosophy — things that don't change sprint to sprint. Sprint-level state belongs in GitHub milestones and `.groom/plan-*.md`.
- **Why now:** Noticed project.md files accumulating "#187, #142" references and "Current Focus: post-v3.4.0" entries that become misleading the moment those issues close or that version ships.
- **Issue:** N/A — organic improvement from observed usage patterns.

## Trade-offs / Risks
- **Value gained:** project.md files will be reliably durable. Agents won't be misled by stale sprint snapshots.
- **Cost / risk incurred:** Existing project.md files with Active Focus sections aren't automatically migrated. They'll stay as-is until the next `/groom` session touches them.
- **Why this is still the right trade:** Migration is naturally triggered by the next groom pass. No breaking change.
- **Reviewer watch-outs:** The Anti-Patterns section is prescriptive — check that the examples are accurate representations of the pattern to avoid.

## What Changed

Three files. Two are groom references, one is the readwise skill.

### Base Branch

```mermaid
graph TD
  A[groom Phase 1] --> B[Read project.md]
  B --> C[Ask: still accurate?]
  C --> D[Rewrite with updates]
  D --> E[project.md contains Active Focus + issue refs + versions]
```

### This PR

```mermaid
graph TD
  A[groom Phase 1] --> B[Read project.md vision/principles]
  B --> C{Vision changed?}
  C -- yes --> D[Rewrite vision/principles sections]
  C -- no --> E[Leave it]
  D --> F[project.md stays durable]
  E --> F
```

### project.md Structure Change

```mermaid
graph TD
  OLD["Before: Vision + Active Focus + Key Issues"] --> X[❌ Stale after one sprint]
  NEW["After: Vision + Principles + Philosophy + Glossary"] --> Y[✅ Accurate 6 months from now]
```

Why this is better:
- Active Focus and issue refs are ephemeral by nature — they belong in GitHub
- Principles and Philosophy are stable — they guide decisions without becoming stale
- The durability rule and Anti-Patterns section give agents a clear signal about what NOT to put in project.md

<details>
<summary>Changes</summary>

## Changes

**`core/groom/references/project-md-format.md`**
- Added durability rule: "should read correctly 6 months from now without updates"
- Replaced `Active Focus` section (milestone, issue refs, theme) with `Principles` + `Philosophy` sections
- Added `What Belongs Here vs. Elsewhere` table (durable vs ephemeral content)
- Added `Anti-Patterns` section with concrete examples and durable replacements
- Updated `Update Frequency` to reflect that sprint-level changes don't belong here

**`core/groom/references/interactive-workflow.md`**
- Phase 1 now reads "current vision/principles" (not just "vision/focus")
- Groom only updates project.md on genuine vision/principles/philosophy/domain changes
- Added explicit guard: never inject ephemeral data (versions, issue numbers, sprint themes)

**`core/readwise/SKILL.md`**
- Fix jq null crashes: `.title // "(untitled)"`, `.summary // ""`, `.notes // ""`
- Consolidate auth setup into one block (source token → validate)
- Default topic search now uses `limit=100` and all locations (no category/location filter by default)
- Comments updated to reflect new defaults

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered

### Option A — Do nothing
- Upside: No migration friction
- Downside: project.md continues to accumulate stale sprint snapshots
- Why rejected: The format was actively causing bad agent context

### Option B — Keep Active Focus, just add a warning
- Upside: Backwards compatible
- Downside: Warning text won't stop agents from writing stale content; format determines behavior
- Why rejected: The section itself is the problem. Remove it, don't warn about it.

### Option C — Current approach (remove Active Focus, add Principles + Philosophy)
- Upside: Makes the right thing easy, the wrong thing hard. Durability rule + Anti-Patterns make intent explicit.
- Downside: Existing project.md files need migration on next groom pass
- Why chosen: Format encodes intent. A Principles section can't hold issue numbers.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA

Documentation-only change. No executable paths, no CLI commands, no tests.

Verification: diff review. Confirm:
1. `project-md-format.md` no longer contains `Active Focus` section
2. `project-md-format.md` contains `Principles`, `Philosophy`, `What Belongs Here`, `Anti-Patterns` sections
3. `interactive-workflow.md` instructs groom to only update on genuine vision/principles changes
4. `readwise/SKILL.md` jq filters include `// "(untitled)"` fallbacks on `.title` fields

</details>

<details>
<summary>Before / After</summary>

## Before / After

**project-md-format.md — removed section:**
```markdown
## Active Focus
Current milestone and key issues driving work right now.
- **Milestone:** [name] — [description]
- **Key Issues:** #N, #N, #N
- **Theme:** [what we're optimizing for right now]
```

**project-md-format.md — added sections:**
```markdown
## Principles
- **[Name.]** [Durable design principle that guides decisions]

## Philosophy
- [Product philosophy — what matters, what doesn't]

## What Belongs Here vs. Elsewhere
| Content | Where it goes | Why |
| Vision, principles, philosophy | project.md | Durable |
| Current sprint / milestone focus | GitHub milestones | Ephemeral |
...

## Anti-Patterns
- **Version pinning:** "Current Focus: post-v3.4.0" — breaks on next release.
- Replace with: Principle: "Ship what matters."
```

**readwise SKILL.md — before:**
```bash
| jq '[.results[] | select(.title + " " + (.summary // "") | test("TOPIC"; "i"))]'
```

**readwise SKILL.md — after:**
```bash
| jq '[.results[] | select(((.title // "") + " " + (.summary // "")) | test("TOPIC"; "i"))]
      | .[] | {title: (.title // "(untitled)"), source_url, summary: (.summary // ""), ...}'
```

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage

No tests. This repo is documentation-only. There are no executable paths to test.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence

- **Confidence:** High
- **Strongest evidence:** Diff is mechanical and legible. Removed sections are provably ephemeral. Added sections are provably durable.
- **Remaining uncertainty:** Some existing project.md files may reference the removed Active Focus schema — they'll need migration on next groom pass.
- **What could still go wrong:** None anticipated. Markdown-only, no runnable code.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project initialization workflow with clarified content handling and revised interview requirements for missing project sections.
  * Improved project format guidance emphasizing durable content organization, introducing new sections for principles and philosophy.
  * Enhanced Readwise configuration documentation with improved field handling and clearer authentication validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->