### PR TITLE
feat(verification): add tailor-verification skill

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-19T18:23:51Z
+# Generated: 2026-03-20T13:50:47Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-19T17:00:14Z
+# Generated: 2026-03-19T17:26:22Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:
@@ -222,6 +222,9 @@ skills:
   - name: sysadmin
     description: "System health diagnostics and maintenance for macOS. Resource usage, disk space, memory pressure, Docker, Homebrew, stuck processes. Quick health checks and safe maintenance actions."
     tags: [actions,checks,diagnostics,disk,docker,health,homebrew,macos,maintenance,memory]
+  - name: tailor-verification
+    description: "Craft repo-specific verification agents and an orchestrator skill from the target repo's actual stack. Discover test runners, auth, routes, page objects, dev server, and browser/MCP tooling, then map "
+    tags: [actual,agents,an,auth,browser,craft,dev,discover,map,mcp]
   - name: ui-skills
     description: "Opinionated constraints for building better interfaces with agents."
     tags: [agents,better,building,constraints,interfaces,opinionated]

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-19T17:26:22Z
+# Generated: 2026-03-19T18:23:51Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -159,7 +159,7 @@ The point is single ownership and meaningful progress. One issue should map to o
    - Delete compatibility scaffolding in greenfield/pre-user paths unless a real contract requires it
 8. **Visual QA** — If diff touches frontend files (`app/`, `components/`, `*.css`), run `/visual-qa --fix`. Fix P0/P1 before proceeding.
 9. **Agentic QA** — If diff touches prompts, model routing, tool schemas, or agent instructions, run `/llm-infrastructure` and inspect trace/eval coverage before shipping.
-10. **Triad Review** — Mandatory review gate before PR. Spawn three agents in parallel:
+10. **Triad Review** — Mandatory review gate before PR. Prefer three agents in parallel:
 
     | Agent | Focus | Kill signal |
     |-------|-------|-------------|
@@ -173,6 +173,11 @@ The point is single ownership and meaningful progress. One issue should map to o
     - **Ship / Don't Ship** verdict
     - Top 3 concerns (if any), each with file:line and specific fix
     - One sentence: what's the single best thing about this code?
+
+    If the harness requires explicit user approval before subagent delegation,
+    ask once for approval or run the same Ousterhout, Carmack, and Grug review
+    lanes yourself sequentially. Do not skip the triad because parallel
+    delegation is unavailable.
 
     **Gate**: All three must say "Ship" to proceed. Fix concerns and re-run
     until consensus. If they disagree, the concern raised by the dissenter
@@ -308,7 +313,8 @@ If the user's own dev server was already running (no `$DEV_PID`), leave it alone
 ## Triad Review Details
 
 The triad (Ousterhout + Carmack + Grug) replaces ad-hoc simplification
-reviews. They run in parallel, each reading the same diff independently.
+reviews. They run in parallel when the harness permits delegation; otherwise
+run the same reviewers yourself sequentially against the same diff.
 
 **Why these three:**
 - **Ousterhout** catches structural rot — shallow modules, information leakage,
