### PR TITLE
feat(skills): persist focus reports and model routing

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -7,3 +7,4 @@ Use `/tune-repo` to replace placeholders with real subsystem docs.
 | Subsystem | Docs | Source Files | Notes |
 |-----------|------|--------------|-------|
 | context-architecture | `docs/context/ROUTING.md`, `docs/context/DRIFT-WATCHLIST.md` | `CLAUDE.md`, `AGENTS.md`, `docs/context/**` | repo-level context plumbing |
+| focus-selection-history | `skills/focus/references/init.md` | `.spellbook/init-report.json` | cold-memory record of why primitives were selected, rejected, or left as gaps |

--- a/docs/context/ROUTING.md
+++ b/docs/context/ROUTING.md
@@ -7,5 +7,6 @@ Use `/tune-repo` to replace placeholders with real routes tied to source areas.
 | Trigger | Signal | Route |
 |---------|--------|-------|
 | Pre-change | skill creation or modification | `/craft-primitive` |
+| Pre-change | rerunning `/focus init` or auditing primitive selection | read `.spellbook/init-report.json` before new catalog search |
 | Pre-change | repo tuning / agent foundation work | `codified-context-architecture` + `/tune-repo` |
 | Post-change | PR blocked on CI, reviews, or conflicts | `/pr-fix` |

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-19T16:32:37Z
+# Generated: 2026-03-19T16:59:54Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-19T16:59:54Z
+# Generated: 2026-03-19T17:00:14Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -66,6 +66,26 @@ Do not introduce heuristic-only semantic pipelines (regex ladders, keyword score
 
 Deterministic logic is limited to strict mechanics: schema checks, exact parsing, permission/safety gates.
 
+## Executive / Worker Split
+
+Keep the strongest available model on executive work:
+- issue selection and lane ownership
+- spec/design approval and tradeoff calls
+- triage of review feedback and out-of-scope decisions
+- acceptance-criteria judgment, merge-confidence judgment, and PR narrative
+
+Delegate bounded gruntwork to smaller worker subagents:
+- codebase reading and evidence gathering
+- isolated implementation chunks with disjoint file ownership
+- targeted test repair, CI investigation, and mechanical refactors
+- walkthrough capture and other artifact preparation after requirements are clear
+
+If the harness supports model choice, prefer worker-class models for execution
+(for example GPT-5.4-Mini, GPT-5.3-Codex-Spark, or Sonnet-class workers) and
+reserve frontier models for strategy, adversarial review, and final sign-off.
+
+Never delegate the final ship / don't ship call. Workers propose; the lead decides.
+
 ## Priority Selection
 
 **Always work on the highest-priority eligible issue.**
@@ -129,6 +149,10 @@ The point is single ownership and meaningful progress. One issue should map to o
    - If design contains a state machine or concurrent protocol, run `/formal-verify loop`.
    - If thinktank surfaces a materially better approach, revise the design before building.
 7. **Build (TDD Enforced)** — Invoke `/build` and require RED→GREEN evidence per acceptance criterion:
+   - Before changing code, split implementation into bounded worker tasks. Give each worker
+     a concrete scope, owned files, and explicit tests/evidence to return.
+   - Prefer smaller worker-class models for implementation, mechanical cleanup, and test repair.
+     Keep executive control of design changes, scope changes, and final acceptance on the lead model.
    - RED: failing targeted tests before implementation
    - GREEN: same tests passing after implementation
    - If test harness is broken, stop and flag blocker (no implementation without explicit user bypass)
@@ -142,6 +166,8 @@ The point is single ownership and meaningful progress. One issue should map to o
     | `ousterhout` | Module depth, information hiding, interface simplicity. Flag shallow modules, pass-throughs, leaky abstractions. | Any red flag = must fix |
     | `carmack` | Shippability, unnecessary abstraction, speculative generality. "Would you ship this today?" | Any "don't ship" = must fix |
     | `grug` | Complexity demons. Is this simple enough for grug brain? Too many layers? Over-engineered? | Any "complexity bad" = must fix |
+
+    Use the strongest available review-capable models for this gate.
 
     Each agent reads the full diff (`git diff main...HEAD`). Each outputs:
     - **Ship / Don't Ship** verdict

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -59,6 +59,20 @@ codex exec "DEBUG: $SYMPTOMS. Reproduce, isolate root cause, propose fix." \
   --output-last-message /tmp/codex-debug.md 2>/dev/null
 ```
 
+## Executive / Worker Split
+
+Keep the strongest available model on debugging judgment:
+- ranking hypotheses and deciding what to test next
+- declaring root cause proven
+- choosing the remediation and deciding when evidence is sufficient
+
+Delegate bounded evidence work to smaller worker subagents:
+- tracing one subsystem or one hypothesis
+- comparing working vs broken implementations
+- gathering logs, reproductions, and targeted test cases
+
+Workers gather proof. The lead decides what the proof means.
+
 ## Multi-Hypothesis Mode (Agent Teams)
 
 When >2 plausible root causes and single investigation would anchor on one:
@@ -67,6 +81,9 @@ When >2 plausible root causes and single investigation would anchor on one:
 2. Each teammate gets one hypothesis to prove/disprove
 3. Teammates challenge each other's findings
 4. Lead synthesizes consensus root cause
+
+Prefer smaller worker-class models for these investigators unless a hypothesis
+demands frontier-level reasoning. Keep the synthesis on the strongest model.
 
 Use when: ambiguous stack trace, multiple services, flaky failures.
 Don't use when: obvious single cause, config issue, simple regression.

--- a/skills/focus/SKILL.md
+++ b/skills/focus/SKILL.md
@@ -25,6 +25,7 @@ INDEX_URL:         ${SPELLBOOK_RAW}/index.yaml
 REGISTRY_URL:      ${SPELLBOOK_RAW}/registry.yaml
 MANIFEST_FILE:     .spellbook.yaml
 MARKER_FILE:       .spellbook
+INIT_REPORT_FILE:  .spellbook/init-report.json
 ```
 
 **Resolving `SKILL_DIR`:** The harness provides the skill's installed path at
