### PR TITLE
fix: discover skills/agents from filesystem, not registry.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,8 @@ spellbook/
 ├── agents/        # 7 agents: planner, builder, critic,
 │                  #   ousterhout, carmack, grug, beck
 ├── harnesses/     # Per-harness configs, hooks, shared principles
-├── registry.yaml  # Single source of truth for globals
-└── bootstrap.sh   # Symlinks spellbook → harness dirs
+├── registry.yaml  # External skill sources (for embeddings)
+└── bootstrap.sh   # Discovers skills/agents from filesystem, symlinks to harness dirs
 ```
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ spellbook/
 ├── agents/        # 7 agent definitions
 ├── harnesses/     # Per-harness configs (claude/, codex/, pi/)
 │   └── shared/    # Common engineering principles
-├── registry.yaml  # Single source of truth
-└── bootstrap.sh   # Symlinks spellbook → harness dirs
+├── registry.yaml  # External skill sources (for embeddings)
+└── bootstrap.sh   # Discovers skills/agents from filesystem, symlinks to harness dirs
 ```
 
 ## Adding a Skill
@@ -53,7 +53,7 @@ spellbook/
 1. Create `skills/{name}/SKILL.md` with frontmatter
 2. Keep it < 500 lines. Encode judgment, not procedures.
 3. Run `/harness lint` to validate quality gates