@@ -331,6 +337,12 @@ Spawn three Agent calls in parallel, each with:
   Top 3 concerns (file:line + specific fix).
   One sentence: best thing about this code."
 ```
+
+**No-delegation fallback:**
+- Ask once for delegation approval if the harness gates subagent spawning.
+- If approval is unavailable, run the Ousterhout, Carmack, and Grug prompts
+  yourself, one after another.
+- Keep the same reviewer-wins gate: any single "Don't Ship" blocks progress.
 
 ## Stopping Conditions
 

--- a/skills/autopilot/references/pr-fix-reviewer-prompts.md
+++ b/skills/autopilot/references/pr-fix-reviewer-prompts.md
@@ -1,6 +1,8 @@
 # Reviewer Prompt Templates
 
 Templates for each reviewer in the /review-branch system.
+Use them with subagents when available, or as sequential self-review lanes
+when the harness blocks delegation.
 
 ## Persona Prompts
 

--- a/skills/tailor-verification/SKILL.md
+++ b/skills/tailor-verification/SKILL.md
@@ -17,6 +17,19 @@ argument-hint: "[init|add|audit] [flow]"
 Discover how a repo can be verified, then codify that knowledge into
 project-local verification primitives instead of rediscovering it every run.
 
+## Composition
+
+This skill orchestrates; it does not reimplement adjacent primitives.
+
+| Dependency | Used For |
+|------------|----------|
+| `/research` | Phase 1 research on stack docs, auth patterns, and known verification gotchas |
+| `/craft-primitive` | Phase 4 creation of project-local flow agents and the `verify-app` router |
+| Browser tooling (`agent-browser`, `browser-use`, repo-native E2E) | Validating that crafted browser-based flows can actually run |
+
+Do not duplicate `/research` retrieval logic or `/craft-primitive` packaging
+logic. Compose with them directly.
+
 ## Outputs
 
 - One verification agent per flow, usually `verify-<flow>.md`

--- a/skills/tailor-verification/SKILL.md
+++ b/skills/tailor-verification/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: tailor-verification
+description: |
+  Craft repo-specific verification agents and an orchestrator skill from the
+  target repo's actual stack. Discover test runners, auth, routes, page
+  objects, dev server, and browser/MCP tooling, then map them into
+  project-local verification primitives. Use when bootstrapping product
+  verification for a repo, calibrating a new codebase, adding one high-value
+  flow, or auditing verification gaps. Keywords: product verification,
+  verify-app, verification agents, Playwright, Clerk, Remix, E2E, page
+  objects, flow audit.
+argument-hint: "[init|add|audit] [flow]"
+---
+
+# /tailor-verification
+
+Discover how a repo can be verified, then codify that knowledge into
+project-local verification primitives instead of rediscovering it every run.
+
+## Outputs
+
+- One verification agent per flow, usually `verify-<flow>.md`
+- One orchestrator skill, usually `verify-app/`
+- Evidence expectations for each flow so future runs produce proof, not prose
+
+## Routing
+
+| Intent | Load |
+|--------|------|
+| `/tailor-verification` | `references/calibration.md` |
+| `/tailor-verification init` | `references/calibration.md` |
+| `/tailor-verification add <flow>` | `references/agent-templates.md` and `references/skill-templates.md` |
+| `/tailor-verification audit` | `references/calibration.md` and `references/evidence-patterns.md` |
+| Need output templates | `references/agent-templates.md`, `references/skill-templates.md` |
+| Need evidence contract | `references/evidence-patterns.md` |
+| Remix + Playwright + Clerk repo | `references/stack-adapters/remix-playwright.md` |
+| Unknown stack or weak signals | `references/stack-adapters/generic.md` |
+
+## Core Flow
+
+1. Research the detected stack and verification patterns. Compose with `/research`.
+2. Discover the repo's real verification infrastructure: runner, auth, routes,
+   fixtures, page objects, dev command, and browser tooling.
+3. Identify the highest-value flows and rank them `P0` to `P3`.
+4. Craft project-local verification agents and one orchestrator skill with
+   `/craft-primitive`. Do not ship the generated outputs back into spellbook.
+
+## Detection Order
+
+1. Existing E2E harness: Playwright, Cypress, or repo-local browser tooling
+2. Auth shape: Clerk, Auth0, NextAuth, custom sessions, test users
+3. Route and page structure: app routes, page objects, wizard steps, dashboards
+4. Evidence surface: screenshots, traces, command logs, persisted artifacts
+
+## Output Rules
+
+- Default to project-local harness directories, not spellbook-managed paths.
+- Mirror the repo's active harness. If it supports multiple harnesses, keep the
+  verification contract aligned across them.
+- Reuse existing helpers and fixtures before inventing new abstractions.
+- Keep agents deeply specific to one flow. The orchestrator routes; it does not
+  absorb all flow knowledge itself.
+
+## Anti-Patterns
+
+- Writing a generic `verify-app` skill with no repo discovery
+- Emitting spellbook-managed `.spellbook` markers for repo-local outputs
+- Treating "there is a Playwright config" as enough to skip route/auth discovery
+- Capturing screenshots without recording the behavior they prove
+- Stuffing all flows into one giant agent instead of one agent per flow

--- a/skills/tailor-verification/references/agent-templates.md
+++ b/skills/tailor-verification/references/agent-templates.md
@@ -50,7 +50,7 @@ Prove that <flow name> works in the local repo and collect durable evidence.
 Replace every placeholder with repo facts:
 
 - real routes
-- actual fixture/user names
+- actual fixture usernames
 - exact evidence paths
 - repo-local commands
 - known failure modes for the flow

--- a/skills/tailor-verification/references/agent-templates.md
+++ b/skills/tailor-verification/references/agent-templates.md
@@ -1,0 +1,66 @@
+# Agent Templates
+
+Each crafted verification agent should own one flow and produce evidence that
+the flow worked. Keep the agent narrow and concrete.
+
+## Claude/Codex Flow Agent Template
+
+```md
+---
+name: verify-<flow-slug>
+description: Verify the <flow name> flow in this repo using its real routes,
+  auth helpers, and test tooling. Use when checking <flow name>, reproducing
+  regressions in this path, or gathering proof for changes that affect it.
+tools: Read, Grep, Glob, Bash
+---
+
+# Verify <Flow Name>
+
+You own one verification lane: <flow name>.
+
+## Goal
+
+Prove that <flow name> works in the local repo and collect durable evidence.
+
+## Inputs
+
+- Route(s): <entry routes>
+- Preconditions: <user state, fixtures, env>
+- Reused helpers: <page objects, fixtures, scripts>
+- Evidence contract: <screenshots, trace, command log, output file>
+
+## Procedure
+
+1. Boot or reuse the local app using the repo's standard dev command.
+2. Reuse existing auth/session helpers before inventing new login steps.
+3. Execute the flow from the real entry route.
+4. Record the expected state transitions and assertions.
+5. Save evidence in the agreed artifact location.
+6. Report `PASS`, `FAIL`, or `BLOCKED` with file-backed evidence.
+
+## Failure Discipline
+
+- Stop on auth or fixture drift and report the exact missing dependency.
+- Do not silently rewrite selectors if the repo already has page objects.
+- If the route moved, identify the new route and update the orchestrator.
+```
+
+## Required Customization
+
+Replace every placeholder with repo facts:
+
+- real routes
+- actual fixture/user names
+- exact evidence paths
+- repo-local commands
+- known failure modes for the flow
+
+## Good Flow Boundaries
+
+Use one agent when the journey has one clear success state:
+
+- `verify-login`
+- `verify-booking-checkout`
+- `verify-team-invite`
+
+Split flows when they have different fixtures, owners, or evidence contracts.

--- a/skills/tailor-verification/references/calibration.md
+++ b/skills/tailor-verification/references/calibration.md
@@ -1,0 +1,99 @@
+# Calibration
+
+`tailor-verification` is a four-phase runtime protocol. The skill does not
+perform verification directly. It discovers how verification should work in the
+current repo, then codifies that into project-local primitives.
+
+## Phase 1: Research
+
+Compose with `/research` before locking the output shape.
+
+- Read the repo's `AGENTS.md`, `README`, `project.md`, and verification docs
+- Research stack-specific verification practice when the stack is not obvious
+- Prefer concrete repo patterns over generic testing advice
+
+Questions to answer:
+- Which user flows actually matter to this product?
+- What makes verification in this stack flaky or expensive?
+- What evidence would convince a maintainer that a flow really works?
+
+## Phase 2: Discover
+
+Scan the repo for the verification surface area.
+
+| Signal | Look for | Why it matters |
+|--------|----------|----------------|
+| Test runner | `playwright.config.*`, `cypress.config.*`, `vitest.config.*` | Tells you how live verification can execute |
+| Auth | `@clerk/`, `auth0`, `next-auth`, session helpers, test users | Determines login/setup strategy |
+| Routes | `app/routes`, `src/app`, router config, page modules | Maps features to candidate flows |
+| Page objects | `*.page.ts`, `pages/`, helpers under `e2e/` | Reuse existing abstractions |
+| Specs | `*.spec.*`, `*.test.*`, `e2e/` | Shows current coverage and gaps |
+| Dev server | `package.json` scripts, port config, env docs | Tells agents how to boot the app |
+| Browser tools | MCP/browser tools, local screenshots, traces | Sets the evidence contract |
+
+Capture concrete findings, not guesses:
+
+```md
+Runner: Playwright (`playwright.config.ts`, projects: chromium, setup)
+Auth: Clerk (`@clerk/remix`, test session helper in `tests/config/users.ts`)
+Routes: Remix nested routes under `app/routes/_app.*`
+Gap: no durable verification agent for booking checkout
+```
+
+## Phase 3: Identify
+
+Map discovered infrastructure to flows and rank them.
+
+Use this rubric:
+
+- `P0`: revenue, auth, checkout, data-loss, core dashboard entry
+- `P1`: major user workflows with multiple steps or risky state transitions
+- `P2`: secondary flows that still touch real integrations
+- `P3`: low-risk polish or read-only views
+
+For each candidate flow, record:
+
+- Flow name and slug
+- Why it matters
+- Entry point(s)
+- Preconditions / fixtures
+- Existing helpers to reuse
+- Evidence required to call it verified
+
+## Phase 4: Craft
+
+Compose with `/craft-primitive`.
+
+Create:
+
+- `verify-<flow>.md` for each approved flow
+- `verify-app/` orchestrator skill that routes to those agents
+
+Crafting rules:
+
+- One flow agent per user journey
+- One orchestrator for routing and shared guardrails
+- Output lives in project-local harness directories
+- Do not add `.spellbook` markers to generated outputs
+
+## Recommended Session Output
+
+At the end of `init`, report:
+
+1. Detected stack and verification surface
+2. Ranked flow candidates
+3. Flows chosen for first pass
+4. Files/paths where the generated primitives were written
+5. Evidence expectations for each crafted flow
+
+## Audit Mode
+
+`/tailor-verification audit` compares existing verification primitives against
+the current repo shape.
+
+Flag:
+
+- flows with no agent
+- agents with stale routes/selectors
+- evidence contracts that no longer match the tooling
+- duplicated logic that belongs in shared fixtures instead

--- a/skills/tailor-verification/references/evidence-patterns.md
+++ b/skills/tailor-verification/references/evidence-patterns.md
@@ -29,6 +29,32 @@ Artifacts: /tmp/verify-booking/<timestamp>/confirmation.png
 Negative signal: redirect back to login or empty confirmation state
 ```
 
