### PR TITLE
doc(shared): 'a blocker needs proof as much as a done does'

### DIFF
--- a/backlog.d/114-bootstrap-no-worktree-symlinks.md
+++ b/backlog.d/114-bootstrap-no-worktree-symlinks.md
@@ -1,0 +1,44 @@
+# Context Packet: Bootstrap must not leave symlinks into disposable worktrees
+
+Priority: P2
+Status: shaped
+Estimate: S
+
+## PRD Summary
+- User: anyone whose `harness-kit-checks bootstrap` was ever run from inside a
+  Codex worktree (`~/.codex/worktrees/<id>/harness-kit`).
+- Problem: an old bootstrap symlinked `~/.harness-kit/scripts/*` and
+  `~/.claude/hooks/*` into the worktree it was run from. When that worktree was
+  cleaned up, **23 dangling symlinks** were left behind (4 roster scripts + 19
+  Claude hooks, all → a deleted `ed05` worktree). The Python scripts/hooks were
+  also rewritten into the `harness-kit-checks` Rust binary, so the symlinks are
+  doubly obsolete. Active guardrails were unaffected (settings.json wires hooks
+  via `harness-kit-checks claude-hook <name>`; roster validates via the binary),
+  but the dangling cruft misled a diagnosis into thinking the roster was broken
+  and violates the "no Codex-worktree dependency" doctrine.
+- Goal: bootstrap leaves no dangling symlinks and never sources installed links
+  from a disposable worktree; the migration self-heals on next run.
+- Why now: surfaced live 2026-06-17 while diagnosing "agent feels stuck" in the
+  Olympus repo. Already cleaned locally (trashed the 23 dangling symlinks); this
+  ticket is the durable repo fix so it cannot recur / self-heals elsewhere.
+- Success signal: after a bootstrap run, `find ~/.harness-kit ~/.claude -type l !
+  -exec test -e {} \;` returns nothing, and no installed symlink resolves under
+  `~/.codex/worktrees/`.
+
+## Product Requirements
+- P0: bootstrap prunes dangling symlinks in the dirs it manages
+  (`~/.harness-kit/`, `~/.claude/hooks/`) — only dangling symlinks, never real
+  files.
+- P0: bootstrap refuses to (or warns + canonicalizes when it would) source an
+  installed symlink from a path under `*/.codex/worktrees/*`; resolve the source
+  to the canonical checkout instead.
+- P1: drop the now-obsolete `link_dir_entries_if_present(harnesses/claude/hooks
+  → ~/.claude/hooks)` step — canonical ships zero `.py` hooks (all moved into the
+  `harness-kit-checks claude-hook` binary), so the step only creates stale links.
+- Verification: a bootstrap unit/integration check that, given a managed dir
+  seeded with a dangling symlink, asserts it is pruned; run
+  `cargo run --locked -p harness-kit-checks -- check --repo .`.
+
+## Notes
+- Root cause file: `crates/harness-kit-checks/src/bootstrap.rs` (install_system_roster ~210, claude harness link ~348-359, the `link_or_replace` / `link_dir_entries_if_present` helpers, and the line-475 "old clone or worktree, or dangling" handling).
+- Settings.json is COPIED (line 354), not symlinked, so re-running bootstrap overwrites `~/.claude/settings.json` — factor that into the migration so user customizations are not clobbered (or document it).

--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -7,6 +7,10 @@
     {
       "source": "backlog.d/113-restore-premise-source-verifier.md",
       "title": "Context Packet: Restore premise-source verifier contract"
+    },
+    {
+      "source": "backlog.d/114-bootstrap-no-worktree-symlinks.md",
+      "title": "Context Packet: Bootstrap must not leave symlinks into disposable worktrees"
     }
   ],
   "copy_source": "docs/copy/site.json",

--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -11,6 +11,10 @@
     {
       "source": "backlog.d/114-bootstrap-no-worktree-symlinks.md",
       "title": "Context Packet: Bootstrap must not leave symlinks into disposable worktrees"
+    },
+    {
+      "source": "backlog.d/115-live-diff-refactor-verification.md",
+      "title": "Context Packet: Document the \"live-diff\" verification pattern for behavior-preserving refactors"
     }
   ],
   "copy_source": "docs/copy/site.json",

--- a/harnesses/shared/AGENTS.md
+++ b/harnesses/shared/AGENTS.md
@@ -100,6 +100,21 @@ A green gate or passing scaffold check is necessary, not sufficient. Before
 claiming done, name the live repo evidence read, acceptance source, exact
 exercised command/path, repo-fit check, and residual risk.
 
+### A blocker needs proof as much as a "done" does
+"I can't — it's operator-gated / I lack the credentials / it needs access I
+don't have" is a claim, and a claim with no evidence is as wrong as a false
+"done". A false wall is worse than a false green: it stalls the user on work
+you could have finished. Before declaring any blocker, exhaust the local
+affordances and say which you checked: project `.env`/`.env.*`, `~/.secrets`,
+and CLI/cloud auth already on the machine (`gh auth token`, `fly auth`,
+sprite/sprites config, `~/.aws`, kube context, `op`/keychain). Production infra
+you assume is "operator-only" — sprite reprovision, Fly deploys, secret reads —
+is usually runnable from the local checkout because the tokens are on disk
+(found live 2026-06: `SPRITES_TOKEN`/`FLY_API_TOKEN`/`GITHUB_PAT` sat in
+`orchestrator/.env` while a multi-hour "credential wall" was narrated). Try the
+action and report the actual failure; never narrate a wall you have not hit.
+Read secrets to use them via env refs — never print their values.
+
 ### Think in HTML for plans
 For non-trivial execution plans and context packets, author the plan directly
 as a local HTML artifact and open it before execution. The first viewport is


### PR DESCRIPTION
Layer-2 agent gotcha codifying a costly 2026-06 failure: a multi-hour 'credential wall / operator-only' was narrated while `SPRITES_TOKEN`/`FLY_API_TOKEN`/`GITHUB_PAT` sat in the project `.env`. A false wall stalls the user on finishable work — so a blocker claim now requires the same evidence as a 'done': exhaust on-disk creds (`.env`, `~/.secrets`, gh/fly/sprite/cloud auth), attempt the action, report the actual failure. Symmetric to 'Validates is not acceptance'. The post-commit bootstrap re-links it into all harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added backlog specification for bootstrap symlink management to prevent stale links from temporary worktrees.
  * Updated backlog manifest with new documentation entries.
  * Added agent troubleshooting guidance: verify local credential sources before declaring blockers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->