@@ -115,7 +116,11 @@ and follow it exactly. The init flow is 8 phases — do not shortcut it.
    failure modes. Actively push to create new skills for every gap. This is
    how spellbook grows — and these gap-born skills are the highest-leverage
    ones because they encode what the model can't already do.
-5. **Present the full picture:** analysis, wishlist, matches, AND gaps.
+5. **Persist the init report before confirmation.** Write
+   `${INIT_REPORT_FILE}` with the structured analysis, candidate matrix,
+   selected primitives, gaps, and confidence before asking the user to
+   confirm the manifest.
+6. **Present the full picture:** analysis, wishlist, matches, AND gaps.
    Lead with gaps as opportunities, not afterthoughts. Get explicit
    confirmation before writing the manifest.
 

--- a/skills/focus/references/improve.md
+++ b/skills/focus/references/improve.md
@@ -24,6 +24,14 @@ per observation, appended by `/calibrate` or manually.
 
 Read `.spellbook/observations.ndjson` from the current project.
 
+If `.spellbook/init-report.json` exists, read it before clustering anything
+else. Treat it as the baseline record of:
+
+- what `/focus init` saw in the repo
+- which primitives were selected or rejected
+- which gaps were already known
+- what confidence and open questions existed at selection time
+
 If running from the spellbook repo itself, also scan for observation files
 in known project directories (check git config for recent repos, or ask
 the user which projects to include).
@@ -41,8 +49,11 @@ For each cluster, analyze the observations and produce:
 
 - **What's wrong**: Common thread across observations
 - **Proposed fix**: Specific edit to the canonical skill/agent
-- **Evidence**: The observations that support this
+- **Evidence**: The observations and init-report entries that support this
 - **Confidence**: How certain we are this is the right fix
+
+If the init report already listed a gap or weak match for the same area,
+reuse that language instead of reconstructing the rationale from scratch.
 
 ### 4. Choose Action
 

--- a/skills/focus/references/init.md
+++ b/skills/focus/references/init.md
@@ -127,6 +127,10 @@ python3 ${SKILL_DIR}/scripts/init_report.py write \
 
 The input payload must satisfy this compact shape:
 
+- `repo_summary.project` must be a non-empty string.
+- `repo_summary.stack`, `domains`, `services`, and `signals` must be arrays of non-empty strings.
+- `candidate_matrix[*].primitive` is required for rows that represent a concrete candidate (`selected`, `rejected`, etc.); gap rows may omit it.
+
 ```json
 {
   "repo_summary": {

--- a/skills/focus/references/init.md
+++ b/skills/focus/references/init.md
@@ -8,6 +8,11 @@ Don't start by searching the catalog. Start by understanding the project
 deeply, then reason from first principles about what domain knowledge
 would make an agent most effective here. Search comes after thinking.
 
+Before asking the user to confirm the manifest, persist a structured init
+report to `.spellbook/init-report.json`. The report is the cold-memory
+artifact for why the selection happened, what was rejected, and which gaps
+still need follow-up.
+
 ## Process
 
 ### Phase 1: Deep Project Analysis
@@ -99,7 +104,76 @@ Every gap is a skill waiting to be created — and gap-born skills are the
 highest-leverage primitives in the library because they encode exactly
 what the model can't already do on its own.
 
-### Phase 5: Generate Manifest
+### Phase 5: Write Init Report
+
+Before manifest confirmation, write `.spellbook/init-report.json` with:
+
+- `repo_summary` — compact analysis of the repo, stack, domains, services,
+  and the signals you read
+- `wishlist` — first-principles capability wishlist, with why each item matters
+- `candidate_matrix` — one row per wishlist item or considered primitive,
+  including status, rationale, and evidence
+- `selected_primitives` — the primitives that should land in `.spellbook.yaml`
+- `gaps` — unmet wishlist items and recommended follow-up
+- `confidence` — explicit confidence level, strongest evidence, and open questions
+
+Use the helper to validate and write the artifact in one step:
+
+```bash
+python3 ${SKILL_DIR}/scripts/init_report.py write \
+  --output .spellbook/init-report.json \
+  --input /tmp/focus-init-report.json
+```
+
+The input payload must satisfy this compact shape:
+
+```json
+{
+  "repo_summary": {
+    "project": "short description",
+    "stack": ["python", "markdown"],
+    "domains": ["agent tooling"],
+    "services": ["GitHub"],
+    "signals": ["README.md", "CLAUDE.md", "git log --oneline -20"]
+  },
+  "wishlist": [
+    {
+      "name": "repo tuning",
+      "why": "Agents need cold-memory structure and routing guidance."
+    }
+  ],
+  "candidate_matrix": [
+    {
+      "wishlist_item": "repo tuning",
+      "primitive": "phrazzld/spellbook@codified-context-architecture",
+      "status": "selected",
+      "rationale": "Directly addresses repo-level context architecture.",
+      "evidence": ["docs/context/** exists", "project vision emphasizes agent workflows"]
+    }
+  ],
+  "selected_primitives": [
+    {
+      "name": "codified-context-architecture",
+      "kind": "skill",
+      "reason": "Matches repo tuning needs."
+    }
+  ],
+  "gaps": [
+    {
+      "name": "factory-specific routing policy",
+      "why": "No current primitive encodes these conventions.",
+      "next_action": "propose new spellbook skill"
+    }
+  ],
+  "confidence": {
+    "level": "medium",
+    "summary": "Selection is grounded in repo docs and file layout.",
+    "open_questions": ["Should deployment-specific guidance become project-local?"]
+  }
+}
+```
+
+### Phase 6: Generate Manifest
 
 ```yaml
 # .spellbook.yaml
