### PR TITLE
feat(skills): add /rethink architectural exploration skill

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Spellbook Index
-# Generated: 2026-03-20T15:49:29Z
+# Generated: 2026-03-21T03:05:41Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:
@@ -195,6 +195,9 @@ skills:
   - name: research
     description: "Web research, multi-AI delegation, and multi-perspective validation. /research [query], /research delegate [task], /research thinktank [topic]. Triggers: \"search for\", \"look up\", \"research\", \"delegate"
     tags: [delegate,delegation,look,multi-ai,multi-perspective,query,research,search,task,thinktank]
+  - name: rethink
+    description: "Architectural exploration: understand current system deeply, research alternatives, synthesize options with tradeoffs, recommend a simpler path. Use when: \"rethink this\", \"is there a better way\", \"sim"
+    tags: [a,alternatives,architectural,better,current,deeply,exploration,is,options,path]
   - name: security-scan
     description: "Whole-codebase vulnerability analysis leveraging 1M context window. Loads entire project source, runs deep security analysis in a single pass. OWASP Top 10, cross-module data flow tracing, dependency "
     tags: [10,1m,a,analysis,context,cross-module,data,deep,dependency,entire]

--- a/registry.yaml
+++ b/registry.yaml
@@ -24,6 +24,7 @@ global:
       - craft-primitive
       - refine
       - reflect
+      - rethink
       - shape
 
   # Design philosophy agents: installed by bootstrap.sh, always available.

