### PR TITLE
docs(skill): codify command surface guidance

### DIFF
--- a/skills/primitive/SKILL.md
+++ b/skills/primitive/SKILL.md
@@ -97,6 +97,40 @@ failure modes, repo-specific conventions, operational patterns.
 domain specialist would approve — decisions it could NOT make from training
 data alone. If the skill doesn't clear that bar, it's not specific enough.
 
+#### Command Surface Design
+
+Default to concentrated, opinionated skills. Use arguments only when they
+select between a few stable sub-capabilities inside one coherent domain.
+
+Use arguments when ALL are true:
+
+- The modes belong to one clear mental model (`focus init`, `focus sync`)
+- The skill has one obvious no-arg happy path
+- The modes share most artifacts, references, and scripts
+- The selector list is short and stable, not an expanding menu
+
+Split into separate skills when ANY are true:
+
+- Modes have different trigger language
+- Modes need different context packs or references
+- Modes have different success criteria or outputs
+- The core flow starts depending on flags, not intent words
+
+Treat `argument-hint` as an intent router, not CLI help text. Prefer noun or
+verb selectors. Reserve flags for mechanics and rare overrides.
+
+Good:
+
+```yaml
+argument-hint: "[init|sync|add|remove] [name]"
+```
+
+Bad:
+
+```yaml
+argument-hint: "[mode] [name] --draft --no-push --strategy smart --skip-checks"
+```
+
 ### 4. Create
 
 1. **Understand** — what problem does this solve?
@@ -160,3 +194,4 @@ without a matching `.spellbook` marker are left alone.
 - Shallow skills that are just a checklist (prefer CLAUDE.md or a hook)
 - Skipping the research phase — skills without research are just reformatted training data
 - Writing generic advice the model already knows instead of specific, hard-won knowledge
+- Building mini-CLIs into `argument-hint` instead of keeping one happy path and a few stable selectors


### PR DESCRIPTION
## Reviewer Evidence

Merge claim: this PR codifies when a Spellbook skill should use argument-based selectors versus splitting into separate focused skills.

Start here: `skills/skill/SKILL.md`, especially the new `3. Research and Design` section and the added anti-pattern.

## Why This Matters

Spellbook's `skill` skill already covered where skills live, how to classify them, and how to create, update, and absorb them. It did not explicitly state when subcommands like `init` are justified versus when a skill should stay concentrated and opinionated.

That gap makes it too easy to drift into flag-heavy or menu-like `argument-hint` surfaces. This PR captures the rule directly in the `skill` skill so future skill design work starts from a clear interface doctrine.

## Trade-offs / Risks

This adds more guidance to an already large `skills/skill/SKILL.md`. The validator still warns that the file is long and lacks a `references/` directory, so reviewers should pressure-test whether this skill needs later progressive-disclosure cleanup.

The generated metadata files also change because Spellbook expects index and embeddings regeneration after skill edits.

## What Changed

The `skill` skill now includes explicit command-surface guidance: default to concentrated skills, use arguments only for a small set of stable selectors inside one coherent domain, and split into separate skills when triggers, context, or success criteria diverge. It also adds a matching anti-pattern against turning `argument-hint` into a mini-CLI.

```mermaid
graph TD
  A[Before] --> B[skill explains creation and absorption]
  B --> C[No explicit rule for args vs focused skills]
```

```mermaid
graph TD
  A[After] --> B[skill explains creation, absorption, and command-surface design]
  B --> C[args only for small stable selectors]
  B --> D[split when triggers or context diverge]
```

```mermaid
graph TD
  A[Author reaches for /skill] --> B[reads interface doctrine]
  B --> C[chooses focused skill or umbrella]
  C --> D[avoids argument-hint sprawl]
```

<details>
<summary>Changes</summary>

- Add command-surface design guidance to `skills/skill/SKILL.md`.
- Renumber the downstream sections to keep the skill coherent.
- Add an anti-pattern covering mini-CLIs in `argument-hint`.
- Regenerate `index.yaml` and `embeddings.json`.

</details>

<details>
<summary>Acceptance Criteria</summary>

- [x] `skill` explicitly states when arguments are appropriate.
- [x] `skill` explicitly states when to split into separate skills.
- [x] `skill` frames `argument-hint` as intent routing rather than CLI syntax.
- [x] Anti-pattern guidance covers flag-heavy command surfaces.
- [x] Spellbook metadata is regenerated after the skill update.

</details>

<details>
<summary>Alternatives Considered</summary>

Do nothing: leaves the design rule implicit and easy to miss.

Put the rule only in `skill-builder` / `skill-creator`: weaker than placing it in the actual `skill` skill that is invoked for skill design work.

</details>

<details>
<summary>Manual QA</summary>

- Read `skills/skill/SKILL.md`.
- Verify the new command-surface guidance exists under `3. Research and Design`.
- Verify the anti-pattern list mentions mini-CLIs in `argument-hint`.
- Inspect `index.yaml` for the regenerated `skill` entry.
- Confirm `embeddings.json` was regenerated successfully.

</details>

<details>
<summary>Test Coverage</summary>

Validated with:

- `python3 skills/skill-builder/scripts/validate_skill.py skills/skill`
- `./scripts/generate-index.sh`
- `python3 scripts/generate-embeddings.py`

Validator warnings remain about `skills/skill/SKILL.md` being a long single file without `references/`; those predate this PR's doctrine change and are not addressed here.

</details>

<details>
<summary>Before / After</summary>

Before: `skill` had no explicit rule for when subcommands were justified.

After: `skill` defines when to use stable selectors, when to split, and how to treat `argument-hint`.

</details>

<details>
<summary>Merge Confidence</summary>

High on the doctrine change itself. Medium overall because the regenerated embeddings are a large derived artifact.

</details>
