### PR TITLE
feat(focus): codify selection telemetry

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -8,3 +8,4 @@ Use `/tune-repo` to replace placeholders with real subsystem docs.
 |-----------|------|--------------|-------|
 | context-architecture | `docs/context/ROUTING.md`, `docs/context/DRIFT-WATCHLIST.md` | `CLAUDE.md`, `AGENTS.md`, `docs/context/**` | repo-level context plumbing |
 | focus-selection-history | `skills/focus/references/init.md` | `.spellbook/init-report.json` | cold-memory record of why primitives were selected, rejected, or left as gaps |
+| focus-observation-history | `skills/focus/references/improve.md`, `skills/focus/references/sync.md` | `.spellbook/observations.ndjson` | append-only event log for selection, sync, and undertrigger signals |

--- a/docs/context/ROUTING.md
+++ b/docs/context/ROUTING.md
@@ -8,5 +8,6 @@ Use `/tune-repo` to replace placeholders with real routes tied to source areas.
 |---------|--------|-------|
 | Pre-change | skill creation or modification | `/craft-primitive` |
 | Pre-change | rerunning `/focus init` or auditing primitive selection | read `.spellbook/init-report.json` before new catalog search |
+| Pre-change | auditing selection drift, missing matches, or sync outcomes | read `.spellbook/observations.ndjson` before revising `focus` behavior |
 | Pre-change | repo tuning / agent foundation work | `codified-context-architecture` + `/tune-repo` |
 | Post-change | PR blocked on CI, reviews, or conflicts | `/pr-fix` |

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-20T15:00:06Z
+# Generated: 2026-03-20T15:49:29Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:

--- a/skills/focus/SKILL.md
+++ b/skills/focus/SKILL.md
@@ -26,6 +26,7 @@ REGISTRY_URL:      ${SPELLBOOK_RAW}/registry.yaml
 MANIFEST_FILE:     .spellbook.yaml
 MARKER_FILE:       .spellbook
 INIT_REPORT_FILE:  .spellbook/init-report.json
+OBSERVATION_LOG_FILE: .spellbook/observations.ndjson
 ```
 
 **Resolving `SKILL_DIR`:** The harness provides the skill's installed path at
@@ -37,7 +38,7 @@ does not provide a skill path, stop and surface the error; do not guess.
 These skills are installed globally by `bootstrap.sh` and are always available.
 **Never suggest, fetch, or install these — they're already present.**
 
-The canonical list lives in `registry.yaml` under `global.skills` (13 skills)
+The canonical list lives in `registry.yaml` under `global.skills` (14 skills)
 and `global.agents` (4 agents). Do not hardcode this list — read the registry.
 
 Focus manages **domain skills** — the project-specific knowledge primitives
@@ -128,6 +129,9 @@ and follow it exactly. The init flow is 8 phases — do not shortcut it.
 8. **Present the full picture:** analysis, wishlist, matches, AND gaps.
    Lead with gaps as opportunities, not afterthoughts. Get explicit
    confirmation before writing the manifest.
+9. **Log compact selection telemetry.** Append `selected`, `excluded`,
+   and `gap` events to `${OBSERVATION_LOG_FILE}` with
+   `scripts/observation_log.py`. Keep events machine-readable and brief.
 
 ### 3. Resolve Skill References
 
@@ -195,7 +199,8 @@ See `references/harnesses/claude-code.md` and `references/harnesses/codex.md`.
 ## Focus Complete
 
 **Manifest**: .spellbook.yaml (5 domain skills, 2 agents)
-**Global layer**: 13 skills + 4 agents (via bootstrap, not shown)
+**Selection Log**: .spellbook/observations.ndjson
+**Global layer**: 14 skills + 4 agents (via bootstrap, not shown)
 
 ### Installed (domain)
 | Type | Name | Claude Code | Codex |
@@ -210,6 +215,9 @@ See `references/harnesses/claude-code.md` and `references/harnesses/codex.md`.
 ### Errors
 (none)
 ```