+## Result Schema
+
+When a repo-local orchestrator, CI check, or follow-on agent needs structured
+aggregation, each flow agent should emit a minimal `result.json`.
+
+```json
+{
+  "flow": "auth-login",
+  "status": "pass",
+  "timestamp": "2026-03-20T10:30:00Z",
+  "assertions": [
+    {
+      "name": "login redirect",
+      "status": "pass",
+      "evidence": "/tmp/verify-login/2026-03-20T10-30-00Z/success.png"
+    }
+  ]
+}
+```
+
+Keep it small:
+
+- `flow` matches the agent slug
+- `status` is one of `pass`, `fail`, `error`, or `skip`
+- `assertions` point to the artifact that proves each claim
+
 ## Good Practices
 
 - Name artifacts after the flow and state they prove

--- a/skills/tailor-verification/references/evidence-patterns.md
+++ b/skills/tailor-verification/references/evidence-patterns.md
@@ -1,0 +1,53 @@
+# Evidence Patterns
+
+Verification primitives are only useful if they produce artifacts a maintainer
+can inspect after the run. "It worked for me" is not evidence.
+
+## Evidence Ladder
+
+Prefer the lightest artifact that still proves the claim:
+
+1. Command output with the assertion visible
+2. Screenshot tied to a named success state
+3. Browser trace or video for multi-step flows
+4. Saved fixture or API response when backend state matters
+
+## Minimum Evidence Contract Per Flow
+
+Every flow should define:
+
+- success state being proven
+- artifact path or output location
+- timestamp or run identifier
+- one negative signal that would fail the flow
+
+Example:
+
+```md
+Success state: booking confirmed with visible confirmation ID
+Artifacts: /tmp/verify-booking/<timestamp>/confirmation.png
+Negative signal: redirect back to login or empty confirmation state
+```
+
+## Good Practices
+
+- Name artifacts after the flow and state they prove
+- Keep scratch artifacts in `/tmp` unless the repo explicitly versions them
+- Capture one artifact per key transition, not every click
+- Tie screenshots to an assertion in the report
+- Record which fixture or test user produced the evidence
+
+## Common Failure Modes
+
+- Screenshots with no explanation of what success looks like
+- Evidence written into the repo without an explicit reason
+- Passing runs that never exercised auth or seeded data
+- Browser traces saved without noting which step failed
+
+## Audit Questions
+
+When reviewing an existing verification agent, ask:
+
+- Can another engineer inspect the artifacts and agree the flow passed?
+- Does the evidence reflect the current routes and UI?
+- Is the artifact location stable enough to find but disposable enough to avoid repo churn?

