### PR TITLE
chore(perms): replace deprecated gemini CLI lane with agy + omp

### DIFF
--- a/harnesses/claude/settings.json
+++ b/harnesses/claude/settings.json
@@ -37,7 +37,8 @@
       "Bash(tree:*)",
       "Bash(topydo:*)",
       "Bash(thinktank:*)",
-      "Bash(gemini:*)",
+      "Bash(agy:*)",
+      "Bash(omp:*)",
       "Bash(curl -s https://api.x.ai/:*)",
       "Bash(curl -s https://api.exa.ai/:*)"
     ],

--- a/harnesses/shared/AGENTS.md
+++ b/harnesses/shared/AGENTS.md
@@ -181,11 +181,12 @@ stacks; work with that grain, not against it.
   fresh-context critic on a different model family has decorrelated failure
   modes. Give critics ONLY the artifact (diff + oracle); never the author's
   reasoning trail.
-- **Peer harness CLIs are available** — codex, pi, goose, opencode,
+- **Peer harness CLIs are available** — codex, pi, goose, opencode, omp,
   cursor-agent, grok, agy, hermes, thinktank, and claude itself. Prefer
-  well-designed open-model lanes through Pi/Goose/OpenCode on OpenRouter when
-  they are smoke-tested for the task; use Claude, Antigravity, Cursor, or Grok
-  only when their specific surface answers a distinct question.
+  well-designed open-model lanes through Pi/Goose/OpenCode/omp on OpenRouter
+  when they are smoke-tested for the task; use Claude, Antigravity, Cursor, or
+  Grok only when their specific surface answers a distinct question. (Gemini
+  CLI is retired — superseded by Antigravity/`agy`; do not reach for it.)
 - **Sprites are substrate, not providers.** Route heavy, long-running,
   detached, or isolation-needing lanes to `/sprites` regardless of which
   model runs them.

--- a/skills/harness-engineering/references/preferred-stack.md
+++ b/skills/harness-engineering/references/preferred-stack.md
@@ -80,9 +80,10 @@ alone unless they sleep most of the time or can be rewritten to Workers/D1.
   peer lanes, and local evidence loops.
 - **Fly Sprites for heavy or isolated lanes**: remote sandboxes, golden
   checkpoints, long-running or parallel work.
-- **Pi/Goose/OpenCode on OpenRouter for open-model breadth** when smoke-tested;
-  use Claude, Codex, Cursor, Antigravity, or Grok when their particular surface
-  answers a distinct question.
+- **Pi/Goose/OpenCode/omp on OpenRouter for open-model breadth** when
+  smoke-tested; use Claude, Codex, Cursor, Antigravity, or Grok when their
+  particular surface answers a distinct question. (Gemini CLI is retired —
+  use Antigravity/`agy` for a Google-family lane.)
 
 ## Design And Artifact Surfaces
 


### PR DESCRIPTION
The claude harness template carried a `Bash(gemini:*)` allow-rule that kept the **deprecated** `gemini` CLI a zero-friction pick for cross-model review lanes — which is how it got grabbed in practice, even though the roster already steers to `agy`/Antigravity (ticket 062 migrated the harness to Antigravity per Google's Gemini-CLI → Antigravity transition).

Replace it with the two installed, current lanes:
- **`agy`** — Antigravity, the official Gemini-CLI successor (per `_done/062`)
- **`omp`** — the OpenRouter workhorse the fleet already runs (model-agnostic; fully non-Gemini)

The active `~/.claude/settings.json` was updated in lockstep (and the post-commit bootstrap re-copies this template, so they stay consistent). Removing the allow-rule (rather than denying) leaves `gemini` available for the documented one-time migration/import path — just no longer auto-permitted.

No other live enabler exists: remaining `gemini` strings in the repo are Antigravity's own `~/.gemini/` config dir, `_done/` migration history, judge-model names, and antipattern provider tags — all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)