+
+The init report is the rich cold-memory snapshot. The observations log is the
+append-only event stream for later `/focus improve` synthesis.
 
 ## Managed vs Unmanaged
 

--- a/skills/focus/references/improve.md
+++ b/skills/focus/references/improve.md
@@ -5,17 +5,40 @@ Synthesize accumulated observations into discrete spellbook improvements.
 ## Observation Format
 
 Observations are stored in `.spellbook/observations.ndjson` — one JSON line
-per observation, appended by `/calibrate` or manually.
+per observation, appended by `/focus`, `/calibrate`, or manually.
+
+Use the `/focus` helper to keep selector telemetry compact and consistent:
+
+```bash
+python3 ${SKILL_DIR}/scripts/observation_log.py validate .spellbook/observations.ndjson
+```
+
+Shared envelope:
+
+- `timestamp` — UTC write time
+- `type` — event family
+- `summary` — one-sentence headline
+- `context` — compact evidence, not raw transcript
+- `confidence` — `0.0` to `1.0`
+
+Supported `/focus` event families:
+
+| Type | Required fields | Meaning |
+|------|-----------------|---------|
+| `selected` | `primitive`, `wishlist_item`, `run_kind` | Candidate chosen for active subset |
+| `excluded` | `primitive`, `wishlist_item`, `run_kind` | Plausible candidate rejected with rationale |
+| `gap` | `wishlist_item`, `run_kind`, `gap_scope` | Need with no strong primitive match |
+| `installed` | `primitive`, `run_kind` | Sync added a managed primitive |
+| `updated` | `primitive`, `run_kind` | Sync refreshed a managed primitive |
+| `removed` | `primitive`, `run_kind` | Sync removed a managed primitive |
+| `undertriggered` | `primitive`, `run_kind` | Later review found a selected primitive is rarely used |
+
+Examples:
 
 ```json
-{
-  "timestamp": "2026-03-16T22:00:00Z",
-  "primitive": "phrazzld/spellbook@autopilot",
-  "type": "friction",
-  "summary": "Autopilot didn't handle draft PRs",
-  "context": "Full context of what happened...",
-  "confidence": 0.6
-}
+{"timestamp":"2026-03-20T15:00:00Z","type":"selected","summary":"Selected codified-context-architecture for repo tuning.","context":"High semantic match and low overlap with the other candidates.","confidence":0.82,"primitive":"phrazzld/spellbook@codified-context-architecture","wishlist_item":"repo tuning","run_kind":"init"}
+{"timestamp":"2026-03-20T15:00:01Z","type":"gap","summary":"No skill matched factory-specific routing policy.","context":"Catalog search found no strong candidate for the repo-specific conventions.","confidence":0.71,"wishlist_item":"factory-specific routing policy","run_kind":"init","gap_scope":"spellbook"}
+{"timestamp":"2026-03-20T15:05:00Z","type":"undertriggered","summary":"React performance skill was installed but never selected in later sessions.","context":"Three review passes and two build sessions completed without routing to the skill.","confidence":0.64,"primitive":"phrazzld/spellbook@react-performance","run_kind":"improve"}
 ```
 
 ## Process
@@ -36,10 +59,15 @@ If running from the spellbook repo itself, also scan for observation files
 in known project directories (check git config for recent repos, or ask
 the user which projects to include).
 
-### 2. Cluster by Primitive
+### 2. Cluster by Primitive or Gap Key
 
-Group observations by the `primitive` FQN. For each primitive with
-2+ observations, there's likely a real pattern worth addressing.
+Group observations by the strongest stable key:
+
+- If `primitive` exists, cluster by primitive FQN
+- For `gap` events without a primitive, cluster by `(wishlist_item, gap_scope)`
+- For selection decisions, use `wishlist_item` to compare winners, losers, and persistent misses
+
+For each cluster with 2+ observations, there's likely a real pattern worth addressing.
 
 Single observations with high confidence (>= 0.8) are also candidates.
 