--- a/skills/tailor-verification/references/skill-templates.md
+++ b/skills/tailor-verification/references/skill-templates.md
@@ -25,7 +25,7 @@ Route verification work to the correct repo-local flow agent.
 |--------|-------|
 | `/verify-app` | Highest-priority default flow |
 | `/verify-app audit` | Audit verification coverage gaps |
-| `/verify-app <flow>` | Matching `verify-<flow>` agent |
+| `/verify-app <flow>` | Matching `verify-<flow>` agent. Flow keys must be lowercase hyphenated slugs. |
 
 ## Default Flow
 
@@ -40,6 +40,7 @@ If no flow is named, run the highest-priority `P0` flow that exists locally.
 
 ## Known Flows
 
+- Flow keys must stay lowercase hyphenated slugs and match the suffix in `verify-<flow>`.
 - `login` -> `verify-login`
 - `checkout` -> `verify-checkout`
 - `team-invite` -> `verify-team-invite`

--- a/skills/tailor-verification/references/skill-templates.md
+++ b/skills/tailor-verification/references/skill-templates.md
@@ -1,0 +1,59 @@
+# Skill Templates
+
+The generated orchestrator should stay small. It routes to flow agents and
+shared rules; it does not restate every selector or step.
+
+## `verify-app` Skill Template
+
+```md
+---
+name: verify-app
+description: |
+  Route product verification work in this repo to the right flow-specific
+  verification agent. Use when verifying the app after changes, checking a
+  named flow, or auditing which critical paths still lack coverage.
+argument-hint: "[flow-name|audit]"
+---
+
+# /verify-app
+
+Route verification work to the correct repo-local flow agent.
+
+## Routing
+
+| Intent | Route |
+|--------|-------|
+| `/verify-app` | Highest-priority default flow |
+| `/verify-app audit` | Audit verification coverage gaps |
+| `/verify-app <flow>` | Matching `verify-<flow>` agent |
+
+## Default Flow
+
+If no flow is named, run the highest-priority `P0` flow that exists locally.
+
+## Shared Rules
+
+- Reuse repo-local fixtures and auth helpers
+- Produce evidence, not just a narrative
+- Fail loudly on environment drift
+- Update this router when flows are added, renamed, or removed
+
+## Known Flows
+
+- `login` -> `verify-login`
+- `checkout` -> `verify-checkout`
+- `team-invite` -> `verify-team-invite`
+```
+
+## Orchestrator Responsibilities
+
+- route to the correct flow agent
+- document the default flow
+- state shared evidence and environment rules
+- make gaps visible in `audit`
+
+## Orchestrator Non-Goals
+
+- encoding full step-by-step flow logic
+- duplicating selectors from flow agents
+- hiding missing verification coverage

