### PR TITLE
feat(skills): add /qa, /demo, /agent-readiness + composable skill architecture

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Re-link skills/agents after commit when skill content changes.
+# Covers the "create new skill, commit, it should appear" case.
+# Bootstrap is fast (<1s) and idempotent.
+
+skill_changed() {
+  git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -q 'skills/\|agents/'
+}
+
+skill_changed || exit 0
+
+echo "[post-commit] Skill/agent content changed — re-linking"
+./bootstrap.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,17 @@
 
 ## What This Repo Is
 
-**Spellbook** — 8 workflow skills, 7 agents, and harness configs for
-AI-assisted development. One repo, all harnesses, symlinked to
-~/.claude, ~/.codex, ~/.pi via bootstrap.sh.
+**Spellbook** — focused workflow skills, specialized agents, and harness
+configs for AI-assisted development. One repo, all harnesses, symlinked
+to ~/.claude, ~/.codex, ~/.pi via bootstrap.sh.
 
 ## Structure
 
 ```
 spellbook/
-├── skills/        # 8 skills: autopilot, code-review, debug, groom,
-│                  #   harness, reflect, research, shape
-├── agents/        # 7 agents: planner, builder, critic,
+├── skills/        # Leaf skills (qa, demo, debug, research, ...) and
+│                  #   orchestrators (autopilot, code-review, settle, ...)
+├── agents/        # Specialized agents: planner, builder, critic,
 │                  #   ousterhout, carmack, grug, beck
 ├── harnesses/     # Per-harness configs, hooks, shared principles
 ├── registry.yaml  # External skill sources (for embeddings)
@@ -29,7 +29,7 @@ backlog.d/ → /groom → /shape (planner) → /autopilot (builder) → /code-re
 
 See `harnesses/shared/principles.md` for engineering doctrine.
 
-- **8 skills, 7 agents** — resist expansion
+- **Focused set of skills and agents** — resist bloat, justify additions
 - **Harness is the product** — models are commodities
 - **Gotchas > instructions** — enumerate what goes wrong
 - **Description is the trigger** — write it assertively

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -297,44 +297,82 @@ if [ ${#GLOBAL_AGENTS[@]} -eq 0 ]; then
   exit 1
 fi
 
+link_parent_dir() {
+  local src="$1"
+  local dest="$2"
+  local label="$3"
+
+  if [ -L "$dest" ]; then
+    local current
+    current="$(readlink "$dest")"
+    if [ "$current" = "$src" ]; then
+      ok "    $label (already linked)"
+      return 0
+    fi
+    # Stale symlink to different location — replace
+    rm -f "$dest"
+  elif [ -d "$dest" ]; then
+    # Migrate from per-entry symlinks to parent symlink.
+    # Remove spellbook-managed symlinks; warn about non-symlink entries.
+    local has_non_symlink=0
+    local entry target
+    for entry in "$dest"/*; do
+      [ -e "$entry" ] || [ -L "$entry" ] || continue
+      if [ -L "$entry" ]; then
+        target="$(readlink "$entry" || true)"
+        case "$target" in
+          "$src"/*|"$SPELLBOOK"/*) rm -f "$entry" ;;
+          *) has_non_symlink=1 ;;
+        esac
+      else
+        has_non_symlink=1
+      fi
+    done
+    if [ "$has_non_symlink" -eq 1 ]; then
+      warn "    $label: non-spellbook entries exist, keeping per-entry links"
+      return 1
+    fi
+    rmdir "$dest" 2>/dev/null || { warn "    $label: dir not empty after cleanup"; return 1; }
+  fi
+
+  ln -sfn "$src" "$dest"
+  ok "    $label → $src"
+}
+
 link_local() {
   local harness="$1"        # e.g. "claude"
   local harness_dir="$2"    # e.g. "$HOME/.claude"
   local skills_dir="$harness_dir/skills"
   local agents_dir="$harness_dir/agents"
-  local skill_names=("${GLOBAL_SKILLS[@]}")
-  local agent_files=()
-  local skill agent src
-
-  for agent in "${GLOBAL_AGENTS[@]}"; do
-    agent_files+=("$agent.md")
-  done
 
   info "  Linking skills..."
-  cleanup_symlinks_under_prefix "$skills_dir" "$SPELLBOOK/skills" "${skill_names[@]}"
-  mkdir -p "$skills_dir"
-  for skill in "${skill_names[@]}"; do
-    src="$SPELLBOOK/skills/$skill"
-    if [ ! -d "$src" ]; then
-      warn "    missing local skill: $skill"
-      continue
-    fi
-    ln -sfn "$src" "$skills_dir/$skill"
-    ok "    $skill"
-  done
+  if ! link_parent_dir "$SPELLBOOK/skills" "$skills_dir" "skills/"; then
+    # Fallback: per-skill symlinks (when non-spellbook entries exist)
+    local skill src
+    local skill_names=("${GLOBAL_SKILLS[@]}")
+    cleanup_symlinks_under_prefix "$skills_dir" "$SPELLBOOK/skills" "${skill_names[@]}"
+    for skill in "${skill_names[@]}"; do
+      src="$SPELLBOOK/skills/$skill"
+      [ -d "$src" ] || { warn "    missing local skill: $skill"; continue; }
+      ln -sfn "$src" "$skills_dir/$skill"
+      ok "    $skill"
+    done
+  fi
 
   info "  Linking agents..."
-  cleanup_symlinks_under_prefix "$agents_dir" "$SPELLBOOK/agents" "${agent_files[@]}"
-  mkdir -p "$agents_dir"
-  for agent in "${GLOBAL_AGENTS[@]}"; do
-    src="$SPELLBOOK/agents/$agent.md"
-    if [ ! -f "$src" ]; then
-      warn "    missing local agent: $agent"
-      continue
-    fi
-    ln -sfn "$src" "$agents_dir/$agent.md"
-    ok "    $agent"
-  done
+  if ! link_parent_dir "$SPELLBOOK/agents" "$agents_dir" "agents/"; then
+    # Fallback: per-agent symlinks
+    local agent src
+    local agent_files=()
+    for agent in "${GLOBAL_AGENTS[@]}"; do agent_files+=("$agent.md"); done
+    cleanup_symlinks_under_prefix "$agents_dir" "$SPELLBOOK/agents" "${agent_files[@]}"
+    for agent in "${GLOBAL_AGENTS[@]}"; do
+      src="$SPELLBOOK/agents/$agent.md"
+      [ -f "$src" ] || { warn "    missing local agent: $agent"; continue; }
+      ln -sfn "$src" "$agents_dir/$agent.md"
+      ok "    $agent"
+    done
+  fi
 
   # Link harness-specific configs if they exist
   local harness_config="$SPELLBOOK/harnesses/$harness"

--- a/index.yaml
+++ b/index.yaml
@@ -1,8 +1,11 @@
 # Spellbook Index
-# Generated: 2026-03-27T00:29:16Z
+# Generated: 2026-03-27T15:14:26Z
 # Do not edit manually. Run: ./scripts/generate-index.sh
 
 skills:
+  - name: agent-readiness
+    description: "Assess and improve codebase readiness for AI coding agents. Dispatches parallel subagents to evaluate style, testing, docs, architecture, CI, observability, security, and dev environment. Produces a s"
+    tags: [a,agents,ai,architecture,assess,ci,codebase,coding,dev,dispatches]
   - name: autopilot
     description: "Full delivery pipeline: plan→build→review→ship. Reads highest-priority backlog item, shapes it, builds it via TDD, runs parallel code review, iterates until clean, ships. Use when: shipping features, "
     tags: [backlog,build,builds,clean,code,delivery,features,full,highest-priority,it]
@@ -12,18 +15,27 @@ skills:
   - name: debug
     description: "Investigate, audit, triage, and fix. Systematic debugging, incident lifecycle, domain auditing, and issue logging. Four-phase protocol: root cause → pattern analysis → hypothesis test → fix. Use for: "
     tags: [analysis,audit,auditing,cause,debugging,domain,fix,four-phase,hypothesis,incident]
+  - name: demo
+    description: "Generate demo artifacts: screenshots, GIF walkthroughs, video recordings, polished launch videos with narration and music. From raw evidence to shipped media. Also handles PR evidence upload via draft"
+    tags: [also,artifacts,demo,draft,evidence,generate,gif,handles,launch,media]
   - name: groom
     description: "Backlog management, brainstorming, architectural exploration, project bootstrapping. File-driven backlog via backlog.d/. Explore, brainstorm, research, synthesize, prioritize. Includes divergent think"
     tags: [architectural,backlog,bootstrapping,brainstorm,brainstorming,d,divergent,exploration,explore,file-driven]
   - name: harness
     description: "Build, maintain, evaluate, and optimize the agent harness — skills, agents, hooks, CLAUDE.md, AGENTS.md, and enforcement infrastructure. Use when: \"create a skill\", \"update skill\", \"improve the harnes"
     tags: [a,agent,agents,build,claude,create,enforcement,evaluate,harnes,harness]
+  - name: qa
+    description: "Browser-based QA, exploratory testing, evidence capture, and bug reporting. Drive running applications and verify they work — not just that tests pass. Use when: \"run QA\", \"test this\", \"verify the fea"
+    tags: [applications,browser-based,bug,capture,drive,evidence,exploratory,fea,just,pass]
   - name: reflect
     description: "Session retrospective, learning extraction, harness postmortem, codification. Distill learnings into hooks/rules/skills. Fix the system, not the instance. Use when: \"done\", \"wrap up\", \"what did we lea"
     tags: [codification,did,distill,done,extraction,fix,harness,hooks,instance,lea]
   - name: research
     description: "Web research, multi-AI delegation, and multi-perspective validation. /research [query], /research delegate [task], /research thinktank [topic]. Triggers: \"search for\", \"look up\", \"research\", \"delegate"
     tags: [delegate,delegation,look,multi-ai,multi-perspective,query,research,search,task,thinktank]
+  - name: settle
+    description: "Unblock, polish, and simplify a PR until it's genuinely merge-ready. Three phases: fix (CI/conflicts/reviews), polish (architecture/tests/docs), simplify (complexity reduction). Runs all three in sequ"
+    tags: [a,architecture,ci,complexity,conflicts,docs,fix,genuinely,in,it]
   - name: shape
     description: "Shape a raw idea into something buildable. Product + technical exploration. Spec, design, critique, plan. Output is a context packet. Use when: \"shape this\", \"write a spec\", \"design this feature\", \"pl"
     tags: [a,buildable,context,critique,design,exploration,feature,idea,is,output]

--- a/skills/agent-readiness/SKILL.md
+++ b/skills/agent-readiness/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: agent-readiness
+description: |
+  Assess and improve codebase readiness for AI coding agents. Dispatches
+  parallel subagents to evaluate style, testing, docs, architecture, CI,
+  observability, security, and dev environment. Produces a scored report
+  with prioritized remediation. Then executes the highest-impact fixes.
+  Use when: "agent readiness", "is this codebase agent-ready",
+  "readiness report", "make this codebase agent-friendly",
+  "agent-ready assessment", "readiness audit", "prepare for agents".
+  Trigger: /agent-readiness, /readiness.
+argument-hint: "[--assess-only] [--fix] [--pillar <name>]"
+---
+
+# /agent-readiness
+
+Assess how well this codebase supports autonomous AI coding agents.
+Then fix the highest-impact gaps.
+
+**Target:** $ARGUMENTS
+
+## Core Insight
+
+The agent is not broken. The environment is. A codebase with fast feedback
+loops and clear instructions makes any agent dramatically more effective.
+A codebase with poor feedback loops defeats any agent you throw at it.
+
+## Workflow
+
+### Phase 1: Assess
+
+Dispatch **parallel subagents** — one per pillar — to evaluate the codebase.
+Each subagent runs the checks from `references/pillar-checks.md` for its
+assigned pillar and returns a structured verdict.
+
+Launch all pillar assessments simultaneously:
+
+| Subagent | Pillar | What it checks |
+|----------|--------|---------------|
+| 1 | Style & Validation | Linters, formatters, type checkers, pre-commit hooks |
+| 2 | Build & CI | Build commands, dependency pinning, CI config, feedback speed |
+| 3 | Testing | Coverage, speed, local execution, unit/integration/E2E layers |
+| 4 | Documentation | CLAUDE.md/AGENTS.md, README, setup guide, architecture docs, ADRs |
+| 5 | Dev Environment | Reproducibility, env templates, devcontainers, isolated workspaces |
+| 6 | Code Quality | Modularity, complexity, file organization, coupling, dead code |
+| 7 | Observability | Structured logging, error handling, metrics, tracing |
+| 8 | Security & Governance | Branch protection, CODEOWNERS, secret scanning, dependency audit |
+
+Each subagent uses **Explore** agent type and reads `references/pillar-checks.md`
+for its pillar's specific pass/fail criteria. Output format per subagent:
+
+```markdown
+## [Pillar Name]
+Score: X/Y checks passed
+Maturity: L1-L5
+
+### Passing
+- [check]: [evidence]
+
+### Failing
+- [check]: [what's missing] → [recommended fix]
+
+### Highest-Impact Fix
+[The single change that would most improve this pillar]
+```
+
+### Phase 2: Report
+
+Synthesize subagent results into a single readiness report:
+
+```markdown
+# Agent Readiness Report: [project-name]
+
+## Overall: Level X — [Maturity Name] (XX%)
+
+| Pillar | Score | Level | Top Fix |
+|--------|-------|-------|---------|
+| Style & Validation | 4/6 | L3 | Add pre-commit hooks |
+| Testing | 2/7 | L1 | Add unit test runner |
+| ... | ... | ... | ... |
+
+## Maturity Levels
+- L1 Functional: Code runs, but agents need hand-holding
+- L2 Documented: Processes written down, some automation
+- L3 Standardized: Enforced automation, agents handle routine work
+- L4 Optimized: Fast feedback, data-driven improvement
+- L5 Autonomous: Self-improving, sophisticated orchestration
+
+## Top 5 Recommendations (by impact)
+1. [highest impact fix across all pillars]
+2. ...
+
+## Detailed Findings
+[per-pillar sections from subagents]
+```
+
+**Maturity level is gated:** must pass 80% of criteria at current level
+and all previous levels before advancing. This prevents cherry-picking.
+
+### Phase 3: Clarify
+
+Present the report and top 5 recommendations to the user. Ask:
+
+1. Which recommendations should we execute now?
+2. Any pillars to skip or deprioritize?
+3. Any constraints (don't change CI provider, keep current test framework, etc.)?
+
+**One question at a time.** Don't dump all three at once.
+
+### Phase 4: Fix
+
+For each approved recommendation, spawn a **builder** subagent (or use
+worktrees for parallel fixes on disjoint files). Each fix follows the
+project's existing patterns — don't introduce new tools the team hasn't
+chosen.
+
+Typical fix categories:
+
+| Fix type | Example | Subagent approach |
+|----------|---------|-------------------|
+| Config addition | Add `.editorconfig`, pre-commit hooks | Single builder, quick |
+| Documentation | Create/update CLAUDE.md, AGENTS.md | Single builder |
+| Test infrastructure | Add test runner, coverage config | Builder + TDD cycle |
+| CI enhancement | Add lint/typecheck/test to CI | Single builder, verify locally |
+| Architecture doc | Create ADR, architecture overview | Builder reads codebase first |
+| Security hardening | Add CODEOWNERS, branch protection | Builder + gh CLI |
+
+After fixes: re-run the failing checks to verify improvement. Report
+the before/after delta.
+
+### Phase 5: Re-assess (optional)
+
+If `--fix` was used, re-run the full assessment to show the improved score.
+Present the before/after comparison.
+
+## Routing
+
+| Argument | Behavior |
+|----------|----------|
+| (none) | Full assess → report → clarify → fix cycle |
+| `--assess-only` | Assess and report only, no fixes |
+| `--fix` | Skip clarification, fix all top 5 recommendations |
+| `--pillar <name>` | Assess only the named pillar |
+
+## Pillar Check Reference
+
+All specific checks are in `references/pillar-checks.md`. Each check is:
+- **Binary**: pass or fail (no subjective scoring)
+- **Evidence-based**: the subagent must cite the file/config/output that proves pass/fail
+- **Actionable**: every failing check has a concrete remediation
+
+See `references/agent-readiness-principles.md` for the deeper "why" behind
+each pillar — useful when explaining recommendations to the user.
+
+## Gotchas
+
+- **Scoring without fixing is theater.** The report is only useful if it
+  leads to action. Always push toward Phase 4.
+- **Don't introduce tools the team hasn't chosen.** If they use Jest, don't
+  suggest Vitest. If they use ESLint, don't add Biome. Work within existing
+  choices.
+- **Pre-commit hooks are the highest-leverage single fix** for most codebases.
+  They give agents instant feedback instead of waiting for CI.
+- **CLAUDE.md/AGENTS.md is the highest-leverage documentation fix.** It's the
+  file agents actually read. A perfect README that agents ignore is worth less
+  than a scrappy CLAUDE.md they always load.
+- **Don't conflate coverage percentage with test quality.** 80% coverage with
+  shallow tests is worse than 50% coverage with behavior-focused tests.
+  Check for assertion density, not just line coverage.
+- **Monorepos need per-app assessment.** A monorepo score is the floor of
+  its worst app, not the average.
+- **Speed matters as much as existence.** A test suite that takes 20 minutes
+  is nearly as bad as no tests for agent workflows. Measure execution time.
+- **The codebase is the product, not the agent.** Every fix here improves
+  the experience for ALL agents and ALL developers, not just one tool.

--- a/skills/agent-readiness/references/agent-readiness-principles.md
+++ b/skills/agent-readiness/references/agent-readiness-principles.md
@@ -1,0 +1,164 @@
+# Agent-Readiness Principles
+
+The deeper "why" behind each pillar. Use this when explaining recommendations
+to the user or when a subagent needs to prioritize between competing fixes.
+
+## The Core Thesis
+
+"The agent is not broken. The environment is." — Factory AI
+
+Agent effectiveness is bounded by three things:
+1. **Environment** — the agent can use the system autonomously
+2. **Intent** — the agent understands what you want and why
+3. **Feedback loops** — the agent can verify its own work, fast
+
+Every pillar maps to one or more of these. Fixes that improve feedback loops
+have the highest ROI because they compound across every agent interaction.
+
+Source: [Christian Houmann, "The agent-ready codebase"](https://bagerbach.com/blog/agent-ready-codebase)
+
+## Why Each Pillar Matters
+
+### Style & Validation → Feedback Loops
+
+Without linters and formatters, agents waste cycles on style drift. They
+submit code, wait for CI, get style failures, fix blindly, repeat. Pre-commit
+hooks give instant feedback — seconds instead of minutes. This is often the
+single highest-leverage fix.
+
+**Factory's observation:** "Missing pre-commit hooks mean the agent waits
+ten minutes for CI feedback instead of five seconds."
+
+Lint rules also encode architectural intent. Named exports, explicit DTOs,
+predictable file naming, and import restrictions teach agents your conventions
+through enforcement rather than documentation.
+
+Source: [Factory AI, "Using Linters to Direct Agents"](https://factory.ai/news/using-linters-to-direct-agents)
+
+### Build & CI → Feedback Loops + Environment
+
+Deterministic builds ensure the agent can verify its work. If the build
+requires tribal knowledge from Slack threads, the agent has no idea how to
+verify. A single build command that works on clone is table stakes.
+
+CI speed matters as much as CI existence. A pipeline that takes 20 minutes
+is nearly as bad as no pipeline for agent workflows. The agent can't iterate
+if each cycle takes 20 minutes.
+
+### Testing → Feedback Loops
+
+Testing is the single biggest lever for agent output quality. With tests,
+the agent has an oracle: change code, run tests, see if it broke something.
+Without tests, the agent is flying blind.
+
+**Key insight:** Coverage percentage matters less than assertion density and
+behavior coverage. 80% line coverage with shallow tests (`expect(true)`) is
+worse than 50% coverage with real assertions. The agent needs tests that
+actually catch regressions.
+
+**Speed matters:** If the suite takes 20 minutes, the agent can't do TDD.
+Target <5 minutes for the full local suite. For larger suites, make it easy
+to run a subset.
+
+Source: [Damian Galarza, "Four Dimensions of Agent-Ready Codebase Design"](https://www.damiangalarza.com/posts/2026-03-25-four-patterns-that-separate-agent-ready-codebases/)
+
+### Documentation → Intent
+
+CLAUDE.md and AGENTS.md are the most important files for agent effectiveness.
+They are loaded into context at startup. A perfect README that agents don't
+read is worth less than a scrappy CLAUDE.md they always load.
+
+What to document for agents:
+- How to build, test, lint, deploy
+- Architectural conventions and why they exist
+- Common gotchas and failure modes
+- Environment variables and their purpose
+- Style guide and naming conventions
+
+Architecture Decision Records (ADRs) help agents understand WHY choices
+were made, not just WHAT the code does. This prevents agents from
+"improving" things that are intentionally designed that way.
+
+### Dev Environment → Environment
+
+"Could you launch a hundred agents in your codebase right now? If not,
+figure out what's stopping you. It's a bottleneck in your factory."
+
+Reproducible environments eliminate "works on my machine." Devcontainers,
+Docker Compose, and setup scripts ensure agents (and new developers) can
+go from clone to running in one command.
+
+Isolated workspaces (git worktrees, multiple checkouts) let multiple agents
+work in parallel without stepping on each other.
+
+Source: [Christian Houmann, "The agent-ready codebase"](https://bagerbach.com/blog/agent-ready-codebase)
+
+### Code Quality & Architecture → Intent + Feedback Loops
+
+Modular code with clear interfaces lets agents work on one piece without
+understanding the whole system. Deep modules (complex internals, simple
+interfaces) are ideal — the agent interacts through the simple interface
+and doesn't need to understand the internals.
+
+Large files, circular dependencies, and god classes force agents to load
+massive context to make any change. Keep files focused. Keep coupling low.
+Keep the blast radius of any change small.
+
+File organization should be predictable. An agent should be able to guess
+where a file lives based on its purpose. Feature-based organization
+(`features/auth/`, `features/billing/`) is more agent-friendly than
+type-based organization (`controllers/`, `models/`, `services/`).
+
+### Observability → Feedback Loops
+
+Agents need to diagnose failures, not just detect them. Structured logging,
+error tracking, and health checks let agents understand what went wrong
+after a change. Without observability, a failing deployment is a black box.
+
+Give agents read access to telemetry. If they can query logs and metrics,
+they can self-diagnose and self-correct.
+
+### Security & Governance → Environment + Guardrails
+
+Branch protection, CODEOWNERS, and review gates are guardrails that prevent
+agents from shipping bad changes. They're not obstacles — they're safety nets.
+
+Secret scanning prevents agents from accidentally committing credentials.
+Dependency auditing prevents agents from introducing vulnerable dependencies.
+
+## Maturity Level Philosophy
+
+Levels are gated, not averaged. A codebase at L3 has solid foundations
+(L1-L2) plus standardized automation. Skipping foundations to chase
+advanced features creates a hollow score.
+
+**L3 is the target for most teams.** It represents the minimum bar for
+agents to handle routine maintenance autonomously: bug fixes, tests, docs,
+dependency upgrades.
+
+| Level | What agents can do |
+|-------|-------------------|
+| L1 | Agent needs constant hand-holding. Every change requires human verification. |
+| L2 | Agent can make changes but needs human to verify and integrate. |
+| L3 | Agent handles routine maintenance: bugs, tests, docs, deps. |
+| L4 | Agent handles feature work with fast iteration cycles. |
+| L5 | Agent handles complex tasks with minimal human oversight. |
+
+## Prioritization Framework
+
+When recommending fixes, prioritize by:
+
+1. **Feedback loop speed** — pre-commit hooks, fast tests, local-first CI
+2. **Agent context** — CLAUDE.md, architecture docs, env var documentation
+3. **Verification ability** — test coverage, type safety, lint rules
+4. **Environment access** — reproducible setup, isolated workspaces
+5. **Governance** — branch protection, code owners, secret scanning
+
+The first three categories account for ~80% of agent effectiveness improvement.
+
+## Reference Implementations
+
+Open-source tools for automated assessment:
+- **Kodus agent-readiness**: `npx @kodus/agent-readiness .` — 39 checks, 7 pillars, TypeScript, MIT
+- **AgentReady**: `pip install agentready` — Python, research-backed, HTML reports
+- **AIReady**: `getaiready.dev` — web-based scanning with cognitive load analysis

--- a/skills/agent-readiness/references/pillar-checks.md
+++ b/skills/agent-readiness/references/pillar-checks.md
@@ -1,0 +1,232 @@
+# Pillar Checks
+
+Binary pass/fail checks for each pillar. Every check must cite evidence
+(file path, config value, command output). Organized by maturity level —
+L1 checks are foundational, L5 checks are aspirational.
+
+Subagents: read YOUR pillar's section. Run every check. Report pass/fail
+with evidence.
+
+---
+
+## 1. Style & Validation
+
+### L1 — Foundational
+- **Linter configured**: `.eslintrc*`, `biome.json`, `.rubocop.yml`, `pyproject.toml [tool.ruff]`, or equivalent exists
+- **Formatter configured**: `prettier`, `black`, `gofmt`, `rustfmt`, or equivalent configured
+- **Type checker enabled**: `tsconfig.json` with `strict: true`, `mypy.ini`, `pyright`, or language-native types
+
+### L2 — Documented
+- **Pre-commit hooks**: `.husky/`, `.pre-commit-config.yaml`, `lefthook.yml`, or lint-staged configured
+- **Lint runs in CI**: CI config runs linter and fails on violations
+- **Editor config**: `.editorconfig` exists for cross-editor consistency
+
+### L3 — Standardized
+- **Zero lint warnings policy**: CI fails on warnings, not just errors
+- **Type coverage >80%**: For gradually-typed languages (TS, Python), most code is typed
+- **Auto-fix on save/commit**: Formatter runs automatically, not manually
+
+### L4 — Optimized
+- **Custom lint rules**: Project-specific rules encoding architectural boundaries
+- **Lint rule for agent patterns**: Named exports, explicit DTOs, predictable file naming
+
+### L5 — Autonomous
+- **Self-healing lint**: Agent can add/fix lint rules based on recurring violations
+
+---
+
+## 2. Build & CI
+
+### L1 — Foundational
+- **Build command exists**: `package.json` scripts, `Makefile`, `Cargo.toml`, or equivalent
+- **CI config exists**: `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, etc.
+- **Dependencies pinned**: Lockfile exists (`package-lock.json`, `yarn.lock`, `Cargo.lock`, `poetry.lock`)
+
+### L2 — Documented
+- **Build documented**: README or CLAUDE.md explains how to build
+- **CI runs on PRs**: CI triggers on pull request events
+- **Single build command**: One command builds the whole project (no multi-step dance)
+
+### L3 — Standardized
+- **CI runs lint + typecheck + test**: All three verification layers in CI
+- **CI fails fast**: Lint/typecheck before tests (fail in seconds, not minutes)
+- **Dependency vulnerability scanning**: `npm audit`, `pip-audit`, Dependabot, or equivalent
+
+### L4 — Optimized
+- **CI <5 minutes**: Total CI pipeline completes in under 5 minutes
+- **Parallel CI jobs**: Lint, typecheck, test run in parallel
+- **Build caching**: Turbo, nx, or CI-level caching for incremental builds
+
+### L5 — Autonomous
+- **CI auto-fixes**: Bot auto-fixes lint/format violations via PR
+- **Flaky test detection**: CI tracks and quarantines flaky tests automatically
+
+---
+
+## 3. Testing
+
+### L1 — Foundational
+- **Test runner configured**: Jest, Vitest, pytest, go test, cargo test, or equivalent
+- **At least one test exists**: Any test file that passes
+- **Tests run locally**: `npm test` or equivalent works without external dependencies
+
+### L2 — Documented
+- **Test command documented**: README or CLAUDE.md explains how to run tests
+- **Test directory structure**: Tests in `__tests__/`, `tests/`, `*_test.go`, or co-located
+- **Coverage tool configured**: Coverage reporting set up (even if threshold is low)
+
+### L3 — Standardized
+- **Coverage >60%**: Line or branch coverage above 60%
+- **Integration tests exist**: Tests that exercise multiple modules together
+- **Tests run in CI**: CI runs the full test suite and fails on failure
+
+### L4 — Optimized
+- **Coverage >80%**: Line or branch coverage above 80%
+- **Test suite <5 minutes**: Full suite completes locally in under 5 minutes
+- **E2E tests exist**: End-to-end tests for critical user flows
+- **Coverage enforced**: CI fails if coverage drops below threshold
+
+### L5 — Autonomous
+- **Mutation testing**: Tools like Stryker or mutmut to verify test quality
+- **Test generation**: Agent can generate meaningful tests, not just coverage padding
+- **Visual regression tests**: Screenshot comparison for UI components
+
+---
+
+## 4. Documentation
+
+### L1 — Foundational
+- **README exists**: `README.md` with project description
+- **Setup instructions**: How to install dependencies and run the project
+- **License file**: `LICENSE` or `LICENSE.md`
+
+### L2 — Documented
+- **CLAUDE.md or AGENTS.md exists**: Agent-specific instructions, conventions, gotchas
+- **Architecture overview**: High-level description of system structure (even a paragraph)
+- **API documented**: For libraries/services, public API is documented
+
+### L3 — Standardized
+- **Contributing guide**: `CONTRIBUTING.md` with PR process, style expectations
+- **Environment variables documented**: All required env vars listed with descriptions
+- **Commands cheat sheet**: Common dev commands in README or CLAUDE.md
+
+### L4 — Optimized
+- **Architecture Decision Records**: `docs/adr/` or equivalent with rationale for key decisions
+- **Runbook for common tasks**: Deployment, debugging, data migration procedures
+- **Docs freshness**: Documentation updated within the last 90 days
+
+### L5 — Autonomous
+- **Living specification**: Tests or types serve as executable documentation
+- **Auto-generated API docs**: OpenAPI, TypeDoc, or equivalent generated from code
+
+---
+
+## 5. Dev Environment
+
+### L1 — Foundational
+- **Package manager configured**: `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`
+- **Gitignore exists**: `.gitignore` with appropriate entries
+- **Works on clone**: `git clone && install && run` works without manual steps
+
+### L2 — Documented
+- **Env template**: `.env.example` or `.env.template` with all required variables
+- **Node/Python/Go version specified**: `.node-version`, `.python-version`, `.tool-versions`, `engines` field
+- **Setup script**: `scripts/setup.sh` or `make setup` for one-command environment setup
+
+### L3 — Standardized
+- **Devcontainer**: `.devcontainer/` config for reproducible environments
+- **Docker compose**: `docker-compose.yml` for local services (DB, cache, etc.)
+- **Seed data**: Database seeds or fixtures for local development
+
+### L4 — Optimized
+- **Isolated workspaces**: Support for git worktrees or parallel checkouts
+- **Hot reload**: Dev server reloads on file changes
+- **Local-first services**: All dependencies runnable locally (no mandatory cloud services)
+
+### L5 — Autonomous
+- **Ephemeral environments**: On-demand preview environments per PR
+- **Self-provisioning**: Agent can set up the full environment from scratch
+
+---
+
+## 6. Code Quality & Architecture
+
+### L1 — Foundational
+- **No files >500 lines**: Or at most <5% of files exceed this
+- **Entry points discoverable**: Main entry points are obvious (`src/index.*`, `main.*`, `app.*`)
+- **No circular dependencies**: Or circular deps detected and documented
+
+### L2 — Documented
+- **Modular structure**: Code organized by feature/domain, not by type (no `controllers/`, `models/`, `services/` only)
+- **Explicit exports**: Public API of modules is clear (index files, `__init__.py`, `mod.rs`)
+- **Consistent naming**: Files and functions follow a consistent naming convention
+
+### L3 — Standardized
+- **Dependency direction enforced**: No upward imports (UI → domain ok, domain → UI not ok)
+- **Max complexity threshold**: Cyclomatic complexity limits enforced via linter
+- **Dead code detection**: Tools or CI checks for unused exports/code
+
+### L4 — Optimized
+- **Deep modules, simple interfaces**: Modules hide complexity behind small public APIs
+- **<10 files changed per typical PR**: Architecture supports small, focused changes
+- **Explicit error types**: Errors are typed/structured, not string messages
+
+### L5 — Autonomous
+- **Architectural fitness functions**: Automated tests that verify architectural constraints
+- **Blast radius analysis**: Tooling that shows impact of changes before they're made
+
+---
+
+## 7. Observability
+
+### L1 — Foundational
+- **Error handling exists**: try/catch, error boundaries, or equivalent patterns
+- **Errors propagate**: No silent swallowing of exceptions (no empty catch blocks)
+- **Console/stdout logging**: Some logging exists for debugging
+
+### L2 — Documented
+- **Structured logging**: JSON logs or structured log library (winston, pino, structlog)
+- **Error tracking**: Sentry, Bugsnag, or equivalent configured
+- **Log levels used**: DEBUG/INFO/WARN/ERROR used appropriately
+
+### L3 — Standardized
+- **Health checks**: `/health` endpoint or equivalent for services
+- **Request logging**: HTTP requests logged with method, path, status, duration
+- **Error context**: Errors include enough context to diagnose (user, request, state)
+
+### L4 — Optimized
+- **Distributed tracing**: OpenTelemetry, Datadog, or equivalent for cross-service tracing
+- **Metrics instrumented**: Key business and technical metrics tracked
+- **Alerting configured**: Alerts fire on error spikes, latency, or health check failures
+
+### L5 — Autonomous
+- **Agent-accessible telemetry**: Agent can query logs/metrics to diagnose issues
+- **Anomaly detection**: Automated detection of unusual patterns
+
+---
+
+## 8. Security & Governance
+
+### L1 — Foundational
+- **No secrets in code**: No hardcoded API keys, passwords, or tokens in source
+- **Gitignore covers secrets**: `.env`, `*.pem`, `*.key` in `.gitignore`
+- **Dependencies not wildly outdated**: No dependencies >2 major versions behind
+
+### L2 — Documented
+- **Branch protection**: Main branch requires PR (check via `gh api repos/{owner}/{repo}` or branch protection rules)
+- **CODEOWNERS exists**: `CODEOWNERS` or equivalent for review routing
+- **Security policy**: `SECURITY.md` with vulnerability reporting instructions
+
+### L3 — Standardized
+- **Secret scanning**: GitHub secret scanning, gitleaks, or equivalent enabled
+- **Dependency auditing in CI**: `npm audit`, `pip-audit`, or Dependabot configured
+- **Input validation**: User-facing inputs validated at system boundaries
+
+### L4 — Optimized
+- **SAST/DAST**: Static or dynamic security analysis in CI
+- **Signed commits**: Commit signing encouraged or enforced
+- **Least privilege**: Service accounts and API keys use minimal permissions
+
+### L5 — Autonomous
+- **Auto-patching**: Dependabot or Renovate auto-merges passing security patches
+- **Runtime protection**: WAF, rate limiting, or equivalent for production services

--- a/skills/autopilot/SKILL.md
+++ b/skills/autopilot/SKILL.md
@@ -53,31 +53,26 @@ spawn a builder sub-agent to fix each concern, then re-review. Loop max 3.
 
 ### 5. QA
 
-If the change has user-facing components, spawn a sub-agent to exercise the
-running application and verify it actually works — not just that tests pass.
+Invoke `/qa` on the running application. Pass the affected routes/features
+and the oracle criteria from the context packet.
 
-- **Web apps:** Use browser tools (Playwright MCP, claude-in-chrome) to navigate
-  to affected pages, exercise the feature, check for console errors and broken UI.
-- **CLIs:** Run the commands with representative inputs, verify output is correct.
-- **APIs:** Curl the endpoints, verify response shape and status codes.
+- **User-facing components:** `/qa` exercises the app with browser tools,
+  captures evidence, classifies findings.
 - **No user-facing components:** Skip (pure refactor, library, config work).
 
-Test the happy path and key edge cases from the oracle criteria. Fix P0/P1 issues
-and re-run QA. Document P2 issues in the PR body.
-
-See `references/qa-and-demo.md` for detailed patterns.
+If `/qa` finds P0/P1 issues, spawn a builder sub-agent to fix, then re-run `/qa`.
+Document P2 issues in the PR body.
 
 ### 6. Demo Artifacts
 
-Every shipped unit of work produces evidence of completion. No exceptions.
+Invoke `/demo` on the QA evidence. Every shipped unit of work produces evidence.
 
-- **Web UI:** GIF walkthrough via chrome MCP's gif_creator showing the feature working.
-- **CLI:** GIF of terminal session showing command execution and output.
-- **API:** Screenshot or captured output of curl request/response.
-- **Library/refactor:** Before/after test output diff.
+- **Web UI:** `/demo --format gif` for walkthrough GIF
+- **CLI:** `/demo --format gif` for terminal session GIF
+- **API:** Screenshot or captured output (may not need `/demo`)
+- **Library/refactor:** Before/after test output diff
 
-Write artifacts to `/tmp/demo-{slug}/`. Reference from PR body or commit message.
-GIFs are the default for anything visual.
+Then `/demo upload` to attach evidence to the PR via draft GitHub release.
 
 If you can't demonstrate it worked, you can't prove it worked.
 

--- a/skills/autopilot/references/qa-and-demo.md
+++ b/skills/autopilot/references/qa-and-demo.md
@@ -1,117 +1,17 @@
 # QA and Demo Artifacts
 
-Patterns for manual QA, demo artifact generation, and observability instrumentation.
+These capabilities are now standalone composable skills:
 
-## Browser QA (Web Apps)
+- **`/qa`** — browser-based QA, exploratory testing, evidence capture, bug reporting
+- **`/demo`** — demo artifact generation, video composition, narration, PR evidence upload
 
-### Starting the dev server
-
-Before QA, verify the dev server is running:
-
-```bash
-# Check if already running
-curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
-
-# Start if not
-bun dev &   # or npm run dev, pnpm dev, etc.
-sleep 5     # wait for compilation
-```
-
-### Playwright MCP (headless, automated)
-
-Use Playwright MCP for structured, repeatable QA:
-- Navigate to affected routes
-- Fill forms, click buttons, verify outcomes
-- Take full-page screenshots for evidence
-- Check for console errors and failed network requests
-- Generate traces for debugging if something fails
-
-Best for: regression testing, form flows, multi-step workflows.
-
-### Chrome MCP (live browser, interactive)
-
-Use claude-in-chrome for exploratory QA and demo recording:
-- Navigate to the running app in Chrome
-- Interact with the feature as a user would
-- Record a GIF walkthrough via gif_creator
-- Read console messages for errors
-- Check network requests for failed calls
-
-Best for: exploratory testing, visual verification, demo artifact capture.
-
-### QA Checklist
-
-For each user-facing change:
-- [ ] Happy path works end-to-end
-- [ ] Key edge cases from oracle criteria verified
-- [ ] No console errors on affected pages
-- [ ] No failed network requests
-- [ ] Loading/empty/error states render correctly
-- [ ] Mobile viewport works (if applicable)
-
-## CLI QA
-
-Run the changed commands with representative inputs:
-
-```bash
-# Capture output for evidence
-your-cli command --args > /tmp/demo-slug/cli-output.txt 2>&1
-
-# Verify exit code
-echo "Exit code: $?"
-
-# Diff against expected output if available
-diff expected-output.txt /tmp/demo-slug/cli-output.txt
-```
-
-## API QA
-
-```bash
-# Hit the endpoint, capture response
-curl -s http://localhost:3000/api/endpoint | jq . > /tmp/demo-slug/api-response.json
-
-# Verify status code
-curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/endpoint
-
-# POST with body
-curl -s -X POST http://localhost:3000/api/endpoint \
-  -H "Content-Type: application/json" \
-  -d '{"key": "value"}' | jq .
-```
-
-## Demo Artifact Generation
-
-### GIFs (default for anything visual)
-
-Use chrome MCP's gif_creator for web UI walkthroughs:
-1. Navigate to the starting state
-2. Start GIF recording
-3. Perform the feature walkthrough (capture extra frames before/after actions)
-4. Stop recording
-5. Name meaningfully: `feature-name-walkthrough.gif`
-
-For CLI demos, use `script` or `asciinema` to record terminal sessions,
-then convert to GIF with ffmpeg or a similar tool.
-
-### Screenshots
-
-For single-state evidence (not flows):
-- Playwright: full-page screenshot
-- Chrome MCP: upload_image after navigating
-
-### Output capture
-
-For non-visual changes:
-```bash
-mkdir -p /tmp/demo-{slug}
-
-# Before/after test diff
-git stash && npm test > /tmp/demo-{slug}/before.txt 2>&1 && git stash pop
-npm test > /tmp/demo-{slug}/after.txt 2>&1
-diff /tmp/demo-{slug}/before.txt /tmp/demo-{slug}/after.txt > /tmp/demo-{slug}/test-diff.txt
-```
+Autopilot invokes them in steps 5-6. They can also be invoked independently
+outside the autopilot pipeline (e.g., after manually shipping, or to iterate
+on demo artifacts for an existing PR).
 
 ## Observability Instrumentation
+
+This section stays here because it's specific to autopilot's ship workflow.
 
 ### Canary integration
 

--- a/skills/demo/SKILL.md
+++ b/skills/demo/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: demo
+description: |
+  Generate demo artifacts: screenshots, GIF walkthroughs, video recordings,
+  polished launch videos with narration and music. From raw evidence to
+  shipped media. Also handles PR evidence upload via draft releases.
+  Use when: "make a demo", "generate demo", "record walkthrough", "launch video",
+  "PR evidence", "upload screenshots", "demo artifacts", "make a video",
+  "demo this feature", "create a walkthrough".
+  Trigger: /demo.
+argument-hint: "[evidence-dir|feature] [--format gif|video|launch] [--narrate] [upload]"
+---
+
+# /demo
+
+Turn evidence into artifacts. From raw QA screenshots to polished launch videos.
+
+**Target:** $ARGUMENTS
+
+## Routing
+
+| Keyword / Intent | Reference |
+|-----------------|-----------|
+| `upload`, PR evidence | `references/pr-evidence-upload.md` |
+| Remotion, video composition, walkthrough video | `references/remotion.md` |
+| Narration, voiceover, TTS, music | `references/tts-narration.md` |
+| Quick evidence (default) | This file |
+
+## Three Tiers of Demo Output
+
+### Tier 1: Quick Evidence (default)
+
+Screenshots + GIFs from QA artifacts. Minimal processing. Done in minutes.
+
+1. Collect evidence from `/tmp/qa-{slug}/`
+2. Convert WebM → GIF via ffmpeg (if needed)
+3. Upload to draft GitHub release
+4. Embed in PR comment
+
+This is the default when invoked as part of `/autopilot` or when the user
+says "upload evidence" or "PR evidence."
+
+### Tier 2: Walkthrough Video
+
+Assemble captures into a composed video with title cards, captions, and
+transitions. No narration.
+
+1. Collect evidence (screenshots, recordings)
+2. Create a Remotion project (or use existing)
+3. Compose: intro card → step-by-step scenes → outro
+4. Render to MP4
+5. Upload or share
+
+See `references/remotion.md` for composition patterns.
+
+### Tier 3: Launch Video
+
+Full production: narration, background music, motion graphics.
+
+1. Write a script (or generate from feature description)
+2. Generate voiceover via TTS
+3. Generate or select background music
+4. Compose in Remotion with captures + voiceover + music + captions
+5. Render and deliver
+
+See `references/remotion.md` and `references/tts-narration.md`.
+
+## FFmpeg Essentials
+
+These are the patterns you'll use constantly for post-processing.
+
+### WebM → GIF (for inline PR rendering)
+
+```bash
+ffmpeg -y -i input.webm \
+  -vf "fps=8,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
+  -loop 0 output.gif
+```
+GitHub renders GIFs inline but not WebM. Always convert for PRs.
+
+### Concatenate clips
+
+```bash
+# Create file list
+echo "file 'clip1.mp4'" > /tmp/concat.txt
+echo "file 'clip2.mp4'" >> /tmp/concat.txt
+
+ffmpeg -y -f concat -safe 0 -i /tmp/concat.txt -c copy output.mp4
+```
+
+### Add audio track
+
+```bash
+ffmpeg -y -i video.mp4 -i narration.mp3 \
+  -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 \
+  -shortest output.mp4
+```
+
+### Burn subtitles/captions
+
+```bash
+ffmpeg -y -i video.mp4 \
+  -vf "subtitles=captions.srt:force_style='FontSize=24'" \
+  output.mp4
+```
+
+### Resize for platforms
+
+```bash
+# 16:9 for YouTube/web
+ffmpeg -y -i input.mp4 -vf "scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2" output-16x9.mp4
+
+# 1:1 for social
+ffmpeg -y -i input.mp4 -vf "crop=min(iw\,ih):min(iw\,ih),scale=1080:1080" output-square.mp4
+
+# 9:16 for mobile/stories
+ffmpeg -y -i input.mp4 -vf "crop=ih*9/16:ih,scale=1080:1920" output-vertical.mp4
+```
+
+## PR Evidence Upload (Quick Reference)
+
+For the full protocol, see `references/pr-evidence-upload.md`.
+
+```bash
+# Upload to draft release
+gh release create qa-evidence-pr-{NUMBER} \
+  --title "QA Evidence: PR #{NUMBER}" \
+  --notes "Visual QA evidence" \
+  --draft \
+  /tmp/qa-{slug}/*.gif \
+  /tmp/qa-{slug}/*.png
+
+# Get asset URLs and embed in PR comment
+RELEASE_TAG=$(gh release list --json tagName,isDraft \
+  --jq '.[] | select(.isDraft) | .tagName' \
+  | grep "qa-evidence-pr-{NUMBER}" | head -1)
+```
+
+## Gotchas
+
+- **WebM in PR comments doesn't render.** Always convert to GIF for inline
+  display. Link to the full WebM/MP4 for higher quality.
+- **GIFs over 10MB** load slowly in PR comments. Target 800px width, 8fps,
+  128-color palette. Trim to the essential flow.
+- **Screenshots of static state don't need GIFs.** Use GIF only for flows
+  with visible state changes.
+- **Remotion requires Node.** Check the project has Node before starting
+  video composition. Consider `npx create-video --yes --blank --tmp` for
+  one-off renders.
+- **TTS costs money.** OpenAI TTS is $0.015/1K chars. ElevenLabs is more
+  expensive but higher quality. Don't generate narration for internal QA
+  evidence — save it for launch videos.
+- **Draft releases cost nothing** but accumulate. Clean up after PR merge
+  if the repo has many PRs.
+- **Committing binary artifacts to the repo** is always wrong. Use draft
+  releases, external hosting, or `/tmp`.

--- a/skills/demo/references/pr-evidence-upload.md
+++ b/skills/demo/references/pr-evidence-upload.md
@@ -17,10 +17,7 @@ up later.
 ```bash
 # 1. Capture evidence (screenshots, GIFs, videos)
 mkdir -p /tmp/pr-evidence
-agent-browser --session qa screenshot /tmp/pr-evidence/feature-demo.png
-agent-browser --session qa record start /tmp/pr-evidence/walkthrough.webm
-# ... do things ...
-agent-browser --session qa record stop
+# Evidence comes from /qa — screenshots, GIFs, videos in /tmp/qa-{slug}/
 
 # 2. Convert video to GIF for inline rendering (GitHub doesn't embed webm)
 ffmpeg -y -i /tmp/pr-evidence/walkthrough.webm \

--- a/skills/demo/references/remotion.md
+++ b/skills/demo/references/remotion.md
@@ -1,0 +1,216 @@
+# Remotion — Programmatic Video Composition
+
+React-based framework for rendering video programmatically. The strongest
+option for agent-driven video composition.
+
+## Why Remotion
+
+- Video as code: React components define scenes, animations, timing
+- Full programmatic control: data-driven, parameterized, batch-renderable
+- Agent-friendly: official Agent Skills for Claude Code, AI-ready docs
+- Rendering: local, server-side via `renderMedia()`, distributed via Lambda
+- Outputs: MP4, WebM, GIF, still images, audio
+
+## Quick Start
+
+```bash
+# One-off video project (non-interactive, for agent use)
+npx create-video --yes --blank --tmp
+
+# With Remotion Agent Skills (recommended for Claude Code)
+npx remotion skills add
+```
+
+### Remotion Agent Skills
+
+Remotion maintains Claude Code skills that define best practices for Remotion
+projects. Install them for guided video creation:
+
+```bash
+npx remotion skills add remotion-dev/skills
+```
+
+These install to `.claude/skills/` and provide Remotion-specific guidance
+that the agent loads automatically.
+
+### AI-Ready Docs
+
+Remotion docs are optimized for agent consumption:
+- Add `.md` to any doc URL: `remotion.dev/docs/player.md`
+- Content negotiation: `Accept: text/markdown` returns markdown
+- Paste any Remotion doc link into Claude Code and it fetches markdown
+
+## Core Concepts
+
+### Composition (the video unit)
+
+```tsx
+import { useCurrentFrame, useVideoConfig, spring, AbsoluteFill } from 'remotion';
+
+export const MyScene: React.FC<{ title: string }> = ({ title }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const scale = spring({ fps, frame, config: { damping: 100 } });
+
+  return (
+    <AbsoluteFill style={{ justifyContent: 'center', alignItems: 'center' }}>
+      <h1 style={{ transform: `scale(${scale})` }}>{title}</h1>
+    </AbsoluteFill>
+  );
+};
+```
+
+### Key APIs
+
+- `useCurrentFrame()` — current frame number
+- `useVideoConfig()` — fps, width, height, durationInFrames
+- `spring()` — physics-based animation
+- `interpolate()` — map frame ranges to values
+- `<Sequence>` — time-offset child compositions
+- `<AbsoluteFill>` — full-frame positioned container
+- `<Img>`, `<Video>`, `<Audio>` — media components
+- `<OffthreadVideo>` — efficient video embedding
+
+## Walkthrough Video Pattern
+
+For assembling QA screenshots/recordings into a walkthrough:
+
+```tsx
+import { Composition } from 'remotion';
+
+// Register the composition
+<Composition
+  id="walkthrough"
+  component={Walkthrough}
+  durationInFrames={300}  // 10 seconds at 30fps
+  fps={30}
+  width={1920}
+  height={1080}
+  defaultProps={{
+    steps: [
+      { image: '/tmp/qa-slug/01-dashboard.png', caption: 'Dashboard loads' },
+      { image: '/tmp/qa-slug/02-create.png', caption: 'Create new item' },
+      { image: '/tmp/qa-slug/03-success.png', caption: 'Success state' },
+    ]
+  }}
+/>
+```
+
+### Scene structure for walkthroughs
+
+```
+Intro card (2s) → Step 1 screenshot + caption (3s) → transition →
+Step 2 screenshot + caption (3s) → ... → Outro card (2s)
+```
+
+## Rendering
+
+### Local render
+
+```bash
+npx remotion render MyComposition output.mp4
+```
+
+### Programmatic render (server-side)
+
+```typescript
+import { renderMedia, selectComposition } from '@remotion/renderer';
+
+const composition = await selectComposition({
+  serveUrl: '/path/to/bundle',
+  id: 'walkthrough',
+  inputProps: { steps: [...] },
+});
+
+await renderMedia({
+  composition,
+  serveUrl: '/path/to/bundle',
+  codec: 'h264',
+  outputLocation: 'output.mp4',
+  inputProps: { steps: [...] },
+});
+```
+
+### Still image render
+
+```bash
+npx remotion still MyComposition frame-50.png --frame=50
+```
+
+Useful for generating thumbnail/preview images from video compositions.
+
+## Captions
+
+Remotion has a captions ecosystem for auto-generated subtitles:
+
+- Generate captions from audio via OpenAI Whisper
+- Render word-by-word or sentence-by-sentence captions
+- Sync captions to audio timing
+
+```tsx
+import { Caption } from '@remotion/captions';
+
+// Captions component syncs text to audio timing
+<Caption words={transcription.words} />
+```
+
+## Dataset Rendering (Batch)
+
+Generate many videos from a JSON dataset — useful for repeatable demos
+across different features or customers:
+
+```typescript
+import { data } from './dataset';
+
+// Register one composition per data entry
+data.map((entry) => (
+  <Composition
+    key={entry.id}
+    id={entry.id}
+    component={DemoVideo}
+    defaultProps={entry}
+    // ...
+  />
+));
+```
+
+Render all:
+```bash
+for id in $(npx remotion compositions --json | jq -r '.[].id'); do
+  npx remotion render "$id" "output/${id}.mp4"
+done
+```
+
+## Prompt-to-Motion-Graphics
+
+Remotion offers a SaaS template for AI-generated animations:
+
+```bash
+npx create-video@latest --template prompt-to-motion-graphics
+```
+
+Users describe animations in natural language → app generates and previews
+in real-time. Best for stylized explainers, not product walkthroughs.
+
+## Recorder
+
+Remotion Recorder captures webcam + screen as separate streams with
+auto-generated captions. Good for talking-head product walkthroughs.
+
+```bash
+bun run dev  # Start the recorder
+# Record webcam, screen, and audio
+# Export as composed video with captions
+```
+
+## Integration with QA Evidence
+
+Typical workflow: `/qa` captures evidence → `/demo` composes with Remotion
+
+1. QA produces screenshots in `/tmp/qa-{slug}/`
+2. Create a Remotion composition that sequences them
+3. Add title cards, captions, transitions
+4. Optionally add narration (see tts-narration.md)
+5. Render to MP4
+6. Upload via draft release or share directly

--- a/skills/demo/references/tts-narration.md
+++ b/skills/demo/references/tts-narration.md
@@ -1,0 +1,178 @@
+# TTS Narration & Audio
+
+Programmable voice and music for demo videos. Three providers, each with
+a clear best-fit.
+
+## Provider Selection
+
+| Provider | Best for | Latency | Cost | Languages |
+|----------|----------|---------|------|-----------|
+| **ElevenLabs** | Quality, voice cloning, music | 100-200ms TTFB | ~$0.015/min | 30+ |
+| **OpenAI TTS** | Simplest API, good-enough quality | ~200ms TTFB | $0.015/1K chars | ~50 |
+| **Cartesia Sonic-3** | Ultra-low latency, real-time | 40-90ms TTFB | $0.006/min | 42 |
+
+**Default recommendation:**
+- Already using OpenAI? → **OpenAI TTS** (one endpoint, streaming, simple)
+- Quality matters most? → **ElevenLabs** (best voices, cloning, emotional range)
+- Latency matters most? → **Cartesia** (fastest TTFB, cheapest)
+- Need generated music? → **ElevenLabs** (only provider with music generation)
+
+## OpenAI TTS
+
+Simplest integration. Six voices, one endpoint.
+
+```bash
+curl -s https://api.openai.com/v1/audio/speech \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tts-1-hd",
+    "input": "Welcome to the feature walkthrough. Let me show you what we built.",
+    "voice": "alloy"
+  }' \
+  --output /tmp/demo-slug/narration.mp3
+```
+
+### Voices
+`alloy` (neutral), `echo` (male), `fable` (British), `onyx` (deep male),
+`nova` (female), `shimmer` (soft female).
+
+### Models
+- `tts-1` — fast, lower quality
+- `tts-1-hd` — slower, higher quality (use for launch videos)
+
+## ElevenLabs
+
+Best quality. Voice cloning from 1 minute of audio. Music generation.
+
+```bash
+curl -s https://api.elevenlabs.io/v1/text-to-speech/{voice_id} \
+  -H "xi-api-key: $ELEVENLABS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Welcome to the feature walkthrough.",
+    "model_id": "eleven_multilingual_v2",
+    "voice_settings": {
+      "stability": 0.5,
+      "similarity_boost": 0.75
+    }
+  }' \
+  --output /tmp/demo-slug/narration.mp3
+```
+
+### Voice library
+Browse voices at `api.elevenlabs.io/v1/voices`. Hundreds of pre-made voices
+plus custom cloning.
+
+### Music generation
+ElevenLabs offers music generation — useful for background tracks:
+```bash
+# Check current API surface for music endpoints
+# This is evolving rapidly
+```
+
+## Cartesia
+
+Ultra-low latency. Best for real-time or interactive narration.
+
+```bash
+curl -s https://api.cartesia.ai/tts/bytes \
+  -H "X-API-Key: $CARTESIA_API_KEY" \
+  -H "Cartesia-Version: 2024-06-10" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model_id": "sonic-3",
+    "transcript": "Welcome to the feature walkthrough.",
+    "voice": { "mode": "id", "id": "a0e99841-438c-4a64-b679-ae501e7d6091" },
+    "output_format": { "container": "mp3", "bit_rate": 128000 }
+  }' \
+  --output /tmp/demo-slug/narration.mp3
+```
+
+## Narration Workflow
+
+### Script generation
+
+1. Describe the feature or provide the QA evidence
+2. Generate a script: one sentence per scene/screenshot
+3. Keep it concise — 10-15 words per scene, 2-3 seconds of speech
+
+### Script → Audio → Video
+
+```bash
+# 1. Generate narration
+curl -s https://api.openai.com/v1/audio/speech \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tts-1-hd",
+    "input": "'"$(cat /tmp/demo-slug/script.txt)"'",
+    "voice": "nova"
+  }' --output /tmp/demo-slug/narration.mp3
+
+# 2. Get audio duration (for Remotion timing)
+ffprobe -v error -show_entries format=duration \
+  -of default=noprint_wrappers=1:nokey=1 \
+  /tmp/demo-slug/narration.mp3
+
+# 3. Compose in Remotion (set durationInFrames from audio duration)
+# 4. Or mux directly with ffmpeg:
+ffmpeg -y -i /tmp/demo-slug/walkthrough.mp4 \
+  -i /tmp/demo-slug/narration.mp3 \
+  -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 \
+  -shortest /tmp/demo-slug/narrated-walkthrough.mp4
+```
+
+## Auto-Captioning
+
+### OpenAI Whisper (transcription → captions)
+
+```bash
+curl -s https://api.openai.com/v1/audio/transcriptions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -F file="@/tmp/demo-slug/narration.mp3" \
+  -F model="whisper-1" \
+  -F response_format="srt" \
+  > /tmp/demo-slug/captions.srt
+```
+
+### Burn captions into video
+
+```bash
+ffmpeg -y -i /tmp/demo-slug/narrated-walkthrough.mp4 \
+  -vf "subtitles=/tmp/demo-slug/captions.srt:force_style='FontSize=24,PrimaryColour=&HFFFFFF&'" \
+  /tmp/demo-slug/final.mp4
+```
+
+### Remotion captions
+
+Remotion's `@remotion/captions` package renders word-by-word synced captions
+as React components — more polished than burned-in SRT subtitles.
+
+## Background Music
+
+### From file
+```bash
+# Mix narration + music (music at -20dB under narration)
+ffmpeg -y -i /tmp/demo-slug/narration.mp3 \
+  -i /tmp/demo-slug/music.mp3 \
+  -filter_complex "[1:a]volume=0.1[music];[0:a][music]amix=inputs=2:duration=first" \
+  /tmp/demo-slug/mixed-audio.mp3
+```
+
+### Generated
+ElevenLabs music generation or royalty-free libraries. For launch videos,
+generated music avoids licensing concerns.
+
+## Cost Awareness
+
+| Task | Provider | Typical cost |
+|------|----------|-------------|
+| 30s narration (~75 words) | OpenAI TTS | ~$0.01 |
+| 30s narration | ElevenLabs | ~$0.02 |
+| 30s narration | Cartesia | ~$0.003 |
+| 2min launch video narration | OpenAI TTS | ~$0.05 |
+| Auto-captioning (Whisper) | OpenAI | ~$0.01/min |
+
+Don't generate narration for internal QA evidence — that's what screenshots
+and GIFs are for. Reserve TTS for launch videos and external demos.

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: qa
+description: |
+  Browser-based QA, exploratory testing, evidence capture, and bug reporting.
+  Drive running applications and verify they work — not just that tests pass.
+  Use when: "run QA", "test this", "verify the feature", "exploratory test",
+  "check the app", "QA this PR", "capture evidence", "manual testing".
+  Trigger: /qa.
+argument-hint: "[url|route|feature] [--tool playwright|chrome|agent-browser]"
+---
+
+# /qa
+
+Drive the running application and verify it works. Tests passing is necessary
+but not sufficient — QA means exercising the real app as a user would.
+
+**Target:** $ARGUMENTS
+
+## Routing
+
+| Intent | Reference |
+|--------|-----------|
+| Exploratory QA (default) | This file |
+| Browser tool deep-dive | `references/browser-tools.md` |
+| Evidence capture patterns | `references/evidence-capture.md` |
+
+## Tool Selection
+
+Pick the right browser tool for the job. Don't default to one — match it.
+
+| Tool | Best for | Token cost |
+|------|----------|------------|
+| **Playwright MCP** | Deterministic automation, test generation, cross-browser, traces | Medium |
+| **Playwright CLI** | Same as MCP but 4x cheaper on tokens; saves snapshots to disk | Low |
+| **Chrome MCP** (claude-in-chrome) | Exploratory QA in live browser, existing auth, GIF recording | Medium |
+| **agent-browser** | Lowest token usage (82% less), annotated screenshots, video | Low |
+| **Stagehand/Browserbase** | Hosted sessions, anti-bot, stealth, session recordings | Medium |
+| **Chrome DevTools MCP** | Deep debug: console, network, perf traces, not primary QA | Low |
+
+**Decision tree:**
+1. Need existing browser auth/cookies? → **Chrome MCP**
+2. Need hosted/stealth/anti-bot? → **Stagehand/Browserbase**
+3. Need deterministic test generation? → **Playwright MCP/CLI**
+4. Need annotated screenshots + lowest token cost? → **agent-browser**
+5. Need deep frontend debug (perf/network)? → **Chrome DevTools MCP**
+6. Not sure? → **Chrome MCP** for exploration, **Playwright** for regression
+
+See `references/browser-tools.md` for setup and detailed usage patterns.
+
+## QA Protocol
+
+### Before
+
+```bash
+# Verify dev server is running
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/
+# Start if not — adapt command to project
+bun dev &
+sleep 5
+```
+
+### During
+
+For each user-facing change, verify:
+
+- [ ] Happy path works end-to-end
+- [ ] Key edge cases from oracle criteria
+- [ ] No console errors on affected pages
+- [ ] No failed network requests
+- [ ] Loading/empty/error states render correctly
+- [ ] Mobile viewport works (if applicable)
+
+**Web apps:** Navigate to affected routes, exercise the feature, capture evidence.
+**CLIs:** Run commands with representative inputs, verify output.
+**APIs:** Curl endpoints, verify response shape and status codes.
+
+### After
+
+- Classify findings: P0 (blocks ship), P1 (fix before merge), P2 (log for later)
+- P0/P1: fix and re-run QA on the fix
+- P2: document in PR body or create issues
+- Capture evidence for everything tested (see below)
+
+## Evidence Requirements
+
+Every QA run produces evidence. No exceptions.
+
+| Change type | Default evidence |
+|-------------|-----------------|
+| UI feature/fix | GIF walkthrough + route screenshots |
+| Visual change | Before/after screenshots |
+| Multi-step flow | GIF or video recording |
+| API/backend | Terminal output as code block |
+| Refactor with parity | GIF showing the app still works |
+
+Evidence goes to `/tmp/qa-{slug}/`. Use `/demo` to upload evidence to PRs.
+
+See `references/evidence-capture.md` for tool-specific capture patterns.
+
+## CLI QA
+
+```bash
+mkdir -p /tmp/qa-{slug}
+your-cli command --args > /tmp/qa-{slug}/cli-output.txt 2>&1
+echo "Exit code: $?"
+```
+
+## API QA
+
+```bash
+curl -s http://localhost:3000/api/endpoint | jq . > /tmp/qa-{slug}/api-response.json
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/endpoint
+```
+
+## Hardening to Tests
+
+When a QA exploration reveals a stable flow worth keeping:
+
+1. Use Playwright's test agents (Planner → Generator → Healer) to convert
+   the exploratory flow into a deterministic test
+2. Or manually write the test based on the QA notes
+3. Add visual baselines if applicable
+
+See `references/browser-tools.md` → Playwright test agents section.
+
+## Gotchas
+
+- **"Tests pass" is not QA.** Tests verify code paths. QA verifies user experience.
+  A test can pass while the page is visually broken.
+- **Collecting evidence before confirming repro** burns agent budget. Confirm the
+  issue reproduces from a clean state before recording elaborate walkthroughs.
+- **Screenshots of motionless screens** should be screenshots, not recordings.
+  Use video/GIF only for flows with multiple steps or state changes.
+- **Skipping console/network checks** misses the most common backend-caused
+  frontend bugs: 500s, CORS, missing env vars.
+- **Auth-heavy apps** need Chrome MCP (existing session) or Stagehand (stealth).
+  Don't waste time re-implementing login flows in Playwright unless you're
+  hardening them into a test.
+- **agent-browser security controls are opt-in.** Turn on guardrails for
+  internal apps.

--- a/skills/qa/references/browser-tools.md
+++ b/skills/qa/references/browser-tools.md
@@ -1,0 +1,271 @@
+# Browser Tools for Agent-Driven QA
+
+Detailed setup and usage patterns for each browser automation tool.
+
+## Playwright MCP
+
+The most mature browser automation MCP. Accessibility tree snapshots instead
+of screenshots — structured text, no vision model needed.
+
+### Setup
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+### Key tools
+
+- `browser_navigate` — load URL, get accessibility snapshot
+- `browser_click` / `browser_type` — interact by element ref
+- `browser_take_screenshot` — full page or element screenshot
+- `browser_snapshot` — current accessibility tree
+- `browser_wait_for_network_idle` — wait for async loads
+- `browser_generate_playwright_test` — convert exploration to test code
+
+### Playwright CLI (token-efficient alternative)
+
+Playwright CLI saves snapshots and screenshots to disk instead of streaming
+them into context. **4x cheaper** on tokens than MCP for the same capability.
+
+```bash
+npx @playwright/cli@latest
+```
+
+Use CLI when embedded in a large coding workflow. Use MCP when the agent needs
+a persistent interactive browser loop.
+
+### Playwright Test Agents (v1.56+)
+
+Three built-in agents for test lifecycle:
+
+**Planner:** Explores the app, creates a structured test plan.
+```
+Input: URL + feature description
+Output: Step-by-step test plan with expected outcomes
+```
+
+**Generator:** Converts a plan into executable Playwright tests with validated
+selectors and assertions.
+```
+Input: Test plan from Planner
+Output: TypeScript Playwright test file
+```
+
+**Healer:** Repairs failing tests by inspecting the live UI and patching
+locators/assertions that broke due to UI changes.
+```
+Input: Failing test + error
+Output: Patched test with updated selectors
+```
+
+### Screenshot and video
+
+```javascript
+// Screenshot
+await page.screenshot({ path: 'screenshot.png', fullPage: true });
+
+// Video recording (set in context)
+const context = await browser.newContext({
+  recordVideo: { dir: '/tmp/qa-videos/' }
+});
+
+// Trace (includes screenshots, DOM snapshots, network)
+await context.tracing.start({ screenshots: true, snapshots: true });
+// ... do things ...
+await context.tracing.stop({ path: 'trace.zip' });
+// View: npx playwright show-trace trace.zip
+```
+
+---
+
+## Chrome MCP (claude-in-chrome)
+
+Live browser control via the claude-in-chrome extension. Best for exploratory
+QA with existing auth state and GIF demo capture.
+
+### Key tools
+
+- `tabs_context_mcp` — **always call first** to get current tab state
+- `navigate` — go to URL
+- `read_page` / `get_page_text` — read page content
+- `find` — locate elements
+- `form_input` — fill forms
+- `computer` — click, type, scroll at coordinates
+- `gif_creator` — record GIF walkthrough
+- `read_console_messages` — check for errors
+- `read_network_requests` — check for failed calls
+- `javascript_tool` — run JS in page context
+
+### GIF recording workflow
+
+1. Navigate to starting state
+2. Start GIF recording via `gif_creator`
+3. Perform the walkthrough — capture extra frames before/after actions
+4. Stop recording
+5. Name meaningfully: `feature-name-walkthrough.gif`
+
+### Best for
+
+- Exploratory QA with existing login/cookies
+- Demo GIF recording
+- Quick visual verification
+- Console/network error checking
+
+### Limitations
+
+- Tied to the user's Chrome instance
+- Cannot run headless or in CI
+- GIF output only (no video)
+
+---
+
+## agent-browser (Vercel Labs)
+
+Rust CLI for AI agents. Compact text output, lowest token usage.
+
+### Install
+
+```bash
+# Via npm
+npm install -g agent-browser
+
+# Or direct binary
+curl -fsSL https://agent-browser.dev/install | sh
+```
+
+### Key features
+
+- **Ref-based snapshots** — accessibility tree with element refs (like Playwright MCP)
+- **Annotated screenshots** — screenshots with visible labels bound to element refs
+- **Video recording** — WebM with start/stop control
+- **Snapshot diffing** — compare before/after states
+- **Pixel diffing** — compare screenshots for visual regression
+- **Sessions** — persistent browser state across commands
+
+### Usage patterns
+
+```bash
+# Navigate and get snapshot
+agent-browser navigate https://localhost:3000
+agent-browser snapshot
+
+# Annotated screenshot (labels on interactive elements)
+agent-browser screenshot --annotate /tmp/qa-slug/annotated.png
+
+# Video recording
+agent-browser record start /tmp/qa-slug/walkthrough.webm
+# ... interact with the page ...
+agent-browser record stop
+
+# Snapshot diff
+agent-browser snapshot --save before.json
+# ... make changes ...
+agent-browser snapshot --diff before.json
+```
+
+### Token efficiency
+
+82% less context than Playwright MCP for equivalent tasks. Snapshots are
+compact by design — built for AI agent consumption.
+
+### Best for
+
+- Token-conscious QA sessions
+- Annotated bug report screenshots
+- Video evidence with precise start/stop
+- Visual regression via pixel diffing
+
+---
+
+## Stagehand / Browserbase
+
+Browserbase is hosted browser infrastructure. Stagehand is the AI framework
+on top, with natural-language-friendly primitives.
+
+### Setup (MCP)
+
+```json
+{
+  "mcpServers": {
+    "browserbase": {
+      "command": "npx",
+      "args": ["@browserbasehq/mcp-server@latest"],
+      "env": {
+        "BROWSERBASE_API_KEY": "<key>",
+        "BROWSERBASE_PROJECT_ID": "<project>"
+      }
+    }
+  }
+}
+```
+
+### Stagehand primitives
+
+- `act("click the login button")` — natural language action
+- `extract("get the price from this page")` — structured data extraction
+- `observe("what's on this page?")` — semantic page understanding
+- `agent` — multi-step autonomous workflow
+
+### Hosted features
+
+- **Session recordings** — every session recorded as video automatically
+- **Live View** — watch the agent in real time
+- **Session Inspector** — replay with timeline, logs, network
+- **Stealth mode** — anti-bot bypass, residential proxies
+- **Caching** — run AI once, cache into deterministic code for reruns
+
+### Best for
+
+- QA on hostile/anti-bot sites
+- Shared session recordings for team review
+- Human-in-the-loop via Live View
+- Production agent workflows at scale
+
+---
+
+## Chrome DevTools MCP
+
+Deep debugging access to a live Chrome instance via DevTools Protocol.
+
+### Setup
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["@anthropic-ai/chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+### Key capabilities
+
+- **Performance traces** — CPU profiling, rendering analysis
+- **Network inspection** — request/response details, timing, failures
+- **Console messages** — errors, warnings, log output (use `pattern` for filtering)
+- **Screenshots** — via CDP (faster than standard approaches)
+- **Script evaluation** — run JS in any frame context
+- **Device emulation** — viewport, user agent, geolocation
+
+### When to use
+
+Chrome DevTools MCP is a **diagnostic tool**, not a primary QA driver. Use when:
+- A page is janky and you need a perf trace
+- Network calls are failing and you need request/response details
+- Console errors need investigation
+- You need to understand render path changes
+
+### Privacy note
+
+Google Chrome DevTools MCP collects usage statistics by default. Performance
+tools may send trace URLs to the CrUX API. For internal/sensitive QA, review
+the privacy settings.

--- a/skills/qa/references/evidence-capture.md
+++ b/skills/qa/references/evidence-capture.md
@@ -1,0 +1,159 @@
+# Evidence Capture Patterns
+
+Cross-tool patterns for capturing QA evidence: screenshots, GIFs, videos, and
+terminal output.
+
+## Directory Convention
+
+```bash
+mkdir -p /tmp/qa-{slug}
+# All evidence for a QA session goes here
+# slug = feature name or PR number
+```
+
+## Screenshots
+
+### Playwright MCP
+```
+browser_take_screenshot  →  saves to specified path
+```
+Full-page screenshots by default. Element screenshots via selector.
+
+### Chrome MCP
+Navigate to the state, then use `upload_image` or `gif_creator` for a
+single-frame capture.
+
+### agent-browser
+```bash
+# Standard screenshot
+agent-browser screenshot /tmp/qa-{slug}/page.png
+
+# Annotated screenshot (labels on interactive elements)
+agent-browser screenshot --annotate /tmp/qa-{slug}/annotated.png
+```
+Annotated screenshots are the best format for bug reports — visible labels
+map directly to actionable element refs.
+
+### Chrome DevTools MCP
+CDP-based screenshots are faster than standard approaches:
+```
+Take a screenshot of the current page state
+```
+
+## GIF Recordings
+
+### Chrome MCP (claude-in-chrome)
+```
+1. gif_creator — start recording
+2. Perform walkthrough (capture extra frames before/after actions)
+3. gif_creator — stop recording
+4. Name: feature-name-walkthrough.gif
+```
+This is the fastest path to inline-renderable GIFs for PRs.
+
+### agent-browser → ffmpeg
+```bash
+# Record as WebM
+agent-browser record start /tmp/qa-{slug}/walkthrough.webm
+# ... interact with the app ...
+agent-browser record stop
+
+# Convert to GIF (GitHub renders GIFs inline, not WebM)
+ffmpeg -y -i /tmp/qa-{slug}/walkthrough.webm \
+  -vf "fps=8,scale=800:-1:flags=lanczos,split[s0][s1];[s0]palettegen=max_colors=128[p];[s1][p]paletteuse=dither=bayer" \
+  -loop 0 /tmp/qa-{slug}/walkthrough.gif
+```
+
+### Playwright trace → screenshots
+```bash
+# Traces include per-action screenshots
+npx playwright show-trace trace.zip
+# Export screenshots from the trace viewer
+```
+
+## Video Recordings
+
+### agent-browser
+```bash
+agent-browser record start /tmp/qa-{slug}/session.webm
+# ... full QA session ...
+agent-browser record stop
+```
+Add `--pause 500` between actions for human-readable playback.
+
+### Browserbase
+Every session is automatically recorded. Access via:
+- Session Inspector (web UI)
+- API: download recording by session ID
+- Live View for real-time observation
+
+### Playwright
+```javascript
+const context = await browser.newContext({
+  recordVideo: { dir: '/tmp/qa-{slug}/' }
+});
+// Video saved on context.close()
+await context.close();
+```
+
+## CLI / Terminal Evidence
+
+### Script capture
+```bash
+# Record terminal session
+script -q /tmp/qa-{slug}/terminal-session.txt \
+  your-cli command --args
+
+# Or with timing for playback
+script -t 2>/tmp/qa-{slug}/timing.txt /tmp/qa-{slug}/session.txt
+```
+
+### Asciinema (richer terminal recording)
+```bash
+asciinema rec /tmp/qa-{slug}/session.cast
+# Convert to GIF:
+# pip install agg  (asciinema gif generator)
+agg /tmp/qa-{slug}/session.cast /tmp/qa-{slug}/terminal.gif
+```
+
+### Simple output capture
+```bash
+your-cli command --args > /tmp/qa-{slug}/output.txt 2>&1
+echo "Exit code: $?" >> /tmp/qa-{slug}/output.txt
+```
+
+## API Evidence
+
+```bash
+# Capture response with headers and status
+curl -s -w "\n\nHTTP Status: %{http_code}\nTime: %{time_total}s\n" \
+  http://localhost:3000/api/endpoint | tee /tmp/qa-{slug}/api-response.json
+
+# POST with body
+curl -s -X POST http://localhost:3000/api/endpoint \
+  -H "Content-Type: application/json" \
+  -d '{"key": "value"}' | jq . > /tmp/qa-{slug}/api-post-response.json
+```
+
+## Evidence Naming Convention
+
+```
+/tmp/qa-{slug}/
+├── 01-dashboard-home.png           # Numbered for sequence
+├── 02-create-form.png
+├── 03-submit-success.png
+├── walkthrough.gif                  # GIF for PR embedding
+├── walkthrough.webm                 # Source video (higher quality)
+├── console-errors.txt               # Console output if errors found
+├── network-failures.txt             # Failed network requests
+├── api-response.json                # API evidence
+└── cli-output.txt                   # CLI evidence
+```
+
+Number screenshots sequentially when they document a flow. Use descriptive
+names that indicate what the screenshot shows.
+
+## Uploading Evidence
+
+Use `/demo upload` to attach evidence to PRs via draft GitHub releases.
+See the `/demo` skill for the full upload protocol.

--- a/skills/settle/SKILL.md
+++ b/skills/settle/SKILL.md
@@ -142,7 +142,7 @@ CI and reviews. The loop terminates when a full pass produces no changes.
 When settlement needs screenshots, videos, logs, or walkthrough proof:
 
 - Upload screenshots/GIFs to draft GitHub release assets, embed download URLs
-  in PR comments. See `autopilot/references/pr-evidence-upload.md` for the recipe.
+  in PR comments. See `/demo` skill (`references/pr-evidence-upload.md`) for the recipe.
 - Convert `.webm` → `.gif` before upload (GitHub renders GIFs inline, not video).
 - Prefer CI artifacts or step summaries for generated verification output.
 - Never commit binary PR evidence into the repo.


### PR DESCRIPTION
## Summary

- **3 new composable leaf skills** that work independently or as composed steps in `/autopilot`:
  - `/qa` — browser-based QA with 5 browser tools compared (Playwright MCP/CLI, Chrome MCP, agent-browser, Stagehand/Browserbase, DevTools MCP), evidence capture patterns, QA protocol
  - `/demo` — demo artifact pipeline from screenshots/GIFs → Remotion video composition → TTS narration (ElevenLabs/OpenAI/Cartesia) → PR evidence upload
  - `/agent-readiness` — Factory AI-style codebase assessment: 8 pillars, 64 binary checks, gated L1-L5 maturity levels, parallel subagent dispatch, automated remediation
- **Composable skill architecture**: `/autopilot` steps 5-6 now delegate to `/qa` and `/demo` instead of inlining. Each skill is independently invocable.
- **bootstrap.sh**: Parent-dir symlinks in local mode — new skills auto-appear without re-bootstrapping. Falls back to per-skill links when non-spellbook entries exist (Codex `.system/`).
- **post-commit hook**: Re-links all harnesses when `skills/` or `agents/` content changes in a commit.
- **CLAUDE.md**: Removed hard "8 skills, 7 agents" count. Now "focused set — resist bloat, justify additions."

## Test plan

- [x] `bootstrap.sh` runs clean across all 3 harnesses (claude, codex, pi)
- [x] Parent-dir symlink works for claude/pi; per-skill fallback works for codex
- [x] New skills auto-discovered: 12 skills across all harnesses
- [x] post-commit hook fires and re-links on commit
- [x] pre-commit hook regenerates index.yaml
- [x] All SKILL.md files under 500 lines (175, 140, 156)
- [x] No dangling references (settle updated, autopilot cleaned)
- [ ] `/qa` triggers on "run QA", "test this", "check the app"
- [ ] `/demo` triggers on "make a demo", "PR evidence", "launch video"
- [ ] `/agent-readiness` triggers on "readiness report", "agent-ready"
- [ ] `/autopilot` composes `/qa` and `/demo` in steps 5-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/agent-readiness` command to assess and improve AI agent readiness across eight pillars (style, build, testing, documentation, dev environment, code quality, observability, security)
  * Added `/qa` command for browser-based exploratory testing and evidence capture
  * Added `/demo` command for generating demo artifacts (GIFs, videos, PR uploads)

* **Chores**
  * Automated skills/agents re-linking via new Git post-commit hook
  * Updated skill index and bootstrap linking logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->