@@ -54,6 +82,13 @@ For each cluster, analyze the observations and produce:
 
 If the init report already listed a gap or weak match for the same area,
 reuse that language instead of reconstructing the rationale from scratch.
+
+When a cluster mixes `selected`, `excluded`, and `gap` events for the same
+wishlist item, prefer the longitudinal story over any single line:
+
+- repeated `gap` + no later `selected` => likely missing skill
+- repeated `excluded` in favor of the same winner => maybe catalog duplication
+- repeated `undertriggered` on the same primitive => selection quality or trigger-quality issue
 
 ### 4. Choose Action
 

--- a/skills/focus/references/init.md
+++ b/skills/focus/references/init.md
@@ -232,6 +232,62 @@ The input payload must satisfy this compact shape:
 }
 ```
 
+### Phase 5b: Log Selection Telemetry
+
+Before confirmation, append a compact event trail to
+`.spellbook/observations.ndjson`. This is the delta log that later
+`/focus improve` runs cluster; it complements the richer init report instead
+of replacing it.
+
+Use the helper so the schema stays consistent:
+
+```bash
+python3 ${SKILL_DIR}/scripts/observation_log.py append \
+  --output .spellbook/observations.ndjson \
+  --input /tmp/focus-init-observations.json
+```
+
+Required fields by event type:
+
+- `selected` and `excluded`: `primitive`, `wishlist_item`, `run_kind`
+- `gap`: `wishlist_item`, `run_kind`, `gap_scope`
+- common envelope: `type`, `summary`, `context`, `confidence`
+
+Example payload:
+
+```json
+[
+  {
+    "type": "selected",
+    "summary": "Selected codified-context-architecture for repo tuning.",
+    "context": "High semantic match and low overlap with the other candidates.",
+    "confidence": 0.82,
+    "primitive": "phrazzld/spellbook@codified-context-architecture",
+    "wishlist_item": "repo tuning",
+    "run_kind": "init"
+  },
+  {
+    "type": "excluded",
+    "summary": "Excluded harness-engineering from the initial subset.",
+    "context": "The global install already covers the same operational ground.",
+    "confidence": 0.73,
+    "primitive": "phrazzld/spellbook@harness-engineering",
+    "wishlist_item": "repo tuning",
+    "run_kind": "init",
+    "related_primitive": "phrazzld/spellbook@codified-context-architecture"
+  },
+  {
+    "type": "gap",
+    "summary": "No skill matched factory-specific routing policy.",
+    "context": "Catalog search found no strong candidate for the repo-specific conventions.",
+    "confidence": 0.71,
+    "wishlist_item": "factory-specific routing policy",
+    "run_kind": "init",
+    "gap_scope": "spellbook"
+  }
+]
+```
+
 ### Phase 6: Generate Manifest
 
 ```yaml
@@ -255,6 +311,7 @@ Show the user:
 3. **Matched skills** with reasoning
 4. **Skill gaps** — wishlist items with no match
 5. **Init report path** — `.spellbook/init-report.json` written and ready to inspect
+6. **Observation log path** — `.spellbook/observations.ndjson` appended with `selected`, `excluded`, and `gap` events
 
 For each gap, offer:
 > "No existing skill covers [X]. Want me to draft a new skill for this

--- a/skills/focus/references/sync.md
+++ b/skills/focus/references/sync.md
@@ -162,3 +162,52 @@ rm -rf "$tmp"
 
 Run harness-specific setup for each target (see `references/harnesses/`).
 Report installed/skipped/errored primitives with per-harness status.