--- a/skills/tailor-verification/references/stack-adapters/generic.md
+++ b/skills/tailor-verification/references/stack-adapters/generic.md
@@ -1,0 +1,47 @@
+# Generic Adapter
+
+Use this when the repo does not strongly match a known stack adapter yet.
+The goal is not perfect coverage. The goal is to discover enough structure to
+craft the first credible verification primitives without hallucinating details.
+
+## Discovery Pass
+
+1. Find the app entry points and dev command
+2. Identify any automated test or browser tooling
+3. Detect auth/session requirements
+4. List the highest-risk user flows from routes, docs, and existing tests
+5. Define the smallest evidence contract that proves each chosen flow
+
+## Safe Defaults
+
+- Prefer existing repo scripts over ad hoc shell commands
+- Prefer read-only or low-risk flows first if auth/setup is unclear
+- Keep output project-local and easy to delete
+- Escalate uncertainty instead of faking stack-specific steps
+
+## Candidate Signals
+
+| Signal | Examples |
+|--------|----------|
+| Browser automation | Playwright, Cypress, Selenium, Puppeteer |
+| Route structure | Next.js app router, Remix routes, Rails routes, Phoenix LiveView, custom SPA routers |
+| Auth | Clerk, Auth0, NextAuth, Supabase Auth, custom sessions |
+| Fixtures | seed scripts, factory helpers, demo accounts, snapshot data |
+| Evidence | screenshots, trace zips, logs, API snapshots |
+
+## First Crafted Outputs
+
+If discovery is weak, still produce:
+
+- one `P0` flow agent with the clearest route and success state
+- one `verify-app` router with an explicit `audit` mode
+- a gap list documenting what still needs repo-specific calibration
+
+## When To Stop And Escalate
+
+Stop instead of guessing when:
+
+- the app cannot be booted from documented repo commands
+- auth depends on missing secrets or undocumented external services
+- multiple competing test harnesses exist and you cannot tell which is canonical
+- no credible success signal can be defined for the chosen flow