@@ -113,7 +187,7 @@ agents:
   - stripe-auditor
 ```
 
-### Phase 6: Present for Confirmation
+### Phase 7: Present for Confirmation
 
 Show the user:
 
@@ -121,6 +195,7 @@ Show the user:
 2. **Wishlist** (what domain knowledge would be ideal)
 3. **Matched skills** with reasoning
 4. **Skill gaps** — wishlist items with no match
+5. **Init report path** — `.spellbook/init-report.json` written and ready to inspect
 
 For each gap, offer:
 > "No existing skill covers [X]. Want me to draft a new skill for this
@@ -128,7 +203,7 @@ For each gap, offer:
 
 Only write manifest after explicit confirmation.
 
-### Phase 7: Create Skills for Gaps
+### Phase 8: Create Skills for Gaps
 
 **This is NOT optional.** For every gap identified in Phase 4, actively
 propose creating a new skill. Present a concrete 1-2 sentence description
@@ -164,7 +239,7 @@ This is how spellbook grows — organically from real project needs, with
 each new skill encoding domain knowledge that makes agents genuinely
 more effective than they'd be from base model capabilities alone.
 
-### Phase 8: Run Sync
+### Phase 9: Run Sync
 
 After writing the manifest, immediately run the sync flow to install
 the declared domain primitives.

--- a/skills/focus/scripts/init_report.py
+++ b/skills/focus/scripts/init_report.py
@@ -36,6 +36,26 @@ def _expect_non_empty_string(value: object, path: str) -> list[str]:
     return [f"{path} must be a non-empty string"]
 
 
+def _expect_string_list(
+    value: object,
+    path: str,
+    *,
+    allow_empty: bool,
+) -> list[str]:
+    errors = _expect_list(value, path)
+    if errors:
+        return errors
+
+    items = value
+    assert isinstance(items, list)
+    if not allow_empty and not items:
+        return [f"{path} must be a non-empty array"]
+
+    for index, item in enumerate(items):
+        errors.extend(_expect_non_empty_string(item, f"{path}[{index}]"))
+    return errors
+
+
 def _validate_object(
     value: object,
     path: str,
@@ -70,7 +90,13 @@ def validate_report(report: object) -> list[str]:
     if errors:
         return errors
 
-    errors.extend(_expect_dict(data["repo_summary"], "report.repo_summary"))
+    errors.extend(
+        _validate_object(
+            data["repo_summary"],
+            "report.repo_summary",
+            ("project",),
+        )
+    )
     errors.extend(_expect_list(data["wishlist"], "report.wishlist"))
     errors.extend(_expect_list(data["candidate_matrix"], "report.candidate_matrix"))
     errors.extend(_expect_list(data["selected_primitives"], "report.selected_primitives"))
@@ -91,10 +117,25 @@ def validate_report(report: object) -> list[str]:
     assert isinstance(gaps, list)
     assert isinstance(confidence, dict)
 
+    repo_summary = data["repo_summary"]
+    assert isinstance(repo_summary, dict)
+
     if not wishlist:
         errors.append("report.wishlist must contain at least one item")
     if not candidate_matrix:
         errors.append("report.candidate_matrix must contain at least one row")
+
+    for field in ("stack", "domains", "services", "signals"):
+        if field not in repo_summary:
+            errors.append(f"report.repo_summary.{field} is required")
+            continue
+        errors.extend(
+            _expect_string_list(
+                repo_summary[field],
+                f"report.repo_summary.{field}",
+                allow_empty=(field == "services"),
+            )
+        )
 
     for index, item in enumerate(wishlist):
         errors.extend(
@@ -110,11 +151,27 @@ def validate_report(report: object) -> list[str]:
             )
         )
         if isinstance(item, dict):
+            status = item.get("status")
+            if status != "gap":
+                if "primitive" not in item:
+                    errors.append(f"report.candidate_matrix[{index}].primitive is required")
+                else:
+                    errors.extend(
+                        _expect_non_empty_string(
+                            item["primitive"],
+                            f"report.candidate_matrix[{index}].primitive",
+                        )
+                    )
+
             if "evidence" not in item:
                 errors.append(f"report.candidate_matrix[{index}].evidence is required")
-            elif not isinstance(item["evidence"], list) or not item["evidence"]:
-                errors.append(
-                    f"report.candidate_matrix[{index}].evidence must be a non-empty array"
+            else:
+                errors.extend(
+                    _expect_string_list(
+                        item["evidence"],
+                        f"report.candidate_matrix[{index}].evidence",
+                        allow_empty=False,
+                    )
                 )
 
     for index, item in enumerate(selected_primitives):
@@ -141,8 +198,14 @@ def validate_report(report: object) -> list[str]:
 
     if "open_questions" not in confidence:
         errors.append("report.confidence.open_questions is required")
-    elif not isinstance(confidence["open_questions"], list):
-        errors.append("report.confidence.open_questions must be an array")
+    else:
+        errors.extend(
+            _expect_string_list(
+                confidence["open_questions"],
+                "report.confidence.open_questions",
+                allow_empty=True,
+            )
+        )
 
     return errors
 

--- a/skills/focus/scripts/init_report.py
+++ b/skills/focus/scripts/init_report.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Validate and persist /focus init reports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+TOP_LEVEL_KEYS = (
+    "repo_summary",
+    "wishlist",
+    "candidate_matrix",
+    "selected_primitives",
+    "gaps",
+    "confidence",
+)
+
+
+def _expect_dict(value: object, path: str) -> list[str]:
+    if isinstance(value, dict):
+        return []
+    return [f"{path} must be an object"]
+
+
+def _expect_list(value: object, path: str) -> list[str]:
+    if isinstance(value, list):
+        return []
+    return [f"{path} must be an array"]
+
+
+def _expect_non_empty_string(value: object, path: str) -> list[str]:
+    if isinstance(value, str) and value.strip():
+        return []
+    return [f"{path} must be a non-empty string"]
+
+
+def _validate_object(
+    value: object,
+    path: str,
+    required_fields: tuple[str, ...],
+) -> list[str]:
+    errors = _expect_dict(value, path)
+    if errors:
+        return errors
+
+    data = value
+    assert isinstance(data, dict)
+    for field in required_fields:
+        if field not in data:
+            errors.append(f"{path}.{field} is required")
+            continue
+        errors.extend(_expect_non_empty_string(data[field], f"{path}.{field}"))
+    return errors
+
+
+def validate_report(report: object) -> list[str]:
+    errors = _expect_dict(report, "report")
+    if errors:
+        return errors
+
+    data = report
+    assert isinstance(data, dict)
+
+    for key in TOP_LEVEL_KEYS:
+        if key not in data:
+            errors.append(f"report.{key} is required")
+
+    if errors:
+        return errors
+
+    errors.extend(_expect_dict(data["repo_summary"], "report.repo_summary"))
+    errors.extend(_expect_list(data["wishlist"], "report.wishlist"))
+    errors.extend(_expect_list(data["candidate_matrix"], "report.candidate_matrix"))
+    errors.extend(_expect_list(data["selected_primitives"], "report.selected_primitives"))
+    errors.extend(_expect_list(data["gaps"], "report.gaps"))
+    errors.extend(_expect_dict(data["confidence"], "report.confidence"))
+    if errors:
+        return errors
+
+    wishlist = data["wishlist"]
+    candidate_matrix = data["candidate_matrix"]
+    selected_primitives = data["selected_primitives"]
+    gaps = data["gaps"]
+    confidence = data["confidence"]
+
+    assert isinstance(wishlist, list)
+    assert isinstance(candidate_matrix, list)
+    assert isinstance(selected_primitives, list)
+    assert isinstance(gaps, list)
+    assert isinstance(confidence, dict)
+
+    if not wishlist:
+        errors.append("report.wishlist must contain at least one item")
+    if not candidate_matrix:
+        errors.append("report.candidate_matrix must contain at least one row")
+
+    for index, item in enumerate(wishlist):
+        errors.extend(
+            _validate_object(item, f"report.wishlist[{index}]", ("name", "why"))
+        )
+
+    for index, item in enumerate(candidate_matrix):
+        errors.extend(
+            _validate_object(
+                item,
+                f"report.candidate_matrix[{index}]",
+                ("wishlist_item", "status", "rationale"),
+            )
+        )
+        if isinstance(item, dict):
+            if "evidence" not in item:
+                errors.append(f"report.candidate_matrix[{index}].evidence is required")
+            elif not isinstance(item["evidence"], list) or not item["evidence"]:
+                errors.append(
+                    f"report.candidate_matrix[{index}].evidence must be a non-empty array"
+                )
+
+    for index, item in enumerate(selected_primitives):
+        errors.extend(
+            _validate_object(
+                item,
+                f"report.selected_primitives[{index}]",
+                ("name", "kind", "reason"),
+            )
+        )
+
+    for index, item in enumerate(gaps):
+        errors.extend(
+            _validate_object(item, f"report.gaps[{index}]", ("name", "why", "next_action"))
+        )
+
+    for field in ("level", "summary"):
+        if field not in confidence:
+            errors.append(f"report.confidence.{field} is required")
+        else:
+            errors.extend(
+                _expect_non_empty_string(confidence[field], f"report.confidence.{field}")
+            )
+
+    if "open_questions" not in confidence:
+        errors.append("report.confidence.open_questions is required")
+    elif not isinstance(confidence["open_questions"], list):
+        errors.append("report.confidence.open_questions must be an array")
+
+    return errors
+
+
+def _read_json(path: str | None) -> object:
+    if path in (None, "-"):
+        raw = sys.stdin.read()
+    else:
+        raw = Path(path).read_text(encoding="utf-8")
+    return json.loads(raw)
+
+
+def cmd_write(args: argparse.Namespace) -> int:
+    report = _read_json(args.input)
+    errors = validate_report(report)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(output)
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    report = _read_json(args.path)
+    errors = validate_report(report)
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("ok")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate and persist /focus init reports."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    write_parser = subparsers.add_parser("write", help="validate and write a report")
+    write_parser.add_argument(
+        "--input",
+        default="-",
+        help="JSON input path or - for stdin",
+    )
+    write_parser.add_argument(
+        "--output",
+        required=True,
+        help="Path to write the validated init report",
+    )
+    write_parser.set_defaults(func=cmd_write)
+
+    validate_parser = subparsers.add_parser("validate", help="validate an existing report")
+    validate_parser.add_argument("path", help="Path to the init report JSON file")
+    validate_parser.set_defaults(func=cmd_validate)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except json.JSONDecodeError as exc:
+        print(f"invalid JSON: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/focus/scripts/test_init_report.py
+++ b/skills/focus/scripts/test_init_report.py
@@ -95,6 +95,37 @@ class InitReportScriptTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("report.candidate_matrix[0].evidence is required", result.stderr)
 
+    def test_selected_candidate_requires_primitive(self) -> None:
+        broken = valid_report()
+        broken["candidate_matrix"][0].pop("primitive")
+
+        result = self.run_script("write", "--output", "/tmp/ignored.json", input_text=json.dumps(broken))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("report.candidate_matrix[0].primitive is required", result.stderr)
+
+    def test_gap_candidate_can_omit_primitive(self) -> None:
+        report = valid_report()
+        report["candidate_matrix"] = [
+            {
+                "wishlist_item": "repo tuning",
+                "status": "gap",
+                "rationale": "No existing primitive covers this need.",
+                "evidence": ["catalog search returned no strong matches"],
+            }
+        ]
+        report["selected_primitives"] = []
+
+        result = self.run_script("write", "--output", "/tmp/ignored.json", input_text=json.dumps(report))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_repo_summary_requires_documented_fields(self) -> None:
+        broken = valid_report()
+        broken["repo_summary"].pop("signals")
+
+        result = self.run_script("write", "--output", "/tmp/ignored.json", input_text=json.dumps(broken))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("report.repo_summary.signals is required", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/skills/focus/scripts/test_init_report.py
+++ b/skills/focus/scripts/test_init_report.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("init_report.py")
+
+
+def valid_report() -> dict:
+    return {
+        "repo_summary": {
+            "project": "Spellbook",
+            "stack": ["markdown", "python"],
+            "domains": ["agent tooling"],
+            "services": ["GitHub"],
+            "signals": ["README.md", "project.md"],
+        },
+        "wishlist": [
+            {
+                "name": "repo tuning",
+                "why": "Agents need repo-specific context structure.",
+            }
+        ],
+        "candidate_matrix": [
+            {
+                "wishlist_item": "repo tuning",
+                "primitive": "phrazzld/spellbook@codified-context-architecture",
+                "status": "selected",
+                "rationale": "It matches the repo-tuning need directly.",
+                "evidence": ["docs/context/** exists", "project.md references agent workflows"],
+            }
+        ],
+        "selected_primitives": [
+            {
+                "name": "codified-context-architecture",
+                "kind": "skill",
+                "reason": "Best match for repo tuning.",
+            }
+        ],
+        "gaps": [
+            {
+                "name": "selection telemetry",
+                "why": "No durable report existed before this run.",
+                "next_action": "persist init report",
+            }
+        ],
+        "confidence": {
+            "level": "medium",
+            "summary": "Grounded in repo docs and file layout.",
+            "open_questions": [],
+        },
+    }
+
+
+class InitReportScriptTest(unittest.TestCase):
+    def run_script(self, *args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            input=input_text,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_write_and_validate_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / ".spellbook" / "init-report.json"
+            report_json = json.dumps(valid_report())
+
+            write = self.run_script("write", "--output", str(output), input_text=report_json)
+            self.assertEqual(write.returncode, 0, write.stderr)
+            self.assertTrue(output.exists())
+
+            validate = self.run_script("validate", str(output))
+            self.assertEqual(validate.returncode, 0, validate.stderr)
+            self.assertEqual(validate.stdout.strip(), "ok")
+
+    def test_missing_top_level_key_fails(self) -> None:
+        broken = valid_report()
+        broken.pop("gaps")
+
+        result = self.run_script("write", "--output", "/tmp/ignored.json", input_text=json.dumps(broken))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("report.gaps is required", result.stderr)
+
+    def test_candidate_matrix_requires_evidence(self) -> None:
+        broken = valid_report()
+        broken["candidate_matrix"][0].pop("evidence")
+
+        result = self.run_script("write", "--output", "/tmp/ignored.json", input_text=json.dumps(broken))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("report.candidate_matrix[0].evidence is required", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -33,6 +33,22 @@ Take PR `$ARGUMENTS` (or the current branch's PR) through three phases until it 
 - Complexity reduced where possible
 - Docs current
 
+## Executive / Worker Split
+
+Keep the strongest available model on review-heavy executive work:
+- deciding which review comments are valid, in scope, or rejected
+- hindsight architecture review and simplification choices
+- confidence assessment and final merge-readiness judgment
+
+Delegate bounded remediation work to smaller worker subagents:
+- fixing one comment thread or one failing check at a time
+- gathering review evidence, reproducing CI failures, and drafting narrow patches
+- mechanical cleanups, focused test additions, and doc refreshes with clear ownership
+
+If the harness supports model choice, use small worker-class models for these
+bounded tasks and reserve frontier models for review disposition, architecture,
+and final settlement calls.
+
 ## Process
 
 ### Phase 1: Fix — Unblock the PR
@@ -50,6 +66,10 @@ Read `../autopilot/references/pr-fix.md` and follow it completely.
    - **Invalid:** reply with clear reasoning
 5. **Async settlement** — after pushing fixes, wait for reviewer bots to re-run.
    Do not declare success while automation can still add findings.
+
+Dispatch the fixes themselves to smaller worker subagents when the scope is
+clear and bounded. Keep comment disposition, reviewer communication, and the
+final "is this settled?" judgment on the lead model.
 
 **Exit gate:** CI green, no open review threads, no unresolved comments.
 
@@ -72,6 +92,9 @@ Read `../autopilot/references/pr-polish.md` and follow it completely.
 4. **Docs** — update any docs/comments that are stale after the changes.
 5. **Confidence assessment** — how confident are we this won't break anything?
    Treat confidence as an explicit deliverable with evidence.
+
+Use the strongest available model for hindsight review and confidence judgment.
+Use smaller workers for narrow polish follow-through once the direction is clear.
 
 **Exit gate:** Architecture clean, tests solid, docs current, confidence stated.
 

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -23,6 +23,20 @@ Take the current working directory state — however messy — and produce:
 1. A clean branch with semantic conventional commits
 2. A PR that makes the merge case obvious to any reviewer
 
+## Executive / Worker Split
+
+Keep the strongest available model on shipping judgment:
+- commit grouping and semantic boundaries
+- PR title/body narrative, trade-offs, and reviewer guidance
+- final decision that the branch is coherent enough to publish
+
+Delegate bounded support work to smaller worker subagents when useful:
+- inventorying changed files and evidence
+- drafting narrow summaries for one module or one verification lane
+- collecting screenshots, command output, or other reviewer artifacts
+
+Do not delegate the final commit plan or PR story. Workers gather material; the lead packages it.
+
 ## Process
 
 ### 1. Orient

--- a/skills/refine/SKILL.md
+++ b/skills/refine/SKILL.md
@@ -74,6 +74,12 @@ not an archive of every bug, nit, brainstorm, review comment, or screenshot.
 
 **Model diversity for architecture.** Use thinktank + CLI agents for diverse perspectives on design decisions.
 
+**Executive / worker split.** Keep backlog priorities, architectural direction,
+issue acceptance, and final roadmap synthesis on the strongest available model.
+Push bounded gruntwork to smaller worker subagents: repo audits, reference
+searches, issue-body rewrites for one item at a time, dedupe passes, and other
+mechanical backlog cleanup with explicit ownership.
+
 ## Org-Wide Standards
 
 All issues MUST comply with `groom/references/org-standards.md`.
@@ -94,6 +100,10 @@ Run `/groom` in six phases:
      on the current architecture. Each answers: "What's the single biggest
      structural problem? What would you change first?"
 
+   Run tracks A-B with smaller workers when possible. Keep the synthesis of
+   tracks C-D, the architectural recommendation, and the final backlog priority
+   calls on the strongest available model.
+
    For greenfield modules, load `references/toolchain-preferences.md` before
    evaluating technology options. See `references/architecture-fitness.md`.
 
@@ -103,6 +113,9 @@ Run `/groom` in six phases:
 3. **Research** — web, cross-repo, and codebase research, scoped to the direction chosen in 2.5. Use `/research web-search` with Exa for reference architecture discovery.
 4. **Exploration** — pitch options, recommend one, discuss. Lock direction.
 5. **Synthesis** — reduce GitHub backlog to cap (demote to BACKLOG.md, close, merge), then promote from BACKLOG.md or create for missing gaps. Every surviving issue must score >= 70.
+
+During synthesis, workers may draft or lint one issue at a time, but the lead
+model owns final inclusion, ordering, and issue acceptance.
 6. **Artifact** — save a dated grooming plan, update `.groom/BACKLOG.md`, visual summary when useful
 
 Synthesis default:

--- a/skills/shape/SKILL.md
+++ b/skills/shape/SKILL.md
@@ -23,6 +23,20 @@ argument-hint: "[idea|issue] [--spec-only] [--design-only] [--critique persona] 
 | Shape Up methodology | R/S notation, fit checks, spikes, slicing | `references/shaping-methodology.md` |
 | Breadboarding | Affordance mapping, vertical slicing | `references/breadboarding.md` |
 
+## Executive / Worker Split
+
+Keep the strongest available model on shaping decisions:
+- problem framing, option generation, and recommendation
+- spec intent contracts and design tradeoff calls
+- critique synthesis and final scope lock
+
+Delegate bounded research work to smaller worker subagents:
+- codebase mapping and pattern collection
+- targeted prior-art or reference searches
+- draft writeups for one option, one subsystem, or one risk area
+
+Workers can prepare options; the lead chooses the direction and writes the final spec/design.
+
 ## Workflow
 
 ### Phase 1: Understand
@@ -76,6 +90,8 @@ Accept: raw idea (string), issue ID, or observation.
 ### Phase 3: Technical Exploration
 
 1. **Investigate** — Read locked spec, codebase, research patterns.
+   Delegate codebase mapping and reference gathering to smaller workers if the
+   surface area is broad, then synthesize their findings on the lead model.
 
 2. **Explore** — 3-5 technical approaches. For each:
    - Architecture sketch, files to modify/create
@@ -95,6 +111,10 @@ Accept: raw idea (string), issue ID, or observation.
    | `grug` | Too many layers? |
 
 4. **Discuss** — No limit on rounds. Design isn't ready until user says so.
+
+Use the strongest available models for critique, recommendation, and scope-lock
+decisions. Smaller workers can draft comparison tables or subsystem notes, but
+they do not choose the design.
 
 5. **Draft design** — Post on issue:
 


### PR DESCRIPTION
## Reviewer Evidence

Text-only reviewer evidence.

Merge claim: `/focus init` now persists a validated `.spellbook/init-report.json`, and the main orchestrator skills now explicitly keep strategy/review on the strongest model while pushing bounded gruntwork to smaller worker subagents.

Start here:
- `skills/focus/references/init.md`
- `skills/focus/scripts/init_report.py`
- `skills/autopilot/SKILL.md`

## Why This Matters

Spellbook had two related workflow gaps. First, `/focus init` described a good selection process but left no durable, machine-checkable artifact of what it analyzed, why primitives were selected, or which gaps remained. That weakened auditability and made `/focus improve` reconstruct context from prose. Second, the orchestrator skills left model routing implicit, which blurred strong-model executive work and smaller-model execution work.

This PR fixes both. It closes the core contract gap in [#70](https://github.com/phrazzld/spellbook/issues/70) by adding a validated init-report artifact, and it codifies a clearer executive/worker split across the main orchestrator skills so future runs delegate bounded implementation work without giving up high-level judgment.

Closes #70.

## Trade-offs / Risks

This adds more explicit process to several skills, which increases instruction surface area slightly. The trade is worthwhile because these are orchestrator skills where ambiguity costs real execution quality. The main thing reviewers should pressure-test is whether the executive/worker split is scoped tightly enough to help orchestration without forcing it into every skill that never delegates.

## What Changed

The `focus` init flow now has a durable report contract and a stdlib-only validator/writer, so selection rationale survives beyond one run. In parallel, the core orchestrator skills now say plainly that the strongest model keeps prioritization, design choice, review disposition, and final acceptance, while smaller workers handle bounded code reading, implementation slices, test repair, and evidence gathering.

```mermaid
graph TD
    A[Repo analysis] --> B[Wishlist]
    B --> C[Catalog match]
    C --> D[Manifest confirmation]
    D --> E[Selection rationale mostly lives in prose]
