### PR TITLE
feat(focus): always install to all supported harnesses

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-18T21:01:21Z
+# Generated: 2026-03-18T21:35:58Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:
@@ -123,6 +123,9 @@ skills:
   - name: land
     description: "Unblock, polish, and simplify a PR until it's genuinely merge-ready. Three phases: fix (CI/conflicts/reviews), polish (architecture/tests/docs), simplify (complexity reduction). Runs all three in sequ"
     tags: [a,architecture,ci,complexity,conflicts,docs,fix,genuinely,in,it]
+  - name: launchd-patterns
+    description: "\"macOS launchd scheduling and service management. LaunchAgent/Daemon patterns, launchctl CLI, plist authoring, cron migration, debugging. The production gotchas Apple docs don't cover.\""
+    tags: [apple,authoring,cli,cover,cron,daemon,debugging,docs,don,gotchas]
   - name: lightning
     description: "Complete Lightning Network lifecycle. Audits channels, routing, invoices. Plans capacity, executes rebalancing, verifies payments. Every run does all."
     tags: [audits,capacity,channels,complete,every,executes,invoices,lifecycle,lightning,network]
@@ -132,6 +135,9 @@ skills:
   - name: llm-semantic-match
     description: "Use LLM sub-calls to resolve user intent to one item from a finite set. Replace all fuzzy/substring string matching in agent tools with this pattern."
     tags: [a,agent,finite,fuzzy,in,intent,item,llm,matching,one]
+  - name: macos-network-diagnostics
+    description: "\"macOS network debugging: DNS resolution paths, firewall layers, Tailscale fleet management, mDNS/Bonjour, SSH tunneling. Diagnostic sequences that go beyond man pages.\""
+    tags: [beyond,bonjour,debugging,diagnostic,dns,firewall,fleet,go,layers,macos]
   - name: mobile-migrate
     description: "\"Add an Expo + EAS React Native mobile app to an existing web project, sharing logic, design tokens, auth, and backend integrations. Use when migrating a web codebase into a web+mobile monorepo.\""
     tags: [a,add,an,app,auth,backend,codebase,design,eas,existing]

--- a/skills/focus/SKILL.md
+++ b/skills/focus/SKILL.md
@@ -66,26 +66,28 @@ the working directory decides scope.
 
 ## Core Flow
 
-### 1. Detect Harness
+### 1. Resolve Harness Targets
 
-Determine which agent harness is running:
+All supported harnesses are always targeted. Focus installs to every
+harness directory, creating them if they don't exist. No detection,
+no if/elif — always both.
 
-```bash
-if [ -n "${CLAUDE_CODE:-}" ] || [ -d ".claude" ]; then HARNESS="claude-code"
-elif [ -n "${CODEX:-}" ] || [ -d ".codex" ]; then HARNESS="codex"
-elif [ -d ".agents" ]; then HARNESS="agents"
-fi
+```
+HARNESS_TARGETS:
+  claude-code:
+    skills: .claude/skills/
+    agents: .claude/agents/
+    agent_format: markdown
+    reference: references/harnesses/claude-code.md
+  codex:
+    skills: .agents/skills/
+    agents: .codex/agents/
+    agent_format: toml
+    reference: references/harnesses/codex.md
 ```
 
-Load harness-specific reference from `references/harnesses/${HARNESS}.md`.
-
-**Harness directory mapping (all paths relative to project root):**
-
-| Harness | Skills Dir | Agents Dir |
-|---------|-----------|------------|
-| Claude Code | `.claude/skills/` | `.claude/agents/` |
-| Codex | `.agents/skills/` | `.codex/agents/` |
-| Generic | `.agents/skills/` | `.agents/agents/` |
+Load **all** harness references. Every sync produces primitives usable
+by every supported harness.
 
 ### 2. Read or Create Manifest
 
@@ -130,51 +132,62 @@ Unqualified names resolve to `phrazzld/spellbook`. External skills use
 
 ### 4. Nuke Managed Primitives
 
-Scan the local harness skills and agents directories. Find ALL directories
-containing a `.spellbook` marker file. Delete them entirely.
+For **each harness target**, scan its skills and agents directories for
+`.spellbook` markers and delete managed primitives:
 
 ```bash