+
+### 9. Log Sync Outcomes
+
+Append compact sync events to `.spellbook/observations.ndjson` after the
+distribution pass succeeds. Use the same helper and shared envelope as init.
+
+```bash
+python3 ${SKILL_DIR}/scripts/observation_log.py append \
+  --output .spellbook/observations.ndjson \
+  --input /tmp/focus-sync-observations.json
+```
+
+Use:
+
+- `installed` when a primitive or agent was added to a harness target set
+- `updated` when an existing managed primitive was replaced with newer content
+- `removed` when a managed primitive disappeared because the manifest no longer declares it
+
+Each sync event requires:
+
+- `type`
+- `summary`
+- `context`
+- `confidence`
+- `primitive`
+- `run_kind` set to `sync`
+
+Example payload:
+
+```json
+[
+  {
+    "type": "installed",
+    "summary": "Installed debug into all harness targets.",
+    "context": "The manifest declared it and distribution completed cleanly.",
+    "confidence": 0.9,
+    "primitive": "phrazzld/spellbook@debug",
+    "run_kind": "sync"
+  },
+  {
+    "type": "removed",
+    "summary": "Removed stripe-auditor from the managed set.",
+    "context": "The manifest no longer declared the agent and cleanup removed the managed copy.",
+    "confidence": 0.88,
+    "primitive": "phrazzld/spellbook@stripe-auditor",
+    "run_kind": "sync"
+  }
+]
+```

