### PR TITLE
feat: add launchd-patterns and macos-network-diagnostics skills

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-18T22:07:46Z
+# Generated: 2026-03-19T13:07:06Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/skills/launchd-patterns/SKILL.md
+++ b/skills/launchd-patterns/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: launchd-patterns
+description: "macOS launchd scheduling and service management. LaunchAgent/Daemon patterns, launchctl CLI, plist authoring, cron migration, debugging. The production gotchas Apple docs don't cover."
+argument-hint: "[create|debug|migrate|patterns]"
+---
+
+## Routing Table
+
+| Command | Action |
+|---------|--------|
+| (no args) / `create` | Create a new LaunchAgent/Daemon |
+| `debug` | Debug a failing launch job |
+| `migrate` | Migrate cron jobs to launchd |
+| `patterns` | Load `references/plist-templates.md` |
+
+## Why launchd, Not cron
+
+cron exists on macOS but is a second-class citizen. launchd is PID 1.
+
+| Feature | cron | launchd |
+|---------|------|---------|
+| Survives sleep/wake | No -- missed jobs are gone | Yes -- fires on wake if time passed |
+| On-demand triggers | Time only | Time, file change, network state, directory contents |
+| Resource limits | None | CPU, memory, I/O throttling per job |
+| Logging | Roll your own | stdout/stderr capture + unified log |
+| Dependency ordering | None | `KeepAlive`, `AfterInitialDemand` |
+| Apple blessed | Deprecated warnings since 10.15 | System default since 10.4 |
+
+`crontab -e` still works but logs a deprecation notice. Apple can remove it any release.
+
+## Core Concepts
+
+| Type | Path | Runs as | Available |
+|------|------|---------|-----------|
+| User Agent | `~/Library/LaunchAgents/` | Current user | When user is logged in |
+| Global Agent | `/Library/LaunchAgents/` | Current user | When any user logs in |
+| Daemon | `/Library/LaunchDaemons/` | root (or `UserName` key) | Always, even before login |
+| System | `/System/Library/Launch*` | root | Always -- **never touch these** |
+
+**Rule of thumb:** If it needs a GUI or user context (menu bar, notifications, user files) use an Agent. If it needs to run without any user logged in, use a Daemon.
+
+## launchctl CLI (Modern vs Legacy)
+
+```bash
+# Modern (macOS 10.11+) -- use these
+launchctl bootstrap gui/$(id -u) /path/to/plist    # Load agent
+launchctl bootstrap system /path/to/plist           # Load daemon
+launchctl bootout gui/$(id -u)/com.user.job         # Unload agent
+launchctl bootout system/com.user.job               # Unload daemon
+launchctl kickstart -k gui/$(id -u)/com.user.job    # Force restart (-k kills first)
+launchctl print gui/$(id -u)/com.user.job           # Full status + config dump
+launchctl list                                       # All loaded jobs
+launchctl list com.user.job                          # Single job status
+
+# Domain targets
+# gui/501          = user with UID 501
+# gui/$(id -u)     = current user (portable)
+# system           = system-wide daemons
+# user/501         = per-user background (no GUI)
+
+# Legacy (still works but deprecated -- avoid)
+launchctl load /path/to/plist       # Caching bugs: unloaded jobs reappear after reboot
+launchctl unload /path/to/plist     # Same issue
+launchctl load -w /path/to/plist    # -w "forces" but interacts badly with bootstrap
+```
+
+**Why bootstrap over load:** `load`/`unload` use a persistent override database (`/var/db/launchd.db/`) that can desync with the actual plist state. `bootstrap`/`bootout` operate directly and predictably.
+
+## Plist Template: StartCalendarInterval (Recurring)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.weekly-cleanup</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/script.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>0</integer>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.user.weekly-cleanup.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.user.weekly-cleanup.stderr.log</string>
+</dict>
+</plist>
+```
+
+## Key Gotchas
+
+1. **Label MUST match filename** (minus `.plist` extension). `com.user.myjob` lives in `com.user.myjob.plist`. launchctl silently ignores mismatches on some macOS versions -- job loads but never fires.
+
+2. **ProgramArguments is an array, not a string.** Each argument is its own `<string>` element. `bash -c "complex command"` requires three elements:
+   ```xml
+   <array>
+       <string>/bin/bash</string>
+       <string>-c</string>
+       <string>complex command with pipes | and stuff</string>
+   </array>
+   ```
+
+3. **StartCalendarInterval fires on wake.** If the Mac was asleep at scheduled time, the job fires immediately on wake. This is the killer feature over cron, which simply misses the window.
+
+4. **File permissions matter silently.** Wrong permissions = job silently ignored, no error in logs.
+
+   | Type | Owner | Permissions |
+   |------|-------|-------------|
+   | LaunchAgent | current user | `644` (`-rw-r--r--`) |
+   | LaunchDaemon | `root:wheel` | `644` (`-rw-r--r--`) |
+
+   ```bash
+   # Fix agent permissions
+   chmod 644 ~/Library/LaunchAgents/com.user.myjob.plist
+
+   # Fix daemon permissions
+   sudo chown root:wheel /Library/LaunchDaemons/com.user.myjob.plist
+   sudo chmod 644 /Library/LaunchDaemons/com.user.myjob.plist
+   ```
+
+5. **launchctl load is DEPRECATED.** Use `bootstrap`/`bootout`. The `load`/`unload` API has persistent override caching where unloaded jobs silently re-appear after reboot.
+
+6. **Code signing on Ventura+ (macOS 13+).** Unsigned scripts may be blocked by Gatekeeper. Workaround: use `/bin/bash` as the program and pass the script path as an argument. `/bin/bash` is Apple-signed.
+   ```xml
+   <!-- Instead of this (may be blocked): -->
+   <string>/Users/me/scripts/myjob.sh</string>
+
+   <!-- Use this: -->
+   <array>
+       <string>/bin/bash</string>
+       <string>/Users/me/scripts/myjob.sh</string>
+   </array>
+   ```
+
+7. **Environment variables are NOT inherited.** launchd does not run your shell profile. `$HOME` and `$USER` exist, but `$PATH`, custom vars, Homebrew env -- all absent. Use the `EnvironmentVariables` key:
+   ```xml
+   <key>EnvironmentVariables</key>
+   <dict>
+       <key>PATH</key>
+       <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+       <key>HOMEBREW_PREFIX</key>
+       <string>/opt/homebrew</string>
+   </dict>
+   ```
+
+8. **PATH is minimal.** Default PATH is just `/usr/bin:/bin:/usr/sbin:/sbin`. Homebrew (`/opt/homebrew/bin` on Apple Silicon, `/usr/local/bin` on Intel), pyenv, nvm, cargo -- none of these exist unless you add them.
+
+9. **StartCalendarInterval with multiple times.** Use an array of dicts, not multiple keys:
+   ```xml
+   <key>StartCalendarInterval</key>
+   <array>
+       <dict>
+           <key>Hour</key><integer>9</integer>
+           <key>Minute</key><integer>0</integer>
+       </dict>
+       <dict>
+           <key>Hour</key><integer>17</integer>
+           <key>Minute</key><integer>0</integer>
+       </dict>
+   </array>
+   ```
+
+10. **RunAtLoad + StartCalendarInterval.** `RunAtLoad` fires the job immediately when bootstrapped AND at the next calendar interval. Useful for "run now and then on schedule." Without it, first run waits for next interval.
+
+## Debugging Failed Jobs
+
+```bash
+# 1. Is it loaded?
+launchctl list | grep com.user.myjob
+
+# 2. Full status dump (most useful command)
+launchctl print gui/$(id -u)/com.user.myjob
+# Look for: "last exit code", "state", "path", "runs"
+
+# 3. Validate plist syntax
+plutil -lint ~/Library/LaunchAgents/com.user.myjob.plist
+
+# 4. Check system log for launch failures
+log show --predicate 'subsystem == "com.apple.xpc.launchd"' --last 5m
+log show --predicate 'process == "myjob"' --last 5m
+
+# 5. Check stdout/stderr logs (if configured)
+cat /tmp/com.user.myjob.stdout.log
+cat /tmp/com.user.myjob.stderr.log
+
+# 6. Dry run the command manually to verify it works
+/bin/bash /path/to/script.sh
+```
+
+### Common Exit Codes (from `launchctl print` or `launchctl list`)
+
+| Code | Meaning | Fix |
+|------|---------|-----|
+| `0` | Success | -- |
+| `78` | Configuration error | Bad plist syntax; run `plutil -lint` |
+| `126` | Permission denied | Check script permissions, code signing |
+| `127` | Command not found | PATH issue; use absolute paths |
+| `-2` | (SIGINT) | Script was interrupted |
+| `-9` | (SIGKILL) | Killed by system (memory pressure, timeout) |
+| `-15` | (SIGTERM) | Normal termination signal |
+
+### "Job loaded but never runs" Checklist
+
+1. Label matches filename? (`plutil -p plist | grep Label` vs filename)
+2. Permissions correct? (`ls -la` the plist)
+3. Script executable? (`chmod +x` or use `/bin/bash` wrapper)
+4. Full paths in ProgramArguments? (no `~`, no `$HOME`)
+5. Check `launchctl print` -- does it show `state = not running` with `runs = 0`?
+6. If `StartCalendarInterval`: is the next fire date in the future? (`launchctl print` shows it)
+
+## Cron Migration
+
+```
+# Cron entry
+0 2 1 * * /path/to/cleanup.sh >> /var/log/cleanup.log 2>&1
+```
+
+Translation:
+
+| Cron field | Value | launchd key |
+|------------|-------|-------------|
+| Minute | 0 | `Minute` = 0 |
+| Hour | 2 | `Hour` = 2 |
+| Day of month | 1 | `Day` = 1 |
+| Month | * | (omit -- means every month) |
+| Day of week | * | (omit -- means every day that matches) |
+
+Steps:
+1. Write plist with `StartCalendarInterval` mapping above fields
+2. Set `StandardOutPath`/`StandardErrorPath` (replaces `>>` redirect)
+3. Add full `PATH` in `EnvironmentVariables` (replaces shell profile)
+4. Use absolute paths for everything (no `~` expansion in plists)
+5. `plutil -lint` the plist
+6. Copy to `~/Library/LaunchAgents/`
+7. `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.cleanup.plist`
+8. Verify: `launchctl list | grep com.user.cleanup`
+9. Remove cron entry: `crontab -e` and delete the line
+
+### Cron vs launchd Field Reference
+
+| Cron | launchd | Notes |
+|------|---------|-------|
+| Minute (0-59) | `Minute` | Same |
+| Hour (0-23) | `Hour` | Same |
+| Day of month (1-31) | `Day` | Same |
+| Month (1-12) | `Month` | Same |
+| Day of week (0-7, 0/7=Sun) | `Weekday` | launchd: 0=Sunday through 6=Saturday (7 NOT valid) |
+| `*/5` (every 5 min) | No equivalent | Use `StartInterval` (300) instead |
+| `1,15` (1st and 15th) | Array of dicts | One dict per combination |
+
+## Common Scheduling Patterns
+
+| Pattern | Key | Example |
+|---------|-----|---------|
+| Every N seconds | `StartInterval` | `<integer>300</integer>` (5 min) |
+| Cron-like schedule | `StartCalendarInterval` | See template above |
+| File/directory change | `WatchPaths` | Trigger when file modified |
+| Directory has contents | `QueueDirectories` | Trigger when dir non-empty, batch processing |
+| Run when network up | `KeepAlive` + `NetworkState` | Wait for connectivity |
+| Run once at load | `RunAtLoad` | Combined with other triggers |
+| Stay alive forever | `KeepAlive` = `true` | Restarts on crash (daemon pattern) |
+| Throttle restarts | `ThrottleInterval` | Min seconds between launches (default: 10) |
+
+## Lifecycle: Create, Test, Deploy
+
+```bash
+# 1. Write and validate
+vim ~/Library/LaunchAgents/com.user.myjob.plist
+plutil -lint ~/Library/LaunchAgents/com.user.myjob.plist
+chmod 644 ~/Library/LaunchAgents/com.user.myjob.plist
+
+# 2. Load
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.myjob.plist
+
+# 3. Test (force immediate run)
+launchctl kickstart gui/$(id -u)/com.user.myjob
+
+# 4. Verify
+launchctl list | grep com.user.myjob
+cat /tmp/com.user.myjob.stdout.log
+
+# 5. Iterate (edit plist, then reload)
+launchctl bootout gui/$(id -u)/com.user.myjob
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.myjob.plist
+
+# 6. Remove
+launchctl bootout gui/$(id -u)/com.user.myjob
+rm ~/Library/LaunchAgents/com.user.myjob.plist
+```

--- a/skills/launchd-patterns/references/plist-templates.md
+++ b/skills/launchd-patterns/references/plist-templates.md
@@ -1,0 +1,288 @@
+# Plist Templates
+
+Copy-paste-ready launchd plist templates. Replace `com.user.JOBNAME`, paths, and schedule values.
+
+All templates assume LaunchAgent (user context). For LaunchDaemon: change install path to `/Library/LaunchDaemons/`, set owner to `root:wheel`, and add `<key>UserName</key><string>username</string>` if you don't want it running as root.
+
+---
+
+## Daily Script
+
+Runs a script every day at 2:30 AM. Fires on wake if the Mac was asleep at that time.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.daily-task</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/me/scripts/daily-task.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.user.daily-task.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.user.daily-task.stderr.log</string>
+</dict>
+</plist>
+```
+
+**Install:**
+```bash
+cp com.user.daily-task.plist ~/Library/LaunchAgents/
+chmod 644 ~/Library/LaunchAgents/com.user.daily-task.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.daily-task.plist
+```
+
+---
+
+## File Watcher
+
+Triggers when a file or directory changes. Useful for auto-processing downloads, config reloads, or build triggers.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.file-watcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/me/scripts/on-file-change.sh</string>
+    </array>
+    <key>WatchPaths</key>
+    <array>
+        <string>/Users/me/Downloads</string>
+    </array>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.user.file-watcher.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.user.file-watcher.stderr.log</string>
+</dict>
+</plist>
+```
+
+**Gotchas:**
+- `WatchPaths` fires on ANY change (create, modify, delete, rename) in the watched path.
+- For directories, fires when directory contents change, NOT when files inside subdirectories change. Not recursive.
+- `ThrottleInterval` prevents rapid re-firing. Default is 10 seconds. Set lower if you need faster response.
+- The job receives no information about WHAT changed. Your script must track state itself (e.g., compare against a manifest file).
+
+---
+
+## Network-Triggered Service
+
+Runs when the network becomes available. Useful for sync jobs, VPN setup, or upload queues.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.network-sync</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/me/scripts/sync-when-online.sh</string>
+    </array>
+    <key>KeepAlive</key>
+    <dict>
+        <key>NetworkState</key>
+        <true/>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.user.network-sync.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.user.network-sync.stderr.log</string>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+</dict>
+</plist>
+```
+
+**How it works:**
+- `KeepAlive` with `NetworkState = true` means: keep the job alive whenever the network is reachable.
+- If the script exits, launchd restarts it (after `ThrottleInterval` seconds) as long as the network is still up.
+- When the network drops, launchd sends SIGTERM. When it returns, the job is relaunched.
+- For one-shot sync (run once when network appears, not continuously): have the script do its work and exit. It will re-run each time network state transitions to "up."
+
+**Important:** `NetworkState` checks for an active interface with an IP, not actual internet connectivity. A captive portal WiFi connection counts as "network available."
+
+---
+
+## On-Demand Long-Running Service
+
+A daemon-style service that starts at login and restarts on crash. Pattern for menu bar apps, local API servers, or background sync engines.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.my-service</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/my-service</string>
+        <string>--port</string>
+        <string>8080</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/me</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.user.my-service.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.user.my-service.stderr.log</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
+</dict>
+</plist>
+```
+
+**Notes:**
+- `KeepAlive = true` means launchd restarts the process whenever it exits (crash or clean exit).
+- `ThrottleInterval` prevents restart storms. If the service crashes immediately, launchd waits 10 seconds before retrying.
+- `ProcessType = Background` tells macOS this is low-priority background work. Reduces CPU/IO priority to avoid impacting foreground apps.
+- `SoftResourceLimits` raises the open file limit (default is 256, too low for many servers).
+- To stop: `launchctl bootout gui/$(id -u)/com.user.my-service`. `kill` alone just triggers a restart.
+
+---
+
+## Batch Processor (QueueDirectories)
+
+Fires whenever a directory has contents. Process files, then remove them. launchd re-triggers if more files appear.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.batch-processor</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/me/scripts/process-queue.sh</string>
+    </array>
+    <key>QueueDirectories</key>
+    <array>
+        <string>/Users/me/queue/incoming</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.user.batch-processor.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.user.batch-processor.stderr.log</string>
+</dict>
+</plist>
+```
+
+**Pattern for the processing script:**
+```bash
+#!/bin/bash
+QUEUE_DIR="/Users/me/queue/incoming"
+DONE_DIR="/Users/me/queue/processed"
+
+mkdir -p "$DONE_DIR"
+
+for file in "$QUEUE_DIR"/*; do
+    [ -f "$file" ] || continue
+    # Process the file
+    echo "Processing: $(basename "$file")"
+    # ... your logic here ...
+    mv "$file" "$DONE_DIR/"
+done
+```
+
+**How `QueueDirectories` differs from `WatchPaths`:**
+- `QueueDirectories` only fires when the directory is **non-empty**. If the script removes all files, launchd waits until new files appear.
+- `WatchPaths` fires on any change, even deletion. Your script must handle empty states.
+- `QueueDirectories` is the right choice for "process files as they arrive" workflows.
+
+---
+
+## Interval Timer (Every N Seconds)
+
+Simple repeating timer. Less precise than `StartCalendarInterval` but simpler for "every 5 minutes" patterns.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.heartbeat</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/me/scripts/heartbeat.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/com.user.heartbeat.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/com.user.heartbeat.stderr.log</string>
+</dict>
+</plist>
+```
+
+**Behavior notes:**
+- Timer starts from when the job finishes, not from when it starts. A 300-second interval with a 60-second script means ~360 seconds between start times.
+- Timer resets on wake from sleep. If Mac sleeps for 8 hours with a 5-minute interval, one run fires on wake, then resumes the 5-minute cadence.
+- Cannot combine `StartInterval` and `StartCalendarInterval` in the same plist. Pick one.

--- a/skills/macos-network-diagnostics/SKILL.md
+++ b/skills/macos-network-diagnostics/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: macos-network-diagnostics
+description: "macOS network debugging: DNS resolution paths, firewall layers, Tailscale fleet management, mDNS/Bonjour, SSH tunneling. Diagnostic sequences that go beyond man pages."
+argument-hint: "[diagnose|dns|firewall|tailscale|ssh|wol]"
+---
+
+## Routing Table
+
+| Command | Action |
+|---------|--------|
+| (no args) / `diagnose` | Run the diagnostic sequence |
+| `dns` | DNS resolution debugging (scutil, dns-sd, split DNS) |
+| `firewall` | Firewall layer debugging (ALF + PF) |
+| `tailscale` | Load `references/tailscale.md` |
+| `ssh` | Load `references/ssh-patterns.md` |
+| `wol` | Wake-on-LAN patterns |
+
+## Critical Rule: dig/nslookup LIE on macOS
+
+`dig`, `nslookup`, `host` bypass macOS DNS resolution — they read `/etc/resolv.conf` directly, which only shows the default resolver. No split DNS, no scoped resolvers, no mDNS. Use these instead:
+
+```bash
+dns-sd -G v4v6 hostname.example.com     # Uses mDNSResponder (what apps use)
+dscacheutil -q host -a name hostname.com  # Uses system resolver
+```
+
+If `dig` works but apps fail (or vice versa): split DNS routing, not the server.
+
+## Diagnostic Sequence (Start Here)
+
+When something network-related breaks on macOS:
+
+```bash
+# 1. Default route and interface
+route -n get 8.8.8.8
+
+# 2. DNS resolvers and ordering (lower order wins)
+scutil --dns | head -40
+
+# 3. System DNS resolution (NOT dig)
+dscacheutil -q host -a name problem-hostname.example.com
+
+# 4. mDNSResponder resolution
+dns-sd -G v4v6 problem-hostname.example.com
+
+# 5. Tailscale routing (if applicable)
+tailscale ping target-device
+tailscale netcheck
+
+# 6. Firewall state
+/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+sudo pfctl -si | head -5
+
+# 7. Nuclear flush (both caches are separate)
+sudo dscacheutil -flushcache; sudo killall -HUP mDNSResponder
+```
+
+## DNS Deep Dive
+
+**scutil --dns** shows ALL resolvers including scoped/supplemental (VPN, Tailscale). Lower `order` value wins. Tailscale injects supplemental resolver (100.100.100.100) with `match domain` for your tailnet.
+
+**Per-domain override:** Drop file in `/etc/resolver/` named after domain. Example: `/etc/resolver/corp.example.com` containing `nameserver 10.0.0.53`. Survives reboots.
+
+**The .local disaster:** `.local` TLD is reserved for mDNS (RFC 6762). macOS sends `.local` queries via multicast first (5-sec timeout), then unicast. Corporate AD domains using `.local` = 5-sec delay on every lookup.
+
+**DNS flush requires BOTH commands:**
+
+```bash
+sudo dscacheutil -flushcache     # Directory Services cache
+sudo killall -HUP mDNSResponder  # Daemon's internal cache
+```
+
+Chrome/Firefox have their own caches (`chrome://net-internals/#dns`).
+
+## Firewall Layers
+
+macOS has TWO independent firewalls:
+
+| Layer | Tool | Purpose |
+|-------|------|---------|
+| ALF (Application Layer) | `socketfilterfw` | Per-app allow/deny incoming |
+| PF (Packet Filter) | `pfctl` | BSD packet filter, IP/port rules |
+
+ALF can allow an app while PF blocks its port. Check both.
+
+```bash
+# ALF status
+/usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate
+
+# PF status and rules
+sudo pfctl -si | head -5   # enabled/disabled
+sudo pfctl -sr              # active rules
+sudo pfctl -sA              # all anchors
+```
+
+**PF reference counting:** macOS PF uses `-E` (enable, returns token) and `-X token` (release). PF disables only when last reference released. `sudo pfctl -d` force-kills ALL consumers including system services. Use tokens.
+
+**Never flush main ruleset:** `sudo pfctl -F all` destroys system anchors. Work in your own anchor: `sudo pfctl -a "my.rules" -f /path/to/rules.conf`.
+
+## mDNS / Bonjour
+
+```bash
+dns-sd -B _services._dns-sd._udp  # Browse ALL service types
+dns-sd -B _ssh._tcp                # Browse SSH services
+dns-sd -L "Name" _ssh._tcp        # Resolve instance to IP:port
+```
+
+All `dns-sd` commands stream continuously. Ctrl-C to stop.
+
+mDNS uses UDP 5353 multicast (224.0.0.251). If PF blocks this, Bonjour/AirDrop/Handoff break silently.
+
+## networksetup
+
+```bash
+networksetup -listnetworkserviceorder   # Service priority (determines default route)
+networksetup -getdnsservers "Wi-Fi"     # DNS for a service
+networksetup -setdnsservers "Wi-Fi" empty  # Revert to DHCP DNS
+```
+
+**Service ordering gotcha:** First active service provides default route. Plugging USB-C Ethernet creates new service at random position — all traffic may shift unexpectedly. DNS is per-service, not global.
+
+## Wake-on-LAN
+
+```bash
+brew install wakeonlan
+wakeonlan AA:BB:CC:DD:EE:FF                     # Same broadcast domain
+wakeonlan -i 192.168.1.255 AA:BB:CC:DD:EE:FF    # Specify broadcast
+```
+
+**WoL over Tailscale does NOT work.** Tailscale is L3 (IP). WoL is L2 (Ethernet broadcast). Subnet routing doesn't forward broadcasts. Use an always-on LAN proxy:
+
+```bash
+ssh pi@always-on-device "wakeonlan AA:BB:CC:DD:EE:FF"
+```
+
+**macOS WoL quirk:** After waking, Mac sleeps again in 30-60 sec unless there's an active session. Establish SSH/screen sharing quickly.
+
+## Cross-Tool Interaction Map
+
+| Scenario | Tools | Root Cause |
+|----------|-------|------------|
+| VPN + Tailscale DNS conflict | `scutil --dns` | Resolver ordering: lowest order wins |
+| Can ping IP but not hostname | `dns-sd`, `dscacheutil` | Split DNS: dig and apps use different paths |
+| AirDrop/Handoff stopped | `dns-sd`, `pfctl` | mDNS blocked: UDP 5353 filtered |
+| SSH through Tailscale hangs | `tailscale ping`, `netcheck` | DERP relay; symmetric NAT kills direct connections |
+| Wake remote Mac over Tailscale | `wakeonlan`, `ssh` | L2 vs L3: need always-on LAN proxy |
+| Hotel Wi-Fi won't authenticate | captive portal | Custom DNS or VPN intercepting probe |
+| Works in Safari not in curl | `scutil --dns` | curl uses resolv.conf; Safari uses mDNSResponder |
+
+## Captive Portal Gotcha
+
+macOS probes `captive.apple.com/hotspot-detect.html` over plain HTTP. Custom DNS servers, VPNs, or DoH/DoT prevent the redirect. Force open:
+
+```bash
+open "http://captive.apple.com/hotspot-detect.html"
+```
+
+Nuclear: disable custom DNS and VPN, connect, authenticate, re-enable.