-find "${SKILLS_DIR}" -name ".spellbook" -maxdepth 2 | while read marker; do
-  rm -rf "$(dirname "$marker")"
-done
-find "${AGENTS_DIR}" -name ".spellbook" -maxdepth 2 2>/dev/null | while read marker; do
-  rm -rf "$(dirname "$marker")"
+for target in HARNESS_TARGETS; do
+  find "${target.skills}" -maxdepth 2 -name ".spellbook" | while read marker; do
+    rm -rf "$(dirname "$marker")"
+  done
+  find "${target.agents}" -maxdepth 1 -name "*.spellbook" 2>/dev/null | while read marker; do
+    rm -f "${marker}" "${marker%.spellbook}.md" "${marker%.spellbook}.toml"
+  done
 done
 ```
 
-**Critical**: Only directories with a `.spellbook` marker are touched.
+**Critical**: Only directories/files with a `.spellbook` marker are touched.
 Everything else is invisible to focus and will not be modified or deleted.
 
 ### 5. Install Primitives
 
-For each resolved skill, download from its source. See `references/sync.md`.
+Two-phase install — download once, distribute to all targets. See `references/sync.md`.
+
+1. **Download phase**: Fetch each skill from GitHub once (into a temp staging area).
+2. **Distribute phase**: Copy staged content to each harness target's skills dir.
+   Skill content (SKILL.md, references/, scripts/, assets/) is format-identical
+   across harnesses — no translation needed.
 
 ### 5b. Install Agents
 
-Agents are markdown files (not directories). Install to the agents dir.
-For Claude Code, agent files are used as-is (markdown + YAML frontmatter).
-For Codex, translate to TOML format during install (see harness references).
+Download each agent source file once, then install per-target:
+- **markdown targets** (Claude Code): copy the `.md` as-is
+- **toml targets** (Codex): translate markdown+YAML frontmatter to TOML format
+  (see `references/harnesses/codex.md` for translation rules)
 
 ### 6. Harness-Specific Setup
 
-After installing primitives, run harness-specific configuration.
+After installing primitives, run harness-specific configuration for **each target**.
 See `references/harnesses/claude-code.md` and `references/harnesses/codex.md`.
+
+- **DMI handling**: For Claude Code, preserve `disable-model-invocation: true`
+  in frontmatter. For Codex, emit `agents/openai.yaml` with
+  `allow_implicit_invocation: false` in the skill directory.
 
 ### 7. Report
 
 ```markdown
 ## Focus Complete
 
-**Harness**: Claude Code
 **Manifest**: .spellbook.yaml (5 domain skills, 2 agents)
 **Global layer**: 13 skills + 4 agents (via bootstrap, not shown)
 
 ### Installed (domain)
-| Type | Name | Status |
-|------|------|--------|
-| skill | stripe | installed |
-| skill | next-patterns | installed |
-| agent | stripe-auditor | installed |
+| Type | Name | Claude Code | Codex |
+|------|------|-------------|-------|
+| skill | stripe | .claude/skills/stripe/ | .agents/skills/stripe/ |
+| skill | next-patterns | .claude/skills/next-patterns/ | .agents/skills/next-patterns/ |
+| agent | stripe-auditor | .claude/agents/stripe-auditor.md | .codex/agents/stripe-auditor.toml |
 
 ### Unchanged (not managed by Spellbook)
 - my-custom-deploy-skill/
@@ -223,7 +236,7 @@ When invoked with a task description:
 - Never touch directories without `.spellbook` markers
 - Never install primitives not declared in the manifest
 - Never skip the nuke step — stale state causes subtle bugs
-- Never hardcode paths — always derive from harness detection
+- Never hardcode paths — always derive from the harness targets table
 - **Never bulk-add a collection without filtering.** Every expanded skill must
   pass the "useful in THIS repo" test.
 - **Never skip agent syncing.** Agents are first-class primitives.

