### PR TITLE
refactor(core): prune to 11 core skills with pack architecture

### DIFF
--- a/.groom/BACKLOG.md
+++ b/.groom/BACKLOG.md
@@ -1,0 +1,49 @@
+# Backlog — agent-skills
+
+Ideas, deferred work, someday/maybes. Promoted to GitHub Issues when ready.
+
+*Last updated: 2026-03-15*
+
+## Deferred from GitHub Issues
+
+### Compete skill — three-way agent competition
+*Demoted from #8 (2026-03-15). Depends on #50 (risk tiers) and #34 (parallel subagent infra).*
+
+Spawn 3 Agent Team workers implementing the same spec independently on separate git worktrees. Evaluation is deterministic where possible (test pass rate, coverage delta, lines changed). Thinktank synthesis as tiebreaker. DMI skill, effort/l.
+
+**Why deferred:** Speculative, high effort, depends on risk tier infrastructure that doesn't exist yet. Re-evaluate after #50 and #34 ship — if parallel subagent infra works well for debug, competition is a natural extension.
+
+## Ideas
+
+### Cross-repo harness sync audit
+After core restructuring, repos consuming skills via symlinks may reference old skill names or paths. Need an audit of all repos that depend on agent-skills to verify their CLAUDE.md, AGENTS.md, and .claude/skills/ symlinks are current.
+
+**Signal:** First user report of a broken skill reference in a consuming repo.
+
+### Pack discoverability improvements
+`/forage` matches against `pack-index.md` using keyword search. Semantic matching (LLM-based) could improve discovery accuracy for ambiguous queries. The `llm-semantic-match` pack skill exists but isn't wired into forage.
+
+**Signal:** User invokes `/forage` and doesn't find a skill that exists.
+
+### Overlay testing after restructuring
+Harness overlays (`overlays/<harness>/<skill>/`) may need updating after the core pruning. No automated test verifies overlays apply correctly to the new skill set.
+
+**Signal:** Harness-specific behavior diverges unexpectedly.
+
+### Skill composition documentation
+Skills compose implicitly (e.g., `/calibrate` loads `/forage` and `/research`, `/settle` reads autopilot references). This composition graph isn't documented anywhere. A generated dependency map could help with impact analysis when modifying skills.
+
+**Signal:** Modifying a skill unexpectedly breaks a downstream skill.
+
+### TypeScript skill testing framework
+`core/research/` has TypeScript tests. Other skills are untested. A lightweight test framework for skills could validate frontmatter, description constraints, reference file existence, and routing table coverage.
+
+**Signal:** Shipping a skill with broken routing or missing references.
+
+## Parked Themes
+
+### Agent competition and verification depth
+Risk tiers (#50) → escalation gates → compete skill → formal verification integration. This is the "pipeline safety" theme. Currently at step 1 (risk tiers). Each step should prove value before building the next.
+
+### Language and platform packs
+Go (#35), Convex (#36) are in GitHub Issues. Future candidates: Elixir (already has patterns in agent pack), Swift/iOS, Python. Add packs only when 3+ repos share identical conventions.

--- a/core/autopilot/SKILL.md
+++ b/core/autopilot/SKILL.md
@@ -154,7 +154,7 @@ The point is single ownership. One issue should map to one active autopilot lane
     - Otherwise re-run the in-flight gate immediately before opening the PR
     - If an open PR already exists for the branch, use `gh pr edit`, not `gh pr create`
     - If another open PR already exists for the same issue, stop and surface the duplication instead of creating a second lane
-    - Load `../pr/references/pr-body-template.md` and follow it
+    - Load `references/pr-body-template.md` and follow it
     - The `Walkthrough` section must link the artifact and name the persistent verification that protects the demonstrated path
     - PR body must contain all sections:
       - **Why This Matters**: Problem, value added, why now, issue link. This is top-of-line.

--- a/core/autopilot/references/pr-body-template.md
+++ b/core/autopilot/references/pr-body-template.md
@@ -194,7 +194,7 @@ This is the proof package for the PR.
 - For UX work, default the artifact to a real video or terminal recording rather than prose or a static note
 - For UX work, ensure the artifact is readable at normal speed and does not bury the changed surface under explanatory overlays
 
-For the script and rubric, load `../../pr-walkthrough/references/walkthrough-contract.md`.
+For the script and rubric, load `./pr-walkthrough-contract.md`.
 
 ### `## Before / After`
 

--- a/core/autopilot/references/pr-fix-workflow.md
+++ b/core/autopilot/references/pr-fix-workflow.md
@@ -192,7 +192,7 @@ If the repo is known to post delayed findings even after checks complete, requir
 
 If the fix materially changes implementation, evidence, or merge risk, update the PR body and walkthrough.
 
-Before editing, read `../../pr/references/pr-body-template.md`.
+Before editing, read `./pr-body-template.md`.
 
 Refresh:
 - `Why This Matters`

--- a/core/autopilot/references/pr-fix.md
+++ b/core/autopilot/references/pr-fix.md
@@ -37,7 +37,7 @@ Conflicts -> CI -> Self-Review -> Review Reconciliation -> Settlement -> Signal
 
 ## Core Workflow
 
-Read [references/workflow.md](./references/workflow.md) and execute the phases in order:
+Read [pr-fix-workflow.md](./pr-fix-workflow.md) and execute the phases in order:
 - assess the PR and list blockers
 - resolve conflicts first
 - fix CI before arguing with reviewers
@@ -53,8 +53,8 @@ Read [references/workflow.md](./references/workflow.md) and execute the phases i
 
 ## Required References
 
-- Review reconciliation: [references/reconciliation-ledger.md](./references/reconciliation-ledger.md)
-- Detailed unblock sequence: [references/workflow.md](./references/workflow.md)
+- Review reconciliation: [pr-fix-reconciliation-ledger.md](./pr-fix-reconciliation-ledger.md)
+- Detailed unblock sequence: [pr-fix-workflow.md](./pr-fix-workflow.md)
 
 ## Hard Stop Rules
 
@@ -93,5 +93,5 @@ Summarize:
 
 ## Absorbed Skills (References)
 
-- **fix-ci** — [references/fix-ci.md](./references/fix-ci.md)
-- **review-branch** — [references/review-branch.md](./references/review-branch.md)
+- **fix-ci** — [pr-fix-fix-ci.md](./pr-fix-fix-ci.md)
+- **review-branch** — [pr-fix-review-branch.md](./pr-fix-review-branch.md)

--- a/core/autopilot/references/pr-polish.md
+++ b/core/autopilot/references/pr-polish.md
@@ -156,7 +156,7 @@ Refresh the `## Walkthrough` section too if the polish changes the strongest mer
 gh pr edit $PR --body "$(updated body)"
 ```
 
-Before editing, read `../pr/references/pr-body-template.md`.
+Before editing, read `./pr-body-template.md`.
 
 Refresh:
 - `Why This Matters` if the polish changed the meaning or significance of the PR

--- a/core/autopilot/references/pr-walkthrough.md
+++ b/core/autopilot/references/pr-walkthrough.md
@@ -100,4 +100,4 @@ Broken image links are a walkthrough failure.
 
 ## References
 
-- `references/walkthrough-contract.md` — renderer selection rubric, evidence quality bar
+- `pr-walkthrough-contract.md` — renderer selection rubric, evidence quality bar

--- a/core/autopilot/references/pr.md
+++ b/core/autopilot/references/pr.md
@@ -22,12 +22,12 @@ That artifact should be an actual capture of the product surface whenever practi
 - Run `/pr-walkthrough` and treat its output as required PR evidence
 - Own ship blockers surfaced by the required gates; fix adjacent repo debt when it is the only thing keeping the lane from opening cleanly
 - `dogfood`, `agent-browser`, and `browser-use` are available here; use them for flow QA evidence
-- Load [references/pr-body-template.md](./references/pr-body-template.md) before writing the PR body
+- Load [pr-body-template.md](./pr-body-template.md) before writing the PR body
 - Treat an existing PR for the same branch or issue as the lane to update, not a reason to create another PR
 
 ## PR Body Requirements (MANDATORY)
 
-Every PR body must follow [references/pr-body-template.md](./references/pr-body-template.md).
+Every PR body must follow [pr-body-template.md](./pr-body-template.md).
 A PR missing template sections is not ready.
 
 Use `<details>/<summary>` to collapse larger sections such as Alternatives,
@@ -55,7 +55,7 @@ Keep `Reviewer Evidence`, `Why This Matters`, `Trade-offs / Risks`, and the open
    - For user-visible interaction changes, default to a real screencast or terminal recording. Only fall back to screenshots when there is no meaningful motion or timing to show.
    - For CLI UX, treat the terminal as the product surface and record the real interaction.
    - Demo quality matters. Keep overlays minimal, keep the changed surface readable, and do not let explanatory text obscure the thing being demonstrated.
-7. **Describe** — Title from issue, body follows [references/pr-body-template.md](./references/pr-body-template.md). Lead with significance/value/trade-offs, not the diff recap.
+7. **Describe** — Title from issue, body follows [pr-body-template.md](./pr-body-template.md). Lead with significance/value/trade-offs, not the diff recap.
 8. **Before/After** — Use screenshots or evidence from visual QA, dogfood, and `/pr-walkthrough`. For non-UI changes, describe behavioral or architectural difference in text. If the change is UX-facing, include a watchable artifact and treat static text as support material, not the main proof. If the PR body gets long, move heavy evidence into `<details>`.
    For private repos, screenshots in the PR body must use GitHub attachments or `../blob/<ref>/...?...raw=true`; never `raw.githubusercontent.com` or bare repo-relative asset paths.
 9. **Open / Update** — Use `gh pr create --assignee phrazzld --body-file <path>` for new PRs. Use `gh pr edit --body-file <path>` when the branch already has a PR.

--- a/core/autopilot/references/simplify.md
+++ b/core/autopilot/references/simplify.md
@@ -16,7 +16,7 @@ For the whole repo or `$ARGUMENTS`, answer four questions with evidence:
 3. If rebuilding today, what are the cleanest plausible designs?
 4. Which one refactor removes the most complexity per unit of risk right now?
 
-Then implement that refactor, verify behavior, and open or update a draft PR via `../pr/SKILL.md`.
+Then implement that refactor, verify behavior, and open or update a draft PR via `../../pr/SKILL.md`.
 Local code changes plus a summary are not a completed `/simplify` run.
 
 ## Latitude
@@ -26,7 +26,7 @@ Local code changes plus a summary are not a completed `/simplify` run.
 - Prefer deletion, consolidation, and stronger module boundaries over new abstractions
 - Use an `ousterhout` reviewer/persona if available; otherwise apply the same checks manually
 - Treat the PR lane as part of the task, not optional follow-up work
-- If `../pr/SKILL.md` blocks on missing evidence, duplicate PRs, auth, or another concrete prerequisite, resolve it when feasible; otherwise report that explicit blocker instead of silently stopping short of the PR step
+- If `../../pr/SKILL.md` blocks on missing evidence, duplicate PRs, auth, or another concrete prerequisite, resolve it when feasible; otherwise report that explicit blocker instead of silently stopping short of the PR step
 - If no safe, high-impact, single-PR simplification exists, say so explicitly instead of inventing churn
 
 ## Workflow
@@ -37,7 +37,7 @@ Local code changes plus a summary are not a completed `/simplify` run.
 4. **Evaluate trade-offs** — Read `references/refactor-rubric.md`. Score the options on module depth, information hiding, operational simplicity, migration cost, behavior risk, and single-PR feasibility.
 5. **Choose one refactor** — Pick the change that maximizes complexity removed per unit of risk and fits in one pull request. Name what will be deleted, what will be consolidated, and what behavior must remain unchanged.
 6. **Implement with proof** — Before edits, write down the module invariants and external contract that must remain stable. Add or adjust tests against that contract where behavior risk is non-trivial. Make the refactor. Update docs if architecture or workflow meaningfully changes. Verify with the tightest commands that cover the affected surface.
-7. **Ship** — After boundary simplification and verification are complete, invoke `../pr/SKILL.md` and follow its workflow all the way through opening or updating the PR. Do not stop after local verification or a narrative summary. The PR should explain the current shape, the first-principles alternatives considered, why this refactor won, and the follow-up work left behind.
+7. **Ship** — After boundary simplification and verification are complete, invoke `../../pr/SKILL.md` and follow its workflow all the way through opening or updating the PR. Do not stop after local verification or a narrative summary. The PR should explain the current shape, the first-principles alternatives considered, why this refactor won, and the follow-up work left behind.
 8. **Codify leftovers** — If the best future architecture cannot fit in one PR, create focused follow-up issues or record the roadmap in the PR body.
 
 ## Output
@@ -49,7 +49,7 @@ Default deliverable:
 - Trade-off evaluation
 - Chosen single-PR simplification
 - Verification evidence
-- PR URL, or the explicit blocker returned by `../pr/SKILL.md`
+- PR URL, or the explicit blocker returned by `../../pr/SKILL.md`
 
 ## References
 

--- a/core/forage/SKILL.md
+++ b/core/forage/SKILL.md
@@ -87,7 +87,7 @@ If "find skills", "skills.sh", "marketplace" → read `references/find-skills.md
 ## What Forage Is NOT
 
 - NOT a skill recommender during autonomous pipelines
-- NOT a skill creator (use /skill-builder or /skill-creator)
+- NOT a skill creator (use `/skill`)
 
 ## Anti-Patterns
 

--- a/core/research/SKILL.md
+++ b/core/research/SKILL.md
@@ -20,21 +20,37 @@ This skill consolidates: `web-search`, `delegate`, `thinktank`, `introspect`.
 
 ## Routing
 
-| Intent | Sub-capability |
-|--------|---------------|
-| Search the web, find docs/info, `web-search`, `web-deep`, `web-news`, `web-docs`, `/web`, `/web-deep`, `/web-news`, `/web-docs` | `references/web-search.md` |
-| Delegate work to Codex/Gemini/agents, orchestrate multi-AI | `references/delegate.md` |
-| Multi-perspective expert validation, consensus | `references/thinktank.md` |
-| Analyze session history, usage patterns, improvement opportunities | `references/introspect.md` |
-| Search saved articles, highlights, reading list | `references/readwise.md` |
-| xAI web/X search, social sentiment, trending | `references/xai-search.md` |
+### Explicit sub-capability (user names one)
 
-If first argument matches `web-search`, `web-deep`, `web-news`, `web-docs`,
-`delegate`, `thinktank`, `introspect`, `readwise`, or `xai`, read the corresponding reference.
-If no argument, select based on user intent. If user specifies a sub-capability
-by name (e.g., "delegate this to codex"), route directly.
+If first argument matches a keyword, route directly to that reference:
 
-Read the relevant reference and follow its instructions.
+| Keyword | Reference |
+|---------|-----------|
+| `web-search`, `web-deep`, `web-news`, `web-docs` | `references/web-search.md` |
+| `delegate` | `references/delegate.md` |
+| `thinktank` | `references/thinktank.md` |
+| `introspect` | `references/introspect.md` |
+| `readwise` | `references/readwise.md` |
+| `xai` | `references/xai-search.md` |
+
+### No sub-capability (default): PARALLEL FANOUT
+
+**When no keyword is specified, fan out to multiple sources in parallel.**
+Research means gathering signal from many vantage points simultaneously.
+The routing table is a dispatch list, not a switch statement.
+
+For any research question, launch these in parallel (via Agent tool):
+
+1. **Web search** (Exa/WebSearch) — current docs, implementations, pricing, APIs
+2. **Thinktank** (`./thinktank "question" --quick --perspectives 3`) — multi-model expert perspectives
+3. **xAI** — social signal, what practitioners are saying (when relevant)
+4. **Codebase search** (Grep/Glob) — what the project already does (when relevant)
+
+Then **synthesize** across all results: consensus, conflicts, citations, recommendations.
+
+Only narrow to a single source when:
+- The user explicitly names one (e.g., "/research web-search [query]")
+- The question is trivially answerable by one source (e.g., "what version is X?")
 
 ## Use When
 

--- a/project.md
+++ b/project.md
@@ -15,27 +15,28 @@ research-backed (web + multi-model validation before codifying).
 | Term | Definition |
 |------|-----------|
 | Skill | A markdown-first module (SKILL.md + optional references/) that gives agents domain expertise |
-| Core skill | Universal skill synced to all harness config dirs |
-| Pack | Domain-specific skill bundle loaded per-project (e.g., payments, growth) |
-| Harness | An AI agent runtime (Claude Code, Codex, Gemini CLI, Pi) |
-| Umbrella | A skill that absorbs related sub-skills as references, saving budget |
+| Core skill | Universal skill synced to all harness config dirs (11 total: 3 implicit + 8 DMI) |
+| Pack | Domain-specific skill bundle loaded per-project (9 packs: web, design, agent, infra, quality, payments, growth, scaffold, finance) |
+| Harness | An AI agent runtime (Claude Code, Codex, Gemini CLI, Factory, Pi) |
+| Umbrella | A skill that absorbs related sub-skills as references, saving budget (autopilot, debug, reflect, research) |
 | DMI | Disable-model-invocation — user-only skills that cost zero budget |
-| Budget | ~16K char Claude Code description limit; skills consume budget per mode |
-| Ralph | Autonomous issue-to-merged-PR loop |
-| Delivery pipeline | groom → shape → autopilot → pr-fix → pr-polish → merge |
+| Budget | ~16K char Claude Code description limit; ~1.4K used by 3 implicit skills |
+| Delivery pipeline | groom → autopilot (shape → build → pr → settle → merge) |
 
 ## Active Focus
 
 - **Milestone:** Skill Quality — sharpen definitions, triggers, and gate semantics
-- **Key Issues:** #6, #7 (pipeline hardening), existing skills needing refinement
+- **Key Issues:** #24 (description audit), #51 (sync-time validation), #31/#32 (pipeline codification)
 - **Theme:** Make every skill precise enough that agents invoke it correctly first-try
+- **Recent:** Core pruning from 50+ to 11 skills, 37 domain skills to 9 packs, 4 umbrella absorptions
 
 ## Quality Bar
 
 - [ ] Every skill has clear trigger conditions (when to invoke, when NOT to)
+- [ ] All descriptions ≤1024 chars with trigger phrases (enforced by sync.sh)
 - [ ] Skills compose — orchestrators call primitives, never reimplement
 - [ ] Agent-agnostic — no Claude-specific assumptions leak into skill bodies
-- [ ] Budget stays within 16K limit with room for growth
+- [ ] Budget stays within 16K limit with room for growth (~1.4K of ~16K used)
 - [ ] Retro patterns flow back into skill definitions
 
 ## Patterns to Follow
@@ -68,7 +69,9 @@ core/{umbrella}/
 | verify-ac as standalone | Worked but wasn't used | Skills become gates only when delivery workflows name exact stop conditions |
 | Effort predictions | Accurate (retro confirms) | Effort/s and effort/m calibration is reliable for this repo |
 | Umbrella pattern (research/) | 4→1 budget savings | Progressive disclosure works; add sub-caps at zero cost |
+| Core pruning 50+ → 11 | Budget 10.2K → 1.4K | Aggressive pruning + pack architecture works; domain knowledge belongs in packs |
+| Standalone pipeline skills | Fragmented, hard to compose | Absorb related skills into umbrellas; sub-capabilities as references cost zero budget |
 
 ---
-*Last updated: 2026-03-11*
-*Updated during: /groom session*
+*Last updated: 2026-03-15*
+*Updated during: /groom session — post-restructuring backlog overhaul*


### PR DESCRIPTION
## Summary

Major architectural restructuring of the skills monorepo:

- **Core pruning**: 50+ core skills to 11 (3 implicit + 8 DMI). Budget drops from ~10.2K to ~1.4K of ~16K limit.
- **Pack architecture**: 37 domain skills moved to 9 packs (web, design, agent, infra, quality, payments, growth, scaffold, finance), discovered via `/forage`.
- **Umbrella absorption**: 24 pipeline/investigation/retrospective skills absorbed into 4 umbrellas (autopilot, debug, reflect, research) as on-demand references.
- **New DMI skills**: `/pr` (commit + PR), `/settle` (fix + polish + simplify), `/skill` (skill engineering), `/calibrate` (mid-session harness postmortem).
- **Backlog overhaul**: Rewrote 4 stale issues, merged 2, demoted 1, created 1 new. Initialized `.groom/BACKLOG.md` two-tier system.

Net: -229 LOC, 359 files touched (mostly renames from `core/` to `packs/`).

## Test plan

- [x] `./scripts/sync.sh all` — 11 skills synced to all harnesses
- [x] `ls core/ | wc -l` — confirms 11 core skills
- [ ] `/forage` discovers pack skills via `pack-index.md`
- [ ] `/settle` composes with autopilot references (pr-fix-*, pr-polish, simplify)
- [ ] `/calibrate` loads and routes to forage/research for diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill routing system with keyword-based dispatch for improved clarity on search behavior.
  * Clarified project glossary with expanded definitions and scope details.
  * Added comprehensive backlog documentation outlining deferred work and future ideas.
  * Consolidated internal reference documentation for better navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->