--- a/skills/macos-network-diagnostics/references/ssh-patterns.md
+++ b/skills/macos-network-diagnostics/references/ssh-patterns.md
@@ -1,0 +1,59 @@
+# SSH Patterns for Fleet Management
+
+## Tunnel Types
+
+```bash
+ssh -L 5432:db.internal:5432 jump     # LOCAL: access remote service locally
+ssh -R 8080:localhost:3000 remote      # REMOTE: expose local service remotely
+ssh -D 1080 remote                     # SOCKS: dynamic proxy
+```
+
+## ProxyJump (Preferred)
+
+```
+# ~/.ssh/config
+Host internal-server
+    HostName 10.0.0.50
+    ProxyJump jump-host
+    User deploy
+```
+
+End-to-end encrypted — jump host sees only opaque bytes. Multi-hop:
+`ProxyJump host1,host2,host3` chains left to right.
+
+Strictly better than agent forwarding.
+
+## Agent Forwarding: Avoid
+
+`ForwardAgent yes` exposes your SSH agent socket on the remote host. Anyone with root can authenticate as you to any server your keys unlock.
+
+Prefer ProxyJump. If you must forward, use `ssh-add -c` for per-use confirmation and scope to specific hosts only.
+
+## 1Password SSH Agent + ProxyJump
+
+`IdentityAgent` takes precedence over `SSH_AUTH_SOCK`. For remote sessions needing forwarded agent, don't set `IdentityAgent` on that host entry.
+
+## Keepalive + Persistent Tunnels
+
+```
+# ~/.ssh/config
+Host *
+    ServerAliveInterval 60
+    ServerAliveCountMax 3
+
+# Persistent tunnel (uses SSH keepalive, not monitor port)
+autossh -M 0 -f -N -L 5432:db.internal:5432 jump-host
+```
+
+## Tailscale + SSH
+
+With Tailscale, direct SSH to any peer — no jump hosts needed:
+
+```
+Host phyrexia
+    HostName phyrexia
+    User phaedrus
+    # MagicDNS resolves if Tailscale DNS enabled
+```
+
+Use `tailscale ssh` for keyless SSH (Tailscale manages auth). Requires enabling in ACLs.