--- a/skills/focus/references/init.md
+++ b/skills/focus/references/init.md
@@ -21,7 +21,7 @@ Read everything available to understand what this project IS:
 | Directory structure | `ls` top-level dirs |
 | Recent activity | `git log --oneline -20` |
 | External services | `.env.example`, config files, API references |
-| Existing skills | `.claude/skills/`, `.codex/skills/` |
+| Existing skills | `.claude/skills/`, `.agents/skills/` |
 
 Synthesize a 1-2 paragraph description of the project covering:
 what it does, what tech it uses, what domains it touches, what

--- a/skills/focus/references/sync.md
+++ b/skills/focus/references/sync.md
@@ -1,6 +1,7 @@
 # Focus Sync
 
 Nuke all Spellbook-managed primitives and rebuild from the manifest.
+Installs to **all** harness targets on every run.
 
 ## Process
 
@@ -27,40 +28,41 @@ globally by bootstrap and must not be duplicated into project-local directories.
 
 ### 3. Nuke Managed Primitives
 
-**Only remove directories/files with `.spellbook` marker files.**
+For **each harness target**, remove managed primitives:
 
 ```bash
-# Skills
-find "${SKILLS_DIR}" -maxdepth 2 -name ".spellbook" -type f | while read marker; do
-  managed_dir="$(dirname "$marker")"
-  rm -rf "$managed_dir"
-done
+for target in HARNESS_TARGETS; do
+  # Skills
+  find "${target.skills}" -maxdepth 2 -name ".spellbook" -type f | while read marker; do
+    managed_dir="$(dirname "$marker")"
+    rm -rf "$managed_dir"
+  done
 
-# Agents
-find "${AGENTS_DIR}" -maxdepth 1 -name "*.md" | while read agent_file; do
-  # Check if the agent has a companion .spellbook marker
-  marker="${agent_file%.md}.spellbook"
-  [ -f "$marker" ] && rm -f "$agent_file" "$marker"
+  # Agents
+  find "${target.agents}" -maxdepth 1 -name "*.spellbook" | while read marker; do
+    rm -f "${marker}" "${marker%.spellbook}.md" "${marker%.spellbook}.toml"
+  done
 done
 ```
 
-### 4. Install Skills
+**Only directories/files with `.spellbook` markers are touched.**
 
-For each skill, download from its source:
+### 4. Download Skills (Once Per Primitive)
+
+Fetch each skill once into a staging area. Do NOT download per-harness —
+skill content is format-identical across all targets.
 
 ```bash
 source="phrazzld/spellbook"  # or "anthropics/skills", etc.
 skill="debug"
-target="${SKILLS_DIR}/${skill}"
+staging="/tmp/spellbook-sync-$$/${skill}"
 raw="https://raw.githubusercontent.com/${source}/main"
 
 # Determine the skill path within the source repo
-# Default: skills/${skill}/SKILL.md
-# Some repos use different layouts — check registry.yaml and index metadata for hints
 skill_path="skills/${skill}"
 
-mkdir -p "$target"
-curl -sfL "$raw/$skill_path/SKILL.md" -o "$target/SKILL.md"
+mkdir -p "$staging"
+curl -sfL "$raw/$skill_path/SKILL.md" -o "$staging/SKILL.md"
 ```
 
 **Download subdirectories** (references/, scripts/, assets/):
@@ -70,10 +72,10 @@ api="https://api.github.com/repos/${source}/contents/${skill_path}"
 for subdir in references scripts assets; do
   files=$(curl -sf "$api/$subdir" 2>/dev/null | \
     python3 -c "import sys,json; [print(f['path']) for f in json.load(sys.stdin)]" 2>/dev/null) || continue
-  mkdir -p "$target/$subdir"
+  mkdir -p "$staging/$subdir"
   echo "$files" | while read path; do
     fname=$(basename "$path")