-4. Commit — pre-commit hook regenerates index.yaml
+4. Run `bootstrap.sh` — it discovers skills from the filesystem automatically
 
 ## Principles
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,7 @@ err()   { printf '\033[0;31m%s\033[0m\n' "$*" >&2; }
 
 is_spellbook_checkout() {
   local dir="$1"
-  [ -d "$dir/skills" ] && [ -d "$dir/agents" ] && [ -d "$dir/harnesses" ] && [ -f "$dir/registry.yaml" ]
+  [ -d "$dir/skills" ] && [ -d "$dir/agents" ] && [ -d "$dir/harnesses" ]
 }
 
 resolve_spellbook_dir() {
@@ -243,88 +243,57 @@ verify_no_broken_spellbook_symlinks() {
   return "$broken"
 }
 
-parse_registry_file() {
-  local registry_file="$1"
-  local output_file="$2"
+discover_local() {
+  local skill agent
+  GLOBAL_SKILLS=()
+  GLOBAL_AGENTS=()
 
-  python3 - "$registry_file" > "$output_file" <<'PY'
-import re
-import sys
-from pathlib import Path
+  for skill in "$SPELLBOOK"/skills/*/SKILL.md; do
+    [ -f "$skill" ] || continue
+    GLOBAL_SKILLS+=("$(basename "$(dirname "$skill")")")
+  done
 
-lines = Path(sys.argv[1]).read_text().splitlines()
+  for agent in "$SPELLBOOK"/agents/*.md; do
+    [ -f "$agent" ] || continue
+    GLOBAL_AGENTS+=("$(basename "$agent" .md)")
+  done
+}
 
-def extract(lines, path):
-    depth = 0
-    target_indent = [None] * len(path)
-    items = []
-    capturing = False
+discover_remote() {
+  GLOBAL_SKILLS=()
+  GLOBAL_AGENTS=()
 
-    for line in lines:
-        if not line.strip() or line.lstrip().startswith('#'):
-            continue
+  local names
+  names=$(curl -sf "https://api.github.com/repos/$REPO/contents/skills" | \
+    python3 -c "import sys,json; [print(d['name']) for d in json.load(sys.stdin) if d['type']=='dir']" 2>/dev/null) \
+    || { err "Failed to list remote skills"; exit 1; }
+  while IFS= read -r name; do
+    [ -n "$name" ] && GLOBAL_SKILLS+=("$name")
+  done <<< "$names"
 
-        indent = len(line) - len(line.lstrip())
-        stripped = line.strip()
-
-        if depth < len(path):
-            if stripped.startswith(path[depth] + ':'):
-                target_indent[depth] = indent
-                depth += 1
-                if depth == len(path):
-                    capturing = True
-                    rest = stripped[len(path[-1]) + 1:].strip()
-                    if rest.startswith('[') and rest.endswith(']'):
-                        items = [value.strip() for value in rest[1:-1].split(',') if value.strip()]
-                        break
-                continue
-        elif capturing:
-            if indent <= target_indent[-1]:
-                break
-            if stripped.startswith('- '):
-                items.append(stripped[2:].strip())
-
-    return items
-
-custom = extract(lines, ['global', 'skills', 'custom_install'])
-standard = extract(lines, ['global', 'skills', 'standard'])
-agents = extract(lines, ['global', 'agents'])
-
-safe = re.compile(r'^[a-z0-9-]+$')
-for name in custom + standard + agents:
-    if not safe.match(name):
-        print(f"INVALID: {name}", file=sys.stderr)
-        sys.exit(1)
-
-print('CUSTOM_INSTALL=(' + ' '.join(custom) + ')')
-print('GLOBAL_SKILLS=(' + ' '.join(standard) + ')')
-print('GLOBAL_AGENTS=(' + ' '.join(agents) + ')')
-PY
+  names=$(curl -sf "https://api.github.com/repos/$REPO/contents/agents" | \
+    python3 -c "import sys,json; [print(f['name'].removesuffix('.md')) for f in json.load(sys.stdin) if f['name'].endswith('.md')]" 2>/dev/null) \
+    || { err "Failed to list remote agents"; exit 1; }
+  while IFS= read -r name; do
+    [ -n "$name" ] && GLOBAL_AGENTS+=("$name")
+  done <<< "$names"
 }
 
 SPELLBOOK="$(resolve_spellbook_dir || true)"
-TEMP_REGISTRY=""
-PARSED="$(mktemp)"
-trap 'rm -f "$PARSED" ${TEMP_REGISTRY:+"$TEMP_REGISTRY"}' EXIT
 
 if [ -n "$SPELLBOOK" ]; then
-  REGISTRY_FILE="$SPELLBOOK/registry.yaml"
+  discover_local
 else
-  TEMP_REGISTRY="$(mktemp)"
-  curl -sfL "$RAW/registry.yaml" -o "$TEMP_REGISTRY" || { err "Failed to fetch registry.yaml"; exit 1; }
-  REGISTRY_FILE="$TEMP_REGISTRY"
+  discover_remote
 fi
 
-parse_registry_file "$REGISTRY_FILE" "$PARSED" || { err "Failed to parse registry.yaml"; exit 1; }
-source "$PARSED"
-
-if [ ${#GLOBAL_SKILLS[@]} -eq 0 ] && [ ${#CUSTOM_INSTALL[@]} -eq 0 ]; then
-  err "No global skills found in registry.yaml"
+if [ ${#GLOBAL_SKILLS[@]} -eq 0 ]; then
+  err "No skills found"
   exit 1
 fi
 
 if [ ${#GLOBAL_AGENTS[@]} -eq 0 ]; then
-  err "No global agents found in registry.yaml"
+  err "No agents found"
   exit 1
 fi
 
@@ -333,7 +302,7 @@ link_local() {
   local harness_dir="$2"    # e.g. "$HOME/.claude"
   local skills_dir="$harness_dir/skills"
   local agents_dir="$harness_dir/agents"
-  local skill_names=("${CUSTOM_INSTALL[@]}" "${GLOBAL_SKILLS[@]}")
+  local skill_names=("${GLOBAL_SKILLS[@]}")
   local agent_files=()
   local skill agent src
 
@@ -430,7 +399,7 @@ install_remote() {
   local skills_dir="$1"
   local agents_dir="$2"
 
-  for skill in "${CUSTOM_INSTALL[@]}" "${GLOBAL_SKILLS[@]}"; do
+  for skill in "${GLOBAL_SKILLS[@]}"; do
     download_skill "$skills_dir" "$skill"
   done
 
@@ -490,8 +459,8 @@ fi
 
 ok "Done. Installed to $installed harness(es)."
 echo
-info "Global skills (${#CUSTOM_INSTALL[@]} + ${#GLOBAL_SKILLS[@]}): ${CUSTOM_INSTALL[*]} ${GLOBAL_SKILLS[*]}"
-info "Global agents (${#GLOBAL_AGENTS[@]}): ${GLOBAL_AGENTS[*]}"
+info "Skills (${#GLOBAL_SKILLS[@]}): ${GLOBAL_SKILLS[*]}"
+info "Agents (${#GLOBAL_AGENTS[@]}): ${GLOBAL_AGENTS[*]}"
 echo
 if [ -n "$SPELLBOOK" ]; then
   info "Mode: symlink (edits in $SPELLBOOK propagate instantly)"

--- a/registry.yaml
+++ b/registry.yaml
@@ -1,32 +1,9 @@
-# Spellbook Registry — single source of truth for primitive metadata.
+# Spellbook Registry — external skill sources for embeddings and on-demand pull.
 #
-# Consumed by: bootstrap.sh, /harness, generate-embeddings.py
-# Do NOT duplicate this metadata elsewhere.
-
-global:
-  # Workflow skills: installed by bootstrap.sh, always available.
-  skills:
-    custom_install:
-      - research
-    standard:
-      - autopilot
-      - code-review
-      - debug
-      - groom
-      - harness
-      - reflect
-      - shape
-
-  # Agent bench: installed by bootstrap.sh, always available.
-  # GAN triad (planner/builder/critic) + design philosophy reviewers.
-  agents:
-    - planner
-    - builder
-    - critic
-    - beck
-    - carmack
-    - grug
-    - ousterhout
+# Skills and agents are discovered from the filesystem (skills/*/SKILL.md,
+# agents/*.md). This file only lists third-party sources.
+#
+# Consumed by: generate-embeddings.py
 
 # External skill sources for domain skills (pulled on demand, not managed by us).
 sources:


### PR DESCRIPTION
## Summary
- **bootstrap.sh** now globs `skills/*/SKILL.md` and `agents/*.md` instead of parsing skill/agent lists from `registry.yaml` — eliminates sync drift (e.g. `settle` existed in `skills/` but wasn't registered)
- **registry.yaml** trimmed to just the `sources:` block (only consumer: `generate-embeddings.py`)
- Net: -105 lines, +51 lines. Deleted the 60-line embedded Python YAML parser

## Test plan
- [x] `bash -n bootstrap.sh` passes syntax check
- [x] `bootstrap.sh` local mode installs all 9 skills + 7 agents (including previously missing `settle`)
- [ ] Verify remote mode still works (GitHub API directory listing)
- [ ] `generate-embeddings.py` still reads `sources:` from trimmed registry.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills and agents are now automatically discovered from the filesystem, eliminating the need for manual registry updates.

* **Changes**
  * Simplified registry configuration to focus exclusively on external sources.
  * Updated skill addition workflow to leverage automatic discovery during initialization.

* **Documentation**
  * Updated repository structure and skill addition workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->