### PR TITLE
fix(focus): replace undefined CLAUDE_SKILL_DIR with harness-agnostic SKILL_DIR

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-18T21:35:58Z
+# Generated: 2026-03-18T21:47:28Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/skills/focus/SKILL.md
+++ b/skills/focus/SKILL.md
@@ -18,6 +18,7 @@ managed primitives on every run. Leave unmanaged primitives untouched.
 ## Constants
 
 ```
+SKILL_DIR:         <base directory of this skill, as provided by the harness>
 SPELLBOOK_REPO:    phrazzld/spellbook
 SPELLBOOK_RAW:     https://raw.githubusercontent.com/phrazzld/spellbook/master
 INDEX_URL:         ${SPELLBOOK_RAW}/index.yaml
@@ -25,6 +26,10 @@ REGISTRY_URL:      ${SPELLBOOK_RAW}/registry.yaml
 MANIFEST_FILE:     .spellbook.yaml
 MARKER_FILE:       .spellbook
 ```
+
+**Resolving `SKILL_DIR`:** The harness provides the skill's installed path at
+load time. Use that path as `SKILL_DIR` — no env var needed. If the harness
+does not provide a skill path, stop and surface the error; do not guess.
 
 ## Global Skills (Already Available)
 
@@ -221,7 +226,7 @@ agents:
 
 When invoked with a task description:
 
-1. Run `python3 ${CLAUDE_SKILL_DIR}/scripts/search.py "<task description>" --top 15 --json`
+1. Run `python3 ${SKILL_DIR}/scripts/search.py "<task description>" --top 15 --json`
 2. **Filter out global skills** — never suggest what's already available
 3. Check which remaining primitives are already in the manifest
 4. Suggest additions (with reasoning and similarity scores)

--- a/skills/focus/references/init.md
+++ b/skills/focus/references/init.md
@@ -56,13 +56,13 @@ of whether they exist in any catalog.
 Now search the Spellbook index for skills matching the wishlist:
 
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py --project-dir . --top 20 --json
+python3 ${SKILL_DIR}/scripts/search.py --project-dir . --top 20 --json
 ```
 
 Also run targeted searches for each wishlist item:
 ```bash
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py "stripe webhook patterns" --top 5 --json
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py "Next.js App Router" --top 5 --json
+python3 ${SKILL_DIR}/scripts/search.py "stripe webhook patterns" --top 5 --json
+python3 ${SKILL_DIR}/scripts/search.py "Next.js App Router" --top 5 --json
 ```
 
 **Critical filter:** Exclude all global skills from results. These are

--- a/skills/focus/references/search.md
+++ b/skills/focus/references/search.md
@@ -10,17 +10,17 @@ Run the search script bundled with the focus skill:
 
 ```bash
 # Free-text query
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py "webhook handling" --top 10
+python3 ${SKILL_DIR}/scripts/search.py "webhook handling" --top 10
 
 # Project analysis
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py --project-dir . --top 15
+python3 ${SKILL_DIR}/scripts/search.py --project-dir . --top 15
 
 # JSON output for programmatic use
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py "query" --json
+python3 ${SKILL_DIR}/scripts/search.py "query" --json
 
 # Filter by type
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py "query" --type skill
-python3 ${CLAUDE_SKILL_DIR}/scripts/search.py "query" --type agent
+python3 ${SKILL_DIR}/scripts/search.py "query" --type skill
+python3 ${SKILL_DIR}/scripts/search.py "query" --type agent
 ```
 
 The script fetches `index.yaml` and `registry.yaml` from GitHub, builds a


### PR DESCRIPTION
## Why This Matters

`/focus init` silently falls back to heuristic matching instead of semantic search because
`${CLAUDE_SKILL_DIR}` is never set by any harness. This means every `/focus` user gets
worse skill recommendations with no error message. Fixing this is essential for the core
value prop of embeddings-based discovery.

Closes #60

## Trade-offs / Risks

- **Accepted**: `SKILL_DIR` is the only constant in the block that isn't a concrete value —
  it's a harness-provided prerequisite. This is intentional: it makes the contract explicit
  rather than assuming a specific env var exists.
- **Residual risk**: If a future harness doesn't provide a skill base path, the agent will
  hit the error guidance (stop and surface) rather than silently failing. This is strictly
  better than the status quo.

## Intent Reference

Replace `${CLAUDE_SKILL_DIR}` with a harness-agnostic path resolution that works across
Claude Code, Codex, and any future harness without requiring manual env var setup.
[Source: #60](https://github.com/phrazzld/spellbook/issues/60)

## Changes

- `skills/focus/SKILL.md`: Added `SKILL_DIR` to Constants block with resolution instructions;
  replaced 1 occurrence of `${CLAUDE_SKILL_DIR}`
- `skills/focus/references/init.md`: Replaced 3 occurrences of `${CLAUDE_SKILL_DIR}`
- `skills/focus/references/search.md`: Replaced 5 occurrences of `${CLAUDE_SKILL_DIR}`

## Alternatives Considered

1. **Do nothing**: Silent fallback continues. Unacceptable — defeats embeddings-first design.
2. **Set CLAUDE_SKILL_DIR in bootstrap.sh**: Couples to one harness name. Violates harness-agnostic principle.
3. **Hardcode absolute path**: Breaks on every machine. Non-starter.
4. **Use harness-provided base directory (chosen)**: Every harness already communicates the
   skill path at load time. Just use it. Zero new infrastructure.

## Acceptance Criteria

- [x] `grep -c 'CLAUDE_SKILL_DIR' skills/focus/SKILL.md` returns `0`
- [x] `search.py` is still referenced in SKILL.md
- [x] No `CLAUDE_SKILL_DIR` anywhere in `skills/focus/`
- [x] Resolution instructions document error path for missing harness context

## Manual QA

```bash
# Verify no CLAUDE_SKILL_DIR references remain
grep -rc 'CLAUDE_SKILL_DIR' skills/focus/
# Expected: 0 for all files (or no output)

# Verify SKILL_DIR is defined and used
grep -c 'SKILL_DIR' skills/focus/SKILL.md
# Expected: 3 (constant def + resolution doc + usage)

# Verify search.py still referenced
grep 'search.py' skills/focus/SKILL.md
# Expected: at least 1 match
```

## What Changed

```mermaid
graph LR
    A["/focus init"] --> B{"${CLAUDE_SKILL_DIR} set?"}
    B -->|No - always| C["Silent fallback to heuristic matching"]
    B -->|Yes - never| D["Semantic search via search.py"]
    style C fill:#f66
    style D fill:#6f6
```

```mermaid
graph LR
    A["/focus init"] --> B{"Harness provides SKILL_DIR?"}
    B -->|Yes - always| D["Semantic search via search.py"]
    B -->|No| E["Stop + surface error"]
    style D fill:#6f6
    style E fill:#ff6
```

The old path was always the red box. The new path is always the green box.

## Test Coverage

This is a markdown-only change (agent instructions, not executable code). Verification
is via grep commands in the AC section above. No unit tests apply.

## Merge Confidence

**High.** 3 files, 9 mechanical replacements, 1 new constant definition, 1 resolution
paragraph. Triad review passed unanimously (Ousterhout, Carmack, Grug all Ship).
Strongest evidence: `grep -rc CLAUDE_SKILL_DIR skills/focus/` returns 0.
Residual risk: none — strictly removes a broken dependency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill search documentation with revised script references.

* **Chores**
  * Standardized variable references across skill configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->