```

```mermaid
graph TD
    A[Repo analysis] --> B[Wishlist]
    B --> C[Candidate matrix]
    C --> D[init_report.py write]
    D --> E[.spellbook/init-report.json]
    E --> F[Manifest confirmation]
    E --> G[/focus improve and later tuning reuse the evidence]
```

```mermaid
sequenceDiagram
    participant L as Lead model
    participant W as Worker subagents
    participant R as Review gates
    L->>W: bounded task with owned scope
    W-->>L: code, tests, or evidence
    L->>R: strategy, review, and final judgment
    R-->>L: pass/fail concerns
```

The new shape is better because it separates durable evidence from ephemeral prose and separates executive judgment from cheap parallel execution.

<details>
<summary>Changes</summary>

- `skills/focus/SKILL.md` now makes `.spellbook/init-report.json` a required init artifact.
- `skills/focus/references/init.md` now defines the report schema and the write step.
- `skills/focus/references/improve.md` now consumes the init report as cold memory.
- `skills/focus/scripts/init_report.py` adds a validating writer/validator.
- `skills/focus/scripts/test_init_report.py` adds round-trip and failure-case coverage.
- `docs/context/INDEX.md` and `docs/context/ROUTING.md` now point at the init report as selection history.
- `skills/autopilot/SKILL.md`, `skills/land/SKILL.md`, `skills/pr/SKILL.md`, `skills/shape/SKILL.md`, `skills/refine/SKILL.md`, and `skills/debug/SKILL.md` now codify the executive/worker split.
- `index.yaml` was refreshed by the repo hook after skill edits.

</details>

<details>
<summary>Acceptance Criteria</summary>

From #70:

- [x] Given a repo without `.spellbook.yaml`, when `/focus init` completes, then it writes `.spellbook/init-report.json` before asking for manifest confirmation.
- [x] Given `.spellbook/init-report.json`, when `jq -e '.repo_summary and .wishlist and .candidate_matrix and .selected_primitives and .gaps and .confidence' .spellbook/init-report.json` runs, then it exits `0`.
- [x] Given `.spellbook/init-report.json`, when `jq -e '.candidate_matrix[] | .wishlist_item and .status and .rationale and .evidence' .spellbook/init-report.json` runs, then it exits `0`.
- [x] Given two `/focus init` runs on the same repo, when a human compares the reports, then differences in selected primitives and unresolved gaps are explicit and attributable.
- [x] Given a gap discovered during init, when the report is read by a later grooming or improvement flow, then the gap is recoverable without rereading the full repo analysis from scratch.

The last two are satisfied by the durable schema, preserved rationale/evidence fields, and explicit `focus improve` consumption of the report.

</details>

<details>
<summary>Alternatives Considered</summary>

- Do nothing: rejected because the lack of a durable init artifact was the exact problem in #70, and model routing ambiguity had already caused a calibration failure.
- Document the report shape in prose only: rejected because it would not make the output mechanically checkable.
- Put the executive/worker split only in repo-level instructions: rejected because the failure lived in spellbook orchestrator skills, so the fix belongs in the canonical skills themselves.

</details>

<details>
<summary>Manual QA</summary>

```bash
python3 -m unittest skills/focus/scripts/test_init_report.py
python3 skills/craft-primitive/scripts/validate_skill.py skills/focus
python3 skills/craft-primitive/scripts/validate_skill.py skills/autopilot
python3 skills/craft-primitive/scripts/validate_skill.py skills/land
python3 skills/craft-primitive/scripts/validate_skill.py skills/pr
python3 skills/craft-primitive/scripts/validate_skill.py skills/shape
python3 skills/craft-primitive/scripts/validate_skill.py skills/refine
python3 skills/craft-primitive/scripts/validate_skill.py skills/debug
```

Round-trip proof run:

```bash
python3 skills/focus/scripts/init_report.py write --input /tmp/focus-init-report.json --output /tmp/.spellbook/init-report.json
python3 skills/focus/scripts/init_report.py validate /tmp/.spellbook/init-report.json
jq -e '.repo_summary and .wishlist and .candidate_matrix and .selected_primitives and .gaps and .confidence' /tmp/.spellbook/init-report.json
jq -e '.candidate_matrix[] | .wishlist_item and .status and .rationale and .evidence' /tmp/.spellbook/init-report.json
```

Expected result: unit tests pass, skill validators return `valid: true`, and both `jq` commands exit `0`.

</details>

<details>
<summary>Test Coverage</summary>

- `skills/focus/scripts/test_init_report.py`
  - valid write/validate round trip
  - missing top-level field rejection
  - missing `candidate_matrix[].evidence` rejection

Gaps:
- No higher-level harness test exercises a full `/focus init` run because Spellbook ships the workflow as skill contract + helper script rather than a standalone init executable.

</details>

<details>
<summary>Before / After</summary>

Before: `/focus init` selection rationale lived mostly in prose, and orchestrator skills left model-routing responsibilities implicit.

After: `/focus init` has a durable validated JSON artifact, and the main orchestrator skills explicitly separate executive judgment from worker execution.

</details>

<details>
<summary>Merge Confidence</summary>

Confidence: medium-high.

Strongest evidence:
- targeted unit coverage for the new helper
- successful validator runs across all touched skills
- successful `jq` verification against a generated init report

Remaining uncertainty:
- `pr` and `shape` still carry pre-existing validator warnings about their broader structure/argument surface; this PR does not try to restructure them.
- The orchestrator routing guidance is instruction-level, so its full payoff will show up in later real runs rather than a single mechanical test.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Init workflow now persists a structured selection report (`.spellbook/init-report.json`) before confirmation, capturing analysis, candidate matrix, selected primitives, gaps, and confidence state.
  * Improvement workflow references init reports as baseline context for reusing prior decisions.

* **Documentation**
  * Updated skill workflows with explicit role-separation guidance and model-selection recommendations across autopilot, debug, focus, land, PR, refine, and shape skills.
  * Added routing documentation for init-report-based decision flows.

* **Tests**
  * Added test coverage for init report validation and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->