-    curl -sfL "$raw/$path" -o "$target/$subdir/$fname"
+    curl -sfL "$raw/$path" -o "$staging/$subdir/$fname"
   done
 done
 ```
@@ -85,31 +87,61 @@ dirs=$(curl -sf "$api/references" 2>/dev/null | \
 for nested_dir in $dirs; do
   nested_files=$(curl -sf "$api/references/$nested_dir" 2>/dev/null | \
     python3 -c "import sys,json; [print(f['path']) for f in json.load(sys.stdin)]" 2>/dev/null) || continue
-  mkdir -p "$target/references/$nested_dir"
+  mkdir -p "$staging/references/$nested_dir"
   echo "$nested_files" | while read path; do
     fname=$(basename "$path")
-    curl -sfL "$raw/$path" -o "$target/references/$nested_dir/$fname"
+    curl -sfL "$raw/$path" -o "$staging/references/$nested_dir/$fname"
   done
 done
 ```
 
-### 5. Write Marker
+### 5. Distribute Skills to All Targets
 
-For each installed primitive, write the source in the marker:
+Copy staged content to each harness target's skills directory:
+
 ```bash
-cat > "$target/.spellbook" << EOF
+for target in HARNESS_TARGETS; do
+  dest="${target.skills}/${skill}"
+  mkdir -p "$dest"
+  cp -R "$staging/"* "$dest/"
+
+  # Write marker
+  cat > "$dest/.spellbook" << EOF
 source: ${source}
 name: ${skill}
 installed: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
+done
 ```
+
+Create target directories if they don't exist. This is intentional —
+the primitives are ready the moment the user starts any harness.
 
 ### 6. Install Agents
 
-Agents from `phrazzld/spellbook` are single `.md` files:
+Download each agent source once, then distribute per-target with
+format translation:
+
 ```bash
 agent="ousterhout"
-curl -sfL "${raw}/agents/${agent}.md" -o "${AGENTS_DIR}/${agent}.md"
+raw="https://raw.githubusercontent.com/${source}/main"
+staging_agent="/tmp/spellbook-sync-$$/agents/${agent}.md"
+curl -sfL "${raw}/agents/${agent}.md" -o "$staging_agent"
+
+for target in HARNESS_TARGETS; do
+  if [ "${target.agent_format}" = "markdown" ]; then
+    cp "$staging_agent" "${target.agents}/${agent}.md"
+    # Write companion marker
+    echo "source: ${source}" > "${target.agents}/${agent}.spellbook"
+  elif [ "${target.agent_format}" = "toml" ]; then
+    # Translate markdown+YAML to TOML (see references/harnesses/codex.md)
+    mkdir -p "${target.agents}"
+    # Extract frontmatter fields → TOML keys
+    # name → name, description → description, body → developer_instructions
+    translate_agent_to_toml "$staging_agent" "${target.agents}/${agent}.toml"
+    echo "source: ${source}" > "${target.agents}/${agent}.spellbook"
+  fi
+done
 ```
 
 ### 7. Rate Limiting
@@ -121,11 +153,12 @@ If rate-limited, fall back to shallow clone:
 ```bash
 tmp=$(mktemp -d)
 git clone --depth 1 "https://github.com/${source}.git" "$tmp"
-cp -R "$tmp/skills/$skill/" "$target/"
+# Copy to staging, then distribute to all targets as above
+cp -R "$tmp/skills/$skill/" "$staging/"
 rm -rf "$tmp"
 ```
 
 ### 8. Post-Install
 
-Run harness-specific setup (see `references/harnesses/`).
-Report installed/skipped/errored primitives.
+Run harness-specific setup for each target (see `references/harnesses/`).
+Report installed/skipped/errored primitives with per-harness status.


### PR DESCRIPTION
## Why This Matters

Today, `/focus` detects **one** harness via an if/elif chain and installs primitives to that harness's directories only. A project set up under Claude Code gets `.claude/skills/` but nothing in `.agents/skills/` or `.codex/agents/`. Switching harnesses requires re-running `/focus` — and the other harness's primitives don't exist until then.

After this PR, every `/focus` run produces primitives usable by **all supported harnesses** (Claude Code + Codex), always. Start Codex in a Claude Code project? Skills are already there.

Closes the gap where harness-switching required manual re-sync.

## Trade-offs / Risks