--- a/skills/tailor-verification/references/stack-adapters/remix-playwright.md
+++ b/skills/tailor-verification/references/stack-adapters/remix-playwright.md
@@ -1,0 +1,67 @@
+# Remix + Playwright Adapter
+
+Use this adapter when the repo shows a Remix app plus Playwright and Clerk-like
+auth signals. This is the concrete starting point for full-stack web products
+with server loaders, nested routes, and browser-driven verification.
+
+## Detection Signals
+
+- `playwright.config.*` exists
+- `@playwright/test` is in dependencies
+- Remix route files under `app/routes/`
+- Clerk packages such as `@clerk/remix`, `@clerk/clerk-react`, or auth wrappers
+- optional page objects under `e2e/`, `tests/e2e/`, or `pages/`
+
+## What To Discover
+
+| Area | Questions |
+|------|-----------|
+| Dev server | What command boots the app? Which port do Playwright tests expect? |
+| Auth | Is there a seeded user, storage state file, test token helper, or Clerk bypass? |
+| Routing | Which nested routes map to login, dashboard, and the highest-risk flows? |
+| Fixtures | Are there seeded orgs, demo accounts, or db reset helpers? |
+| Evidence | Does the repo already save traces, screenshots, or videos? |
+
+## High-Value Flow Candidates
+
+Start with flows that commonly fail in this stack:
+
+- login -> redirect -> protected route render
+- onboarding or wizard flows spanning multiple Remix routes
+- CRUD flows that depend on loader/action round-trips
+- invite/accept flows with auth state transitions
+- checkout/booking flows that depend on server mutations and confirmation screens
+
+## Remix-Specific Gotchas
+
+- Loader redirects can mask auth failures; verify the final route, not just page load
+- Nested route layouts can make a screenshot look correct while the child route failed
+- Actions may succeed server-side while stale client UI hides the result; verify post-action state
+- Route file names often encode flow boundaries better than nav labels do
+
+## Playwright-Specific Gotchas
+
+- Reuse existing storage state and fixtures before adding new login choreography
+- Honor the repo's trace and screenshot config instead of inventing new output paths
+- Prefer page objects when they exist; selector drift is a maintenance trap
+- If the repo splits projects by browser or auth state, target the existing project first
+
+## Clerk-Specific Gotchas
+
+- Clerk boot can race page assertions; wait for the authenticated shell, not arbitrary timeouts
+- Local dev may require seeded publishable keys or test env vars before auth works
+- Protected routes can redirect through middleware and still end on a rendered page; confirm user identity in the UI
+
+## Recommended First Pass Outputs
+
+- `verify-login`
+- `verify-primary-dashboard`
+- one domain-critical multi-step flow such as checkout, booking, or invite acceptance
+
+Each should define:
+
+- route entry point
+- auth strategy
+- fixture strategy
+- success state
+- artifact contract


### PR DESCRIPTION
## Reviewer Evidence
- Start here: `skills/tailor-verification/SKILL.md`, then `skills/autopilot/SKILL.md` triad review fallback.
- Walkthrough notes: internal skill and process change; no UI artifact is needed.
- Fast claim: this branch adds a new meta-skill for crafting repo-specific verification primitives, tightens its routing/output contracts from review feedback, and fixes autopilot so triad review degrades to a sequential self-review when delegation is gated.
- Durable evidence:
  - `python3 skills/craft-primitive/scripts/validate_skill.py skills/tailor-verification`
  - `python3 skills/craft-primitive/scripts/validate_skill.py skills/autopilot`

## Why This Matters
- Problem: Spellbook had no reusable way to turn a target repo's actual verification stack into project-local verification agents, so verification remained generic and repeatedly rediscovered.
- Value: `tailor-verification` gives Spellbook a concrete meta-skill for research -> discovery -> prioritization -> craft, with templates, routing contracts, machine-readable evidence guidance, and stack adapters that produce durable verification primitives instead of one-off QA prose.
- Why now: issue #87 scoped the core gap, and review/polish work surfaced a second harness gap where autopilot's triad review assumed subagent delegation was always available.
- Issue: Closes #87

## Trade-offs / Risks
- Value gained: a new distributable skill for repo-specific verification setup, plus a clearer autopilot review contract under delegation-limited harnesses.
- Cost / risk incurred: Spellbook now carries another meta-skill and more verification doctrine to maintain.
- Why this is still the right trade: the new skill keeps the top-level router small and pushes detail into references, so the added scope is focused rather than monolithic.
- Reviewer watch-outs: calibration persistence is intentionally deferred to follow-up issue #98 because it changes storage policy, not just reference prose.

## What Changed
This PR adds `tailor-verification` as a new spellbook skill with calibration, composition rules, templates, evidence guidance, a minimal result schema, and stack adapters, then tightens `autopilot` so triad review explicitly falls back to sequential self-review when subagent delegation is unavailable.

### Base Branch
```mermaid
graph TD
  A[Repo wants repo-specific verification] --> B[Agents rediscover stack details ad hoc]
  B --> C[No reusable verification primitives]
  D[Autopilot triad review] --> E[Assumes parallel subagent delegation]
  E --> F[Delegation-limited harnesses become ambiguous]
```

### This PR
```mermaid
graph TD
  A[Repo wants repo-specific verification] --> B[Run tailor-verification]
  B --> C[Research]
  C --> D[Discover stack signals]
  D --> E[Identify high-value flows]
  E --> F[Craft project-local verification agents and verify-app router]
  F --> G[Emit evidence plus result schema]
  H[Autopilot triad review] --> I[Use subagents when allowed]
  H --> J[Otherwise run sequential self-review lanes]
```

### Architecture / State Change
```mermaid
graph TD
  TV[tailor-verification] --> COMP[composition contract]
  TV --> CAL[calibration protocol]
  TV --> TMP[agent and skill templates]
  TV --> EVD[evidence patterns and result schema]
  TV --> ADP[stack adapters]
  ADP --> RP[Remix + Playwright]
  ADP --> GEN[generic fallback]
```

Why this is better:
- verification knowledge is now codified as reusable spellbook structure instead of ad hoc session work.
- crafted flow routers now document slug-normalized flow keys and structured evidence output.
- autopilot's review gate now survives environments where delegation needs explicit approval.

<details>
<summary>Intent Reference</summary>

## Intent Reference
The issue intent was to create a meta-skill that discovers repo-specific verification infrastructure and crafts project-local verification agents plus an orchestrator skill. This branch implements that shape directly and keeps the outputs project-local instead of spellbook-managed.

Source: #87

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `skills/tailor-verification/SKILL.md` as the routing entry point.
- Added an explicit composition contract so the skill composes with `/research` and `/craft-primitive` instead of reimplementing them.
- Added calibration, agent-template, skill-template, evidence-pattern, and stack-adapter references under `skills/tailor-verification/references/`.
- Added a minimal `result.json` schema for structured verification aggregation.
- Added slug-normalization guidance for `verify-app` flow routing and cleaned up template wording.
- Added a concrete Remix + Playwright adapter and a generic fallback adapter.
- Regenerated `index.yaml` so the new skill is discoverable.
- Updated `skills/autopilot/SKILL.md` to define the no-delegation triad fallback.
- Updated `skills/autopilot/references/pr-fix-reviewer-prompts.md` so the reviewer prompts are explicitly reusable for sequential self-review lanes.
- Filed follow-up issue #98 for persistent calibration records.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given a repo with recognizable verification infrastructure, when an agent reads `skills/tailor-verification/SKILL.md`, then it is routed to the correct sub-flow for full setup, initialization, adding a flow, or auditing gaps.
- [x] Given a user who wants first-time repo calibration, when the agent follows the `init` guidance, then it executes the four phases research -> discover -> identify -> craft and understands which existing spellbook skills to compose with.
- [x] Given a repo with a known stack such as Remix + Playwright + Clerk, when the agent opens the stack adapter references, then it finds concrete discovery signals, flow candidates, and evidence expectations instead of generic testing advice.
- [x] Given the new skill directory, when `python3 skills/craft-primitive/scripts/validate_skill.py skills/tailor-verification` runs, then the skill structure and frontmatter validate successfully.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: no new maintenance surface.
- Downside: repo-specific verification knowledge stays implicit and gets rediscovered every run.
- Why rejected: this was the exact gap issue #87 was opened to close.

### Option B — Fold everything into an existing verification or autopilot skill
- Upside: fewer top-level skills.
- Downside: it would mix repo-calibration, template generation, and runtime verification into a shallower umbrella.
- Why rejected: `tailor-verification` is a distinct meta-skill with different outputs and a clear project-local boundary.

### Option C — Current approach
- Upside: small router, focused references, reusable templates, explicit project-local output contract.
- Downside: one more skill to maintain, with calibration persistence still deferred.
- Why chosen: it matches spellbook's progressive-disclosure architecture and keeps the verification-calibration concern isolated.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
```bash
python3 skills/craft-primitive/scripts/validate_skill.py skills/tailor-verification
python3 skills/craft-primitive/scripts/validate_skill.py skills/autopilot
./scripts/generate-index.sh
```
Expected results:
- both validators return `"valid": true`
- index generation completes without errors

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- Structural validation via `skills/craft-primitive/scripts/validate_skill.py` for `skills/tailor-verification`.
- Structural validation via `skills/craft-primitive/scripts/validate_skill.py` for `skills/autopilot` after the calibration fix.
- Catalog regeneration via `./scripts/generate-index.sh`.

Gap:
- no broader repo-level lint/typecheck/test harness exists at the repo root, so validation is limited to the skill validator and generated index path.

</details>

<details>
<summary>Before / After</summary>

## Before / After
Before: Spellbook had no dedicated skill for discovering a repo's verification infrastructure and crafting repo-local verification primitives, and autopilot's triad review text implied delegation-only execution.

After: Spellbook has a dedicated `tailor-verification` skill with composition rules, templates, adapters, and a minimal structured evidence schema, and autopilot now documents a no-delegation fallback that preserves the same review standard.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence: medium-high
- Strongest evidence: both touched skills validate cleanly, the new skill is indexed, and review feedback tightened the routing/evidence contract without expanding runtime scope.
- Remaining uncertainty: the new skill's real value depends on running it in consumer repos with diverse verification stacks.
- What could still go wrong: the first generated repo-local verification agents may expose stack-specific gaps that need another adapter or the deferred calibration-state follow-up in #98.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "tailor-verification" skill to discover repo-specific verification surfaces and generate project-local verification agents and an orchestrator.
  * Autopilot review flow now supports conditional parallel or sequential triad review depending on harness capabilities.

* **Documentation**
  * Added comprehensive guides covering skill usage, agent templates, calibration/workflow, evidence patterns, orchestrator templates, and stack adapter guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->