--- a/skills/focus/scripts/observation_log.py
+++ b/skills/focus/scripts/observation_log.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Validate and append /focus observation events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+VALID_TYPES = {
+    "selected": ("primitive", "wishlist_item", "run_kind"),
+    "excluded": ("primitive", "wishlist_item", "run_kind"),
+    "gap": ("wishlist_item", "run_kind", "gap_scope"),
+    "installed": ("primitive", "run_kind"),
+    "updated": ("primitive", "run_kind"),
+    "removed": ("primitive", "run_kind"),
+    "undertriggered": ("primitive", "run_kind"),
+}
+VALID_RUN_KINDS = {"init", "sync", "improve", "manual"}
+VALID_GAP_SCOPES = {"repo-local", "spellbook"}
+
+
+def _expect_dict(value: object, path: str) -> list[str]:
+    if isinstance(value, dict):
+        return []
+    return [f"{path} must be an object"]
+
+
+def _expect_non_empty_string(value: object, path: str) -> list[str]:
+    if isinstance(value, str) and value.strip():
+        return []
+    return [f"{path} must be a non-empty string"]
+
+
+def _expect_confidence(value: object, path: str) -> list[str]:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1:
+        return []
+    return [f"{path} must be a number between 0 and 1"]
+
+
+def validate_event(event: object, path: str, *, require_timestamp: bool) -> list[str]:
+    errors = _expect_dict(event, path)
+    if errors:
+        return errors
+
+    data = event
+    assert isinstance(data, dict)
+
+    for field in ("type", "summary", "context"):
+        if field not in data:
+            errors.append(f"{path}.{field} is required")
+        else:
+            errors.extend(_expect_non_empty_string(data[field], f"{path}.{field}"))
+
+    if "confidence" not in data:
+        errors.append(f"{path}.confidence is required")
+    else:
+        errors.extend(_expect_confidence(data["confidence"], f"{path}.confidence"))
+
+    if require_timestamp:
+        if "timestamp" not in data:
+            errors.append(f"{path}.timestamp is required")
+        else:
+            errors.extend(_expect_non_empty_string(data["timestamp"], f"{path}.timestamp"))
+    elif "timestamp" in data:
+        errors.extend(_expect_non_empty_string(data["timestamp"], f"{path}.timestamp"))
+
+    if errors:
+        return errors
+
+    event_type = data["type"]
+    assert isinstance(event_type, str)
+    if event_type not in VALID_TYPES:
+        errors.append(f"{path}.type must be one of: {', '.join(sorted(VALID_TYPES))}")
+        return errors
+
+    for field in VALID_TYPES[event_type]:
+        if field not in data:
+            errors.append(f"{path}.{field} is required for type={event_type}")
+        else:
+            errors.extend(_expect_non_empty_string(data[field], f"{path}.{field}"))
+
+    run_kind = data.get("run_kind")
+    if isinstance(run_kind, str) and run_kind not in VALID_RUN_KINDS:
+        errors.append(
+            f"{path}.run_kind must be one of: {', '.join(sorted(VALID_RUN_KINDS))}"
+        )
+
+    gap_scope = data.get("gap_scope")
+    if isinstance(gap_scope, str) and gap_scope not in VALID_GAP_SCOPES:
+        errors.append(
+            f"{path}.gap_scope must be one of: {', '.join(sorted(VALID_GAP_SCOPES))}"
+        )
+
+    return errors
+
+
+def _read_json(path: str | None) -> object:
+    if path in (None, "-"):
+        raw = sys.stdin.read()
+    else:
+        raw = Path(path).read_text(encoding="utf-8")
+    return json.loads(raw)
+
+
+def _read_events(path: str | None) -> list[dict[str, object]]:
+    payload = _read_json(path)
+    if isinstance(payload, dict):
+        events = [payload]
+    elif isinstance(payload, list):
+        events = payload
+    else:
+        raise ValueError("input must be a JSON object or array of objects")
+
+    typed_events: list[dict[str, object]] = []
+    for event in events:
+        if not isinstance(event, dict):
+            raise ValueError("every event must be a JSON object")
+        typed_events.append(dict(event))
+    return typed_events
+
+
+def cmd_append(args: argparse.Namespace) -> int:
+    try:
+        events = _read_events(args.input)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    for index, event in enumerate(events):
+        errors.extend(validate_event(event, f"event[{index}]", require_timestamp=False))
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    with output.open("a", encoding="utf-8") as handle:
+        for event in events:
+            event.setdefault(
+                "timestamp",
+                datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            )
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+    print(output)
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    path = Path(args.path)
+    try:
+        raw_lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    event_count = 0
+
+    for line_number, raw_line in enumerate(raw_lines, start=1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        event_count += 1
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError as exc:
+            errors.append(f"line {line_number}: invalid JSON ({exc.msg})")
+            continue
+        errors.extend(validate_event(payload, f"line {line_number}", require_timestamp=True))
+
+    if event_count == 0:
+        errors.append("observations log must contain at least one event")
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("ok")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Append and validate /focus observation events")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    append_parser = subparsers.add_parser("append", help="append validated events to an NDJSON file")
+    append_parser.add_argument("--output", required=True, help="path to .spellbook/observations.ndjson")
+    append_parser.add_argument("--input", help="JSON file containing one event object or an array; defaults to stdin")
+    append_parser.set_defaults(func=cmd_append)
+
+    validate_parser = subparsers.add_parser("validate", help="validate an NDJSON observations file")
+    validate_parser.add_argument("path", help="path to .spellbook/observations.ndjson")
+    validate_parser.set_defaults(func=cmd_validate)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/focus/scripts/test_observation_log.py
+++ b/skills/focus/scripts/test_observation_log.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("observation_log.py")
+
+
+def valid_events() -> list[dict[str, object]]:
+    return [
+        {
+            "type": "selected",
+            "summary": "Selected codified-context-architecture for repo tuning.",
+            "context": "High semantic match and low overlap with the other candidates.",
+            "confidence": 0.82,
+            "primitive": "phrazzld/spellbook@codified-context-architecture",
+            "wishlist_item": "repo tuning",
+            "run_kind": "init",
+        },
+        {
+            "type": "excluded",
+            "summary": "Excluded harness-engineering from the initial subset.",
+            "context": "The global install already covers the same operational ground.",
+            "confidence": 0.73,
+            "primitive": "phrazzld/spellbook@harness-engineering",
+            "wishlist_item": "repo tuning",
+            "run_kind": "init",
+            "related_primitive": "phrazzld/spellbook@codified-context-architecture",
+        },
+        {
+            "type": "gap",
+            "summary": "No skill matched factory-specific routing policy.",
+            "context": "Catalog search found no strong candidate for the repo-specific conventions.",
+            "confidence": 0.71,
+            "wishlist_item": "factory-specific routing policy",
+            "run_kind": "init",
+            "gap_scope": "spellbook",
+        },
+    ]
+
+
+class ObservationLogScriptTest(unittest.TestCase):
+    def run_script(self, *args: str, input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), *args],
+            input=input_text,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_append_and_validate_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / ".spellbook" / "observations.ndjson"
+
+            append = self.run_script(
+                "append",
+                "--output",
+                str(output),
+                input_text=json.dumps(valid_events()),
+            )
+            self.assertEqual(append.returncode, 0, append.stderr)
+            self.assertTrue(output.exists())
+
+            lines = output.read_text(encoding="utf-8").strip().splitlines()
+            self.assertEqual(len(lines), 3)
+
+            for line in lines:
+                event = json.loads(line)
+                self.assertIn("timestamp", event)
+                self.assertIn(event["type"], {"selected", "excluded", "gap"})
+
+            validate = self.run_script("validate", str(output))
+            self.assertEqual(validate.returncode, 0, validate.stderr)
+            self.assertEqual(validate.stdout.strip(), "ok")
+
+    def test_selected_requires_primitive(self) -> None:
+        broken = valid_events()
+        broken[0].pop("primitive")
+
+        result = self.run_script("append", "--output", "/tmp/ignored.ndjson", input_text=json.dumps(broken))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("event[0].primitive is required for type=selected", result.stderr)
+
+    def test_gap_requires_scope_but_not_primitive(self) -> None:
+        events = [valid_events()[2]]
+
+        result = self.run_script("append", "--output", "/tmp/ignored.ndjson", input_text=json.dumps(events))
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_append_rejects_blank_timestamp_when_provided(self) -> None:
+        events = valid_events()
+        events[0]["timestamp"] = ""
+
+        result = self.run_script("append", "--output", "/tmp/ignored.ndjson", input_text=json.dumps(events))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("event[0].timestamp must be a non-empty string", result.stderr)
+
+    def test_sync_outcomes_require_primitive(self) -> None:
+        result = self.run_script(
+            "append",
+            "--output",
+            "/tmp/ignored.ndjson",
+            input_text=json.dumps(
+                [
+                    {
+                        "type": "installed",
+                        "summary": "Installed debug into all harness targets.",
+                        "context": "The manifest declared it and distribution completed cleanly.",
+                        "confidence": 0.9,
+                        "run_kind": "sync",
+                    }
+                ]
+            ),
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("event[0].primitive is required for type=installed", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Reviewer Evidence
- Start here: `skills/focus/scripts/observation_log.py` and `skills/focus/references/improve.md`
- Walkthrough notes: this change is internal to the `focus` skill, so the reviewer proof is terminal execution rather than screenshots.
- Fast claim: `/focus` now has a documented and mechanically validated `observations.ndjson` contract for `selected`, `excluded`, `gap`, and sync outcome events.

```text
$ python3 -m unittest skills.focus.scripts.test_init_report skills.focus.scripts.test_observation_log
....................
----------------------------------------------------------------------
Ran 20 tests in 0.779s

OK

$ python3 skills/focus/scripts/observation_log.py append --output /tmp/focus-observations.ndjson < sample-events.json
/tmp/focus-observations.ndjson

$ jq -e 'select(.type == "gap" or .type == "selected" or .type == "excluded")' /tmp/focus-observations.ndjson >/dev/null
$ python3 skills/focus/scripts/observation_log.py validate /tmp/focus-observations.ndjson
ok
```

## Why This Matters
- Problem: `focus` selection decisions were described in prose and init reports, but there was no compact append-only event stream that later curation could cluster across runs.
- Value: this adds a shared telemetry contract for `init`, `sync`, and `improve`, plus a small helper that keeps the log machine-checkable instead of relying on manual memory or ad hoc JSON.
- Why now: issue [#72](https://github.com/phrazzld/spellbook/issues/72) is the missing link between subset selection and evidence-driven Spellbook curation.
- Issue: closes [#72](https://github.com/phrazzld/spellbook/issues/72)

## Trade-offs / Risks
- Value gained: durable, jq-friendly event history for focus decisions and sync outcomes, with tests guarding the schema.
- Cost / risk incurred: one new helper script and more detail in the `focus` references.
- Why this is still the right trade: the complexity is isolated in one small module, while the docs stay declarative and aligned around a single event shape.
- Reviewer watch-outs: pressure-test whether the required fields are the smallest useful contract, especially for `gap` and `undertriggered` events.

## What Changed
Before this PR, `/focus init` produced a rich init report but no append-only selection log, `/focus sync` reported outcomes without a durable telemetry contract, and `/focus improve` depended on sparse generic observations. After this PR, `focus` owns a specific `observations.ndjson` schema, a helper to append and validate it, and aligned guidance across init, sync, improve, and repo context docs.

### Base Branch
```mermaid
graph TD
  A["/focus init"] --> B["wishlist + candidate matrix"]
  B --> C[".spellbook/init-report.json"]
  D["/focus sync"] --> E["install/update managed primitives"]
  F["/focus improve"] --> G["read sparse manual observations"]
```

### This PR
```mermaid
graph TD
  A["/focus init"] --> B["wishlist + candidate matrix"]
  B --> C[".spellbook/init-report.json"]
  B --> D["selected/excluded/gap events"]
  E["/focus sync"] --> F["installed/updated/removed events"]
  D --> G[".spellbook/observations.ndjson"]
  F --> G
  G --> H["/focus improve clustering"]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> InitSelection
  InitSelection --> InitReport: write cold-memory snapshot
  InitSelection --> ObservationLog: append selected/excluded/gap
  ObservationLog --> SyncOutcomes: append installed/updated/removed
  ObservationLog --> ImproveSynthesis: cluster by primitive or gap key
  ImproveSynthesis --> [*]
```

Why this is better:
- The init report stays the rich snapshot, while the observation log becomes the append-only delta stream.
- One helper owns schema validation, so init/sync/improve do not each invent their own event shape.

<details>
<summary>Intent Reference</summary>

## Intent Reference
Issue [#72](https://github.com/phrazzld/spellbook/issues/72) now includes a `Product Spec` and `Technical Design` section. Core intent summary:

- Persist compact, machine-readable selection telemetry from normal `/focus` runs.
- Keep the schema append-only and inspectable with `jq`.
- Make repeated gaps and undertriggered selections usable by `/focus improve` without reconstructing sessions manually.

</details>

<details>
<summary>Changes</summary>

## Changes
- Added `skills/focus/scripts/observation_log.py` to append and validate compact focus observation events.
- Added `skills/focus/scripts/test_observation_log.py` to lock the event contract with TDD coverage.
- Updated `skills/focus/references/init.md`, `skills/focus/references/sync.md`, and `skills/focus/references/improve.md` to use the shared schema and helper.
- Updated `skills/focus/SKILL.md` and `docs/context/{INDEX,ROUTING}.md` so the cold-memory surface includes `.spellbook/observations.ndjson`.
- Refreshed `index.yaml` via the repo hook after the skill content changed.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- Upside: no new script or docs surface.
- Downside: `focus improve` keeps depending on memory and sporadic manual observations.
- Why rejected: it leaves the exact issue unresolved.

### Option B — Document the schema in markdown only
- Upside: smaller diff.
- Downside: no mechanical check, easy for init/sync/improve guidance to drift.
- Why rejected: the issue explicitly wants machine-checkable event data.

### Option C — Build a larger runtime telemetry subsystem
- Upside: richer future automation.
- Downside: too much surface area for a skill repo and violates the “compact event data, not transcripts” boundary.
- Why rejected: the helper script gives the needed contract without overbuilding.

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Given a `/focus init` or `/focus sync` run, when it finishes, then `.spellbook/observations.ndjson` contains structured events for `selected`, `excluded`, and `gap` outcomes.
- [x] Given `.spellbook/observations.ndjson`, when `jq -e 'select(.type == "gap" or .type == "selected" or .type == "excluded")' .spellbook/observations.ndjson >/dev/null` runs, then it exits `0`.
- [x] Given a repo repeatedly emits the same `gap` event across sessions, when `/focus improve` runs, then it can cluster that evidence into a concrete Spellbook improvement proposal.
- [x] Given an installed skill is never selected or later appears undertriggered, when the telemetry is reviewed, then the signal is available for curation without reconstructing the session manually.
- [x] Given a single `/focus` run, when the log is inspected, then it is compact event data rather than a raw transcript.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
1. Run `python3 -m unittest skills.focus.scripts.test_init_report skills.focus.scripts.test_observation_log`.
2. Append a sample selection payload with `python3 skills/focus/scripts/observation_log.py append --output /tmp/focus-observations.ndjson`.
3. Run `jq -e 'select(.type == "gap" or .type == "selected" or .type == "excluded")' /tmp/focus-observations.ndjson >/dev/null`.
4. Run `python3 skills/focus/scripts/observation_log.py validate /tmp/focus-observations.ndjson`.
5. Read `skills/focus/references/improve.md` and confirm the clustering guidance covers `primitive` and gap-key aggregation.

Expected result: tests pass, `jq` exits `0`, validator prints `ok`, and the docs consistently reference the shared observation schema.

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: terminal execution + doc review
- Artifact: the embedded terminal proof in `Reviewer Evidence`
- Claim: the branch adds a shared focus telemetry contract that is both documented and mechanically validated
- Before / After scope: init report only -> init report plus append-only observation log shared by init/sync/improve
- Persistent verification: `python3 -m unittest skills.focus.scripts.test_init_report skills.focus.scripts.test_observation_log`
- Residual gap: there is still no end-to-end harness runner for `/focus` itself; this PR validates the contract and the helper that the skill now instructs agents to use

</details>

## Before / After
Before: `focus` had a rich `init-report.json` path but no dedicated, validated observation stream for selection or sync outcomes. `improve` described generic observations but not a focus-specific schema for decisions, gaps, and undertriggering.

After: `focus` now documents `.spellbook/observations.ndjson` as a first-class artifact, ships a validator/appender for that file, and aligns init, sync, improve, and repo context docs around the same event contract.

<details>
<summary>Test Coverage</summary>

## Test Coverage
- `skills/focus/scripts/test_observation_log.py`
- `skills/focus/scripts/test_init_report.py`

Coverage notes:
- Added round-trip and validation failure coverage for the new observation helper.
- Re-ran the existing init report suite to ensure the new telemetry path did not regress the adjacent cold-memory artifact.
- Gap: no end-to-end harness execution test for `/focus` command routing exists in this repo.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: high
- Strongest evidence: focused unit tests plus direct `append -> jq -> validate` command verification on the new helper
- Remaining uncertainty: future event families may need field adjustments as `focus improve` sees real usage
- What could still go wrong after merge: a caller could choose a semantically weak `summary` or `context`, but the schema and docs now make the mechanical contract explicit

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced observation logging system to record selection, sync outcomes, and gap events during focus skill operations for improved workflow telemetry tracking.

* **Documentation**
  * Enhanced focus workflow documentation with expanded observation lifecycle guidance and concrete event examples.
  * Added detailed validation requirements and field specifications for different event types.

* **Tests**
  * Added test coverage for observation logging operations and event validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->