- **Duplicate skill copies** — the same SKILL.md lives in `.claude/skills/X/` and `.agents/skills/X/`. Acceptable because skills are small and nuke-and-rebuild prevents drift.
- **Creates directories eagerly** — if a project never uses Codex, `.agents/` and `.codex/` still get created. This is intentional: primitives ready the moment any harness starts.
- **No symlinks** — duplicate copies over symlinks for cross-platform reliability.

## What Changed

Replaced single-harness detection with a static `HARNESS_TARGETS` table. Focus now always installs to both Claude Code and Codex directories.

```mermaid
graph TD
    A["/focus sync"] --> B{Detect harness}
    B -->|Claude Code| C[Install to .claude/]
    B -->|Codex| D[Install to .agents/ + .codex/]
    B -->|Generic| E[Install to .agents/]
```

```mermaid
graph TD
    A["/focus sync"] --> B[Resolve HARNESS_TARGETS]
    B --> C[Download once to staging]
    C --> D[Distribute to .claude/skills/]
    C --> E[Distribute to .agents/skills/]
    C --> F["Agents: .md → .claude/agents/"]
    C --> G["Agents: .toml → .codex/agents/"]
```

The second shape is simpler (no branching) and always produces a complete install.

<details>
<summary>Changes</summary>

### `skills/focus/SKILL.md`
- Step 1: `Detect Harness` → `Resolve Harness Targets` — static table, no if/elif
- Step 4: Nuke loops over all targets
- Steps 5/5b: Two-phase install (download once, distribute to all)
- Step 6: Harness-specific setup runs for each target, including DMI mapping
- Step 7: Report shows per-harness columns

### `skills/focus/references/sync.md`
- Restructured into download phase (once per primitive) + distribute phase (per harness)
- Agent install does format translation: markdown for Claude Code, TOML for Codex
- Nuke iterates all targets

### `skills/focus/references/init.md`
- Phase 1 existing-skills signal scans both `.claude/skills/` and `.agents/skills/`

</details>

<details>
<summary>Acceptance Criteria</summary>

- [x] No if/elif harness detection — static target table
- [x] Skills installed to both `.claude/skills/` and `.agents/skills/`
- [x] Agents installed to both `.claude/agents/` (markdown) and `.codex/agents/` (TOML)
- [x] Download happens once per primitive, not once per harness
- [x] Nuke-and-rebuild hits both harness directories
- [x] `.spellbook` markers written in both locations
- [x] Report shows per-harness install status
- [x] Init scans all harness dirs for existing skills
- [x] Manifest format unchanged (harness-agnostic)
- [x] Unmanaged primitives in either location untouched

</details>

<details>
<summary>Alternatives Considered</summary>

**Do nothing** — Users re-run `/focus` when switching harnesses. Workable but friction-prone and violates the "primitives ready when you need them" principle.

**Symlinks** — Single copy with symlinks to each harness dir. Fragile across platforms (Windows, some CI environments). Rejected for reliability.

**Harness preference flag** — Let users opt into which targets via manifest. Over-engineering — the cost of always installing both is negligible (skills are small text files).

</details>

<details>
<summary>Test Coverage</summary>

These are instructional skill files (markdown), not executable code. Verification is manual:
1. Run `/focus init` → confirm both harness dirs populated
2. Run `/focus sync` → confirm nuke-and-rebuild hits both
3. Check agent format: `.md` in `.claude/agents/`, `.toml` in `.codex/agents/`
4. Verify `.spellbook` markers in both locations
5. Verify unmanaged primitives untouched

</details>

<details>
<summary>Merge Confidence</summary>

**High.** Changes are purely instructional (skill markdown, not executable code). The logic is simpler than before — a static table replacing a conditional chain. No behavioral regressions possible in existing single-harness usage since both targets are always populated.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added launchd-patterns skill for macOS launchd configuration and pattern management.
  * Added macos-network-diagnostics skill for advanced macOS network diagnostics.

* **Improvements**
  * Enhanced skill distribution system to support multiple harness targets with improved per-target handling and agent format translation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->