--- a/skills/macos-network-diagnostics/references/tailscale.md
+++ b/skills/macos-network-diagnostics/references/tailscale.md
@@ -1,0 +1,36 @@
+# Tailscale CLI Reference
+
+## Core Commands
+
+```bash
+tailscale status                    # Peer status: direct vs DERP relay
+tailscale ping <hostname-or-ip>     # Test direct connectivity
+tailscale netcheck                  # NAT type, DERP latency, IPv6
+tailscale dns status                # DNS resolver state
+tailscale dns query <hostname>      # Query through Tailscale resolver
+tailscale version                   # Client/daemon version (watch for mismatch)
+```
+
+## MagicDNS
+
+Full names: `<hostname>.<tailnet>.ts.net`. Short names only work if "Use Tailscale DNS settings" is checked (adds tailnet as search domain).
+
+CLI tools that bypass system DNS (`dig`, `nslookup`, `host`) NEVER resolve MagicDNS names. Test with `ping` or `dns-sd`.
+
+## Exit Node DNS Override
+
+When using exit node, ALL DNS goes through it — overrides split DNS and custom nameservers. By design for privacy, breaks internal DNS. Fix: mark specific nameservers as not overridden in admin console, or configure per-domain split DNS.
+
+## Direct vs Relayed
+
+`tailscale ping` shows direct (UDP hole-punch) vs DERP relay.
+`tailscale netcheck` shows NAT type.
+If `MappingVariesByDestIP: true` = symmetric NAT → all traffic through DERP relays.
+
+## Version Mismatch
+
+App Store updates GUI but may not update `tailscaled`. `tailscale version` shows both. Fix: restart from menu bar or `killall Tailscale` and relaunch.
+
+## Debug Menu
+
+Option+click the Tailscale menu bar icon → debug menu → "Bug Report" generates full config dump.


### PR DESCRIPTION
## Summary

- Adds `launchd-patterns` skill — plist authoring, agent/daemon lifecycle, troubleshooting
- Adds `macos-network-diagnostics` skill — SSH, Tailscale, DNS, and connectivity debugging

## Test plan

- [ ] Verify `skills/launchd-patterns/SKILL.md` has valid frontmatter
- [ ] Verify `skills/macos-network-diagnostics/SKILL.md` has valid frontmatter
- [ ] Confirm `index.yaml` regenerated by pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive macOS launchd configuration guide covering job types, modern commands, production gotchas, debugging workflows, and cron migration with copy-paste-ready plist templates.
  * Added macOS network diagnostics guide with structured workflows for routing, DNS, firewalls, and optional Tailscale and Wake-on-LAN troubleshooting.
  * Added SSH patterns reference documenting tunnel types, multi-hop configurations, and Tailscale SSH integration.
  * Added Tailscale CLI reference with core commands and macOS DNS behavior guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->