--- a/skills/rethink/SKILL.md
+++ b/skills/rethink/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: rethink
+description: |
+  Architectural exploration: understand current system deeply, research alternatives,
+  synthesize options with tradeoffs, recommend a simpler path.
+  Use when: "rethink this", "is there a better way", "simplify this system",
+  "architectural alternatives", "what would you redesign", "question the architecture",
+  "step back and rethink".
+  Trigger: /rethink, "rethink the architecture", "what would you change".
+argument-hint: "[scope] — module, subsystem, directory, or architectural concern"
+---
+
+# /rethink
+
+Architectural exploration. Understand deeply, research alternatives, recommend a simpler path.
+
+## When to Use
+
+- Current architecture feels wrong but you can't articulate why
+- Complexity has accreted and you want to see the design space
+- Before major refactors — know your options first
+- System works but is harder to reason about than it should be
+- You want to question foundational assumptions, not just fix bugs
+
+NOT for: incremental improvements (use `/land --simplify`), issue planning (use `/shape`),
+backlog strategy (use `/refine`), deciding what to build next (use `/moonshot`).
+
+## Interface
+
+`/rethink [scope]`
+
+Scope is a module, subsystem, directory, or architectural concern.
+Examples: `/rethink the auth system`, `/rethink src/payments/`,
+`/rethink how we handle state`, `/rethink the build system`.
+
+## Executive / Worker Split
+
+Workers gather evidence; the lead decides. Never delegate the architectural recommendation.
+
+- **Phase 1 workers**: Explore agents gather structure, data flow, pain points, history
+- **Phase 2 workers**: Triad agents provide critique; `/research` handles web fanout
+- **Phase 3**: Lead model only — all synthesis, recommendation, and judgment
+
+## Process
+
+### Phase 1: Understand
+
+Build a deep mental model before forming opinions.
+
+Spawn 2-4 Explore workers in parallel:
+
+| Worker | Focus |
+|--------|-------|
+| Structure | Module boundaries, dependency graph, public interfaces, file organization |
+| Data flow | How data moves: entry points, transformations, storage, exit points |
+| Pain points | Complexity hotspots, large files, deep call chains, leaky abstractions |
+| History | Git history (30+ commits) — what changes most, what's coupled, what broke |
+
+Workers return evidence, not opinions.
+
+**Mandatory reads** before proceeding:
+- CLAUDE.md, README, any ADRs or project docs
+- The actual source files in scope (not just structure)
+- Recent PRs touching the scope (last 5-10)
+
+### Phase 2: Research
+
+Three parallel tracks:
+
+1. **Reference architectures** — Invoke `/research "how do production systems implement [this concern]"`.
+   Focus on systems that solved the SAME problem differently.
+
+2. **Triad critique** — Spawn ousterhout, carmack, grug agents on the current architecture:
+   > "Here is [scope]. What is the single biggest structural problem?
+   > What would you change first? What would you delete?"
+
+3. **Prior art in codebase** — Has this been rethought before?
+   Check git log for large refactors, ADRs, comments with `TODO: rethink`,
+   `tech debt`, `HACK`, `FIXME`.
+
+**All web research MUST use `/research`** — do not bypass the fanout.
+
+If exploration produces variations on the same theme instead of genuine alternatives,
+load `references/alternative-lenses.md` for hard reframing moves.
+
+### Phase 3: Synthesize
+
+Produce the Rethink Report (structure below). The lead model does this alone.
+
+**Rules:**
+- Recommend one path. Not a menu — a recommendation with conviction.
+- Every alternative must be concrete enough to implement, not vague directions.
+- "Do nothing" is always an explicit option with honest tradeoffs.
+- Cost in complexity-removed matters more than features-added.
+- The best rethink often deletes code, not adds it.
+
+## Output: Rethink Report
+
+```
+## Current Architecture
+
+[2-3 paragraphs: what exists, how it works, key design decisions (explicit and implicit)]
+
+### Structural Assessment
+
+| Dimension | Rating |
+|-----------|--------|
+| Module depth | Shallow / adequate / deep |
+| Information hiding | Leaky / partial / strong |
+| Coupling | High / moderate / low |
+| Complexity budget | Over / at / under budget |
+| Change cost | High / moderate / low |
+
+### What the Triad Said
+- **Ousterhout**: [core structural concern]
+- **Carmack**: [shippability/pragmatism concern]
+- **Grug**: [complexity concern]
+
+## Alternatives
+
+### Option 0: Do Nothing
+[Honest assessment. What happens if we leave it? When does it break?]
+
+### Option 1: [Name]
+[Architecture sketch. Key insight. What changes structurally.]
+- **Gains**: what improves (be specific)
+- **Costs**: what it takes (effort, risk, migration)
+- **Deletes**: what goes away (the best part)
+- **Unlocks**: what becomes possible that isn't today
+
+### Option 2: [Name]
+[Same structure]
+
+### Option N: [2-4 total alternatives]
+
+## Recommendation
+
+[Which option and WHY. The argument for why this is the right move
+at this point in the project's life.]
+
+## Next Steps
+
+[Concrete: "/shape this", "create an issue", "try a spike", "do nothing for now"]
+```
+
+## Anti-Patterns
+
+- Listing options without recommending one (that's a menu, not a rethink)
+- Recommending the current architecture with minor tweaks (that's `/land --simplify`)
+- Ignoring the "do nothing" option (sometimes the answer is "it's fine")
+- Over-researching without forming an opinion (research informs; it doesn't decide)
+- Proposing rewrites when the real problem is one leaky abstraction
+- Adding layers to fix problems caused by too many layers
+
+## Composability
+
+After `/rethink`, the user may:
+- `/shape` — plan the recommended alternative in detail
+- `/refine` — fit the rethink into the backlog
+- `/autopilot` — just build it
+- `/research thinktank` — stress-test the recommendation further

--- a/skills/rethink/references/alternative-lenses.md
+++ b/skills/rethink/references/alternative-lenses.md
@@ -1,0 +1,36 @@
+# Alternative Lenses
+
+Load when Phase 2 exploration is producing variations on the same theme
+instead of genuinely different architectures.
+
+## Structural Lenses
+
+Pick one lens. Generate a full alternative through it.
+
+| Lens | Question |
+|------|----------|
+| **Inversion** | What if the control flow went the opposite direction? |
+| **Deletion** | What if we deleted the entire module and started over? What's the minimum? |
+| **Monolith** | What if this was one file? What would that look like? |
+| **Split** | What if every concern was its own service/module? |
+| **Data-first** | What if we designed the data model first and let code follow? |
+| **Event-sourced** | What if all state changes were events? |
+| **Functional core** | What if all business logic was pure functions, side effects at edges? |
+| **Capabilities** | What if we designed around capabilities/permissions, not entities? |
+| **API-first** | What if we designed the public API first and worked backward? |
+| **User-backward** | What if we started from the ideal user experience and worked to implementation? |
+
+## Process
+
+1. Name the current architectural frame in one sentence
+2. Pick the lens that feels most uncomfortable (that's the one with new information)
+3. Generate a complete alternative through that lens — not a sketch, a real design
+4. Ask: is this genuinely simpler, or just different?
+
+## Rules
+
+- One lens at a time. Don't combine.
+- The goal is to find an architecture that's actually simpler, not just novel.
+- If the lens produces something worse, that's useful — it confirms the current approach.
+- If the lens produces something clearly better, that's the breakthrough.
+- If every lens produces something worse, the current architecture is probably right.


### PR DESCRIPTION
## Why This Matters

No existing skill questions whether the current architecture is the right one.
`/moonshot` asks "what should we build next?" (additive), `/land --simplify` does
tactical cleanup, `/shape` plans HOW to build. But nothing asks: "should we
rebuild what exists?"

`/rethink` fills that gap — a structured process for exploring architectural
alternatives before committing to a major refactor.

Part of #102

## Trade-offs / Risks

- **Added complexity**: One more global skill in the process chain. Mitigated by clear
  scope boundaries (rethink ≠ shape ≠ refine ≠ moonshot).
- **Triad dependency**: Phase 2 invokes ousterhout/carmack/grug agents. If those aren't
  installed, that track degrades gracefully (skip, don't fail).
- **Research dependency**: Phase 2 routes through `/research`. Same graceful degradation.

## What Changed

New `/rethink` skill with three-phase architectural exploration workflow.

```mermaid
graph TD
    A["/rethink scope"] --> B["Phase 1: Understand"]
    B --> C1["Explore: Structure"]
    B --> C2["Explore: Data Flow"]
    B --> C3["Explore: Pain Points"]
    B --> C4["Explore: History"]
    C1 & C2 & C3 & C4 --> D["Phase 2: Research"]
    D --> E1["/research reference architectures"]
    D --> E2["Triad critique"]
    D --> E3["Prior art in codebase"]
    E1 & E2 & E3 --> F["Phase 3: Synthesize"]
    F --> G["Rethink Report"]
    G --> H1["/shape"] & H2["/refine"] & H3["/autopilot"]
```

The report structure forces a recommendation (not a menu) and always includes
"do nothing" as an explicit option with honest tradeoffs.

<details>
<summary>Changes</summary>

- `skills/rethink/SKILL.md` — Core skill definition (three phases, output template, anti-patterns)
- `skills/rethink/references/alternative-lenses.md` — 10 reframing lenses for when exploration gets stuck
- `registry.yaml` — Added `rethink` to `global.skills.standard`
- `index.yaml` — Auto-regenerated by pre-commit hook

</details>

<details>
<summary>Acceptance Criteria</summary>

- [x] SKILL.md follows frontmatter convention (name, description, argument-hint)
- [x] Three-phase process: Understand → Research → Synthesize
- [x] Executive/worker split documented
- [x] Structured output template (Rethink Report)
- [x] Registered as global skill in registry.yaml
- [x] Anti-patterns section prevents common misuse
- [x] Composability section links to downstream skills

</details>

<details>
<summary>Alternatives Considered</summary>

**Do nothing** — Users already have `/moonshot` + `/shape`. But neither questions
existing architecture; both assume you're building forward.

**Four phases (separate brainstorm)** — Rejected as temporal decomposition (Ousterhout
red flag). Brainstorming happens naturally during research and synthesis.

**File output instead of conversation** — Rejected. Rethink is a decision tool
upstream of planning. If user wants to persist, they route to `/shape`.

</details>

<details>
<summary>Manual QA</summary>

```bash
# Install globally
bash bootstrap.sh

# Verify installed
ls ~/.claude/skills/rethink/SKILL.md
ls ~/.claude/skills/rethink/references/alternative-lenses.md

# In any project, invoke:
# /rethink the auth system
# /rethink src/payments/
```

</details>

<details>
<summary>Merge Confidence</summary>

**High** — Purely additive. New skill + one line in registry.yaml. No existing
behavior modified. Pre-commit hook confirmed index.yaml regeneration.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `/rethink` command for comprehensive architectural exploration and review with structured multi-phase workflow, enabling systematic evidence-based analysis across codebase structure, data flow, pain points, and design patterns.
  * Generates detailed Rethink Reports including architectural assessments, design feedback capture, bounded sets of implementable alternatives, and explicit recommendations.
  * Includes reference documentation for architectural exploration lenses and methodologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->