### PR TITLE
fix(skills): codify pr artifact hygiene

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-20T14:38:06Z
+# Generated: 2026-03-20T15:00:06Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/skills/land/SKILL.md
+++ b/skills/land/SKILL.md
@@ -130,6 +130,18 @@ Phase 1 (fix) → Phase 2 (polish) → Phase 3 (simplify)
 Each phase that generates commits sends you back to Phase 1 to re-verify
 CI and reviews. The loop terminates when a full pass produces no changes.
 
+## Reviewer Artifact Policy
+
+When settlement needs screenshots, videos, logs, or walkthrough proof:
+
+- Prefer GitHub-uploaded attachments for screenshots and videos referenced by
+  reviewers.
+- Prefer CI artifacts or step summaries for generated verification output.
+- Do not commit PR-only review evidence unless the repo explicitly versions
+  those artifacts or the harness cannot publish them another way.
+- If a checked-in fallback is unavoidable, keep it branch-scoped and document
+  the reason in the PR.
+
 ## Flags
 
 - `$ARGUMENTS` as PR number — target specific PR

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -124,7 +124,8 @@ not a changelog. Lead with significance, not mechanics.
 #### Visible on first load:
 
 **Reviewer Evidence** — If the PR has user-visible changes, put proof first:
-- Screenshot or video link (prefer GitHub-uploaded attachments)
+- Screenshot, video, or artifact link. Prefer GitHub-uploaded attachments for
+  screenshots/videos and CI artifacts or step summaries for generated proof.
 - One-sentence merge claim
 - "Start here" pointer for reviewers
 
@@ -180,7 +181,8 @@ If `--draft` flag, add `--draft` to create.
 ### 8. Post-Open
 
 - Add a context comment if notable design decisions were made
-- If the PR touches frontend, attach screenshots or demo video
+- If the PR touches frontend, attach screenshots or demo video to the PR via
+  GitHub attachments rather than checking review media into the repo
 - Report the PR URL
 
 Do NOT claim the PR is "ready to merge" or "review-clean". Opening a PR
@@ -192,6 +194,19 @@ If the change is user-visible:
 - **Motion/interaction/state change** → video (screencast or terminal recording)
 - **Static visual change** → screenshots (before/after)
 - **Internal/API change** → text before/after is sufficient
+
+## Artifact Hygiene
+
+PR evidence is review support, not product content.
+
+- Prefer GitHub-uploaded attachments for screenshots and videos shown in the PR
+  body or comments.
+- Prefer CI artifacts or step summaries for generated logs, walkthrough
+  bundles, coverage proof, and other machine-produced verification output.
+- Do not commit PR-only evidence into the repo unless the repo explicitly wants
+  versioned artifacts or the harness cannot publish attachments/artifacts.
+- If a checked-in fallback is unavoidable, keep it branch-scoped, explain why
+  in the PR, and do not normalize it as the default workflow.
 
 For private repos, use GitHub-uploaded attachments, not raw URLs.
 


### PR DESCRIPTION
**Reviewer Evidence**
- Text-only policy change; start with the new `Artifact Hygiene` section in `skills/pr/SKILL.md`
- Merge claim: this makes Spellbook's reusable PR workflows default to PR attachments and CI artifacts instead of checked-in reviewer media
- Start here: `skills/pr/SKILL.md` `Artifact Hygiene`, then `skills/land/SKILL.md` `Reviewer Artifact Policy`

**Why This Matters**
Spellbook already had one-off guidance against committing scratch QA artifacts, but the canonical shipping skills still left too much room for agents to treat repo-committed PR evidence as normal. That makes history noisy, grows repos with binaries, and encourages the wrong steady-state review workflow. This patch turns the preference into an explicit rule in the skills agents actually use when opening and settling PRs.

Issue link: N/A — calibration-driven follow-up from a real PR evidence workflow miss.

**Trade-offs / Risks**
This adds a little more prescription to the PR skills. That is intentional: artifact storage is one of the places where a vague preference quickly becomes repo churn. The remaining risk is that some repos genuinely need versioned evidence; the skill keeps that as a documented fallback instead of forbidding it outright.

**What Changed**
`skills/pr` now distinguishes human-facing review media from generated verification output and tells agents where each belongs: GitHub attachments for screenshots/videos, CI artifacts or step summaries for generated proof. It also adds an explicit `Artifact Hygiene` section making checked-in PR evidence fallback-only and requiring justification if used. `skills/land` now carries the same rule during PR settlement so the policy survives follow-up fixes and polish.

```mermaid
graph TD
    A["User-visible PR change"] --> B["Collect evidence"]
    B --> C["Agent chooses any convenient storage"]
    C --> D["Repo-committed media can become the default"]
```

```mermaid
graph TD
    A["User-visible PR change"] --> B["Collect evidence"]
    B --> C["Screenshots or video?"]
    C -->|"Yes"| D["GitHub PR attachment"]
    C -->|"Generated proof"| E["CI artifact or step summary"]
    D --> F["Checked-in fallback only if justified"]
    E --> F
```

```mermaid
graph TD
    A["Calibration miss"] --> B["Find harness gap in shipping skills"]
    B --> C["Update /pr guidance"]
    B --> D["Update /land guidance"]
    C --> E["Consistent reviewer artifact policy"]
    D --> E
```

<details>
<summary>Details</summary>

**Changes**
- `skills/pr/SKILL.md`: tighten reviewer-evidence language, add attachment guidance in post-open flow, add `Artifact Hygiene`
- `skills/land/SKILL.md`: add `Reviewer Artifact Policy` for settlement flow
- `index.yaml`: regenerated by the pre-commit hook after skill-content changes

**Acceptance Criteria**
- [x] `/pr` explicitly prefers PR attachments for screenshots/videos
- [x] `/pr` explicitly prefers CI artifacts or step summaries for generated proof
- [x] `/pr` treats checked-in PR evidence as fallback-only
- [x] `/land` preserves the same reviewer-artifact policy during settlement

**Alternatives Considered**
- Do nothing: leaves the same ambiguity that caused the miss
- Add a repo-level AGENTS rule only: weaker than fixing the reusable skills agents actually invoke
- Create a new evidence-specific skill: unnecessary indirection for a policy that belongs inside existing PR workflows

**Manual QA**
- `python3 skills/craft-primitive/scripts/validate_skill.py skills/pr`
- `python3 skills/craft-primitive/scripts/validate_skill.py skills/land`
- `git diff --check`

Expected result: both skills validate successfully and the diff is whitespace-clean.

**Test Coverage**
This repo is markdown-first. Validation coverage is the skill validator plus pre-commit regeneration of `index.yaml`.

**Before / After**
Before: Spellbook's shipping skills preferred attachments in places, but did not explicitly reject repo-committed PR evidence as the default workflow.

After: `/pr` and `/land` both direct agents toward GitHub attachments for media, CI artifacts or step summaries for generated proof, and justified fallback-only commits when uploads are unavailable or the repo explicitly versions artifacts.

**Merge Confidence**
High. The change is narrow, validated locally, and aligns the shipping skills with the artifact-hygiene rule already present elsewhere in Spellbook.

</details>
