### PR TITLE
docs(skills): require metadata secret scanning in repo gates

### DIFF
--- a/crates/harness-kit-checks/src/agent_roster.rs
+++ b/crates/harness-kit-checks/src/agent_roster.rs
@@ -1819,7 +1819,11 @@ providers:
             },
         )?;
 
-        assert!(started.elapsed().as_secs_f64() < 2.0);
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "dispatch timeout cleanup took {elapsed:?}"
+        );
         assert_eq!(receipt["provider_status"], "error");
         assert_eq!(receipt["attempt_status"], "failed");
         assert!(receipt["summary"].as_str().unwrap().contains("timed out"));

--- a/crates/harness-kit-checks/src/git_hooks.rs
+++ b/crates/harness-kit-checks/src/git_hooks.rs
@@ -96,15 +96,15 @@ pub fn run_pre_push(repo: &Path, pre_push_input: &str) -> Result<String> {
 
     let changes = changed_paths_for_push(repo, pre_push_input)?;
     log_push_classification(&mut lines, &changes);
-    if changes.paths.is_empty() {
-        lines.push("pre-push: no pushed file changes detected; skipping local gates".to_string());
-        return Ok(lines.join("\n"));
-    }
-
-    if !changes.force_full && push_allows_fast_gate(&changes.paths) {
-        run_fast_pre_push_gate(repo, &mut lines, &changes.paths)?;
-    } else {
-        run_full_pre_push_gate(repo, &mut lines)?;
+    match pre_push_gate_decision(&changes) {
+        PrePushGateDecision::Skip => {
+            lines.push(
+                "pre-push: no pushed file changes detected; skipping local gates".to_string(),
+            );
+            return Ok(lines.join("\n"));
+        }
+        PrePushGateDecision::Fast => run_fast_pre_push_gate(repo, &mut lines, &changes.paths)?,
+        PrePushGateDecision::Full => run_full_pre_push_gate(repo, &mut lines)?,
     }
     Ok(lines.join("\n"))
 }
@@ -136,6 +136,27 @@ struct PushChangeSet {
     paths: Vec<String>,
     source: String,
     force_full: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PrePushGateDecision {
+    Skip,
+    Fast,
+    Full,
+}
+
+fn pre_push_gate_decision(changes: &PushChangeSet) -> PrePushGateDecision {
+    if changes.force_full {
+        return PrePushGateDecision::Full;
+    }
+    if changes.paths.is_empty() {
+        return PrePushGateDecision::Skip;
+    }
+    if push_allows_fast_gate(&changes.paths) {
+        PrePushGateDecision::Fast
+    } else {
+        PrePushGateDecision::Full
+    }
 }
 
 fn changed_paths_for_push(repo: &Path, pre_push_input: &str) -> Result<PushChangeSet> {
@@ -617,6 +638,26 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("decision full local gate"))
         );
+    }
+
+    #[test]
+    fn conservative_pre_push_classification_runs_full_gate_even_without_paths() {
+        let changes = PushChangeSet {
+            paths: Vec::new(),
+            source: "new refs/heads/topic".to_string(),
+            force_full: true,
+        };
+        assert_eq!(pre_push_gate_decision(&changes), PrePushGateDecision::Full);
+    }
+
+    #[test]
+    fn empty_non_conservative_pre_push_classification_skips() {
+        let changes = PushChangeSet {
+            paths: Vec::new(),
+            source: "fallback diff origin/master..HEAD".to_string(),
+            force_full: false,
+        };
+        assert_eq!(pre_push_gate_decision(&changes), PrePushGateDecision::Skip);
     }
 
     #[test]

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Harness Kit Index
-# Generated: 2026-06-17T19:33:33Z
+# Generated: 2026-06-19T00:11:53Z
 # Do not edit manually. Run: harness-kit-checks generate-index --repo .
 
 skills:

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -26,6 +26,12 @@ The gate is implemented in Rust at
 experimental runner, but it is not the default local gate, not required for
 pre-push, and not the source of truth for shipping this repo.
 
+When `/ci` runs in a consumer repo, do not assume Harness Kit's Rust gate is
+installed there. Read that repo's root instructions, package manifests, CI
+workflows, hook config, and shipped scripts, then strengthen the repo-owned
+gate. Harness Kit can supply reusable checks, but the acceptance question is
+whether that repo has an active gate an agent will actually hit.
+
 ## Modes
 
 - Default: audit the gate surface, fix mechanical gaps, then run the Rust gate.
@@ -49,6 +55,11 @@ pre-push, and not the source of truth for shipping this repo.
 5. **Fix-until-green on self-healable failures.** Formatting drift, stale
    generated docs/index, and trivial lints get fixed. Logic failures get a
    precise diagnosis.
+6. **Security floor is part of CI.** A credible repo gate prevents or fails on
+   secret leaks in source files, generated artifacts, logs, and Git/PR
+   metadata. Commit subjects/bodies, PR titles/bodies, release notes, and
+   agent-generated summaries are in scope. Prefer server-side push protection
+   or pre-receive hooks when available; otherwise require repo hooks plus CI.
 
 ## Delegation Judgment
 
@@ -72,6 +83,12 @@ Check the live gate surface:
 - `ci_check.rs` contains the default lane list.
 - Generated docs/index are current after skill/docs/backlog changes.
 - Dagger references are legacy/optional only, never mandatory local closeout.
+- Secret scanning covers both committed content and metadata that never appears
+  in the working tree: commit message file, outbound commit range, PR title/body,
+  and release/changelog text. The report must redact matched values.
+
+For non-Harness Kit repos, replace the Harness Kit-specific bullets above with
+that repo's equivalent gate contract, then apply the same security floor.
 
 ## Run
 

--- a/skills/ci/references/audit.md
+++ b/skills/ci/references/audit.md
@@ -4,6 +4,10 @@ Use this to decide whether the Rust-owned local gate is strong enough to trust.
 For Harness Kit, default CI lives in
 `crates/harness-kit-checks/src/ci_check.rs`, not Dagger.
 
+For consumer repos, first identify the repo-owned gate from root instructions,
+package manifests, CI workflows, hooks, and shipped scripts. Do not assume the
+Harness Kit Rust gate runs there. Apply this rubric to the repo's actual gate.
+
 ## Required Checks
 
 - `cargo run --locked -p harness-kit-checks -- check --repo .` exists and runs.
@@ -16,6 +20,13 @@ For Harness Kit, default CI lives in
   eval, no-claims, portable-path, conflict-marker, and deliver-composition
   checks are covered.
 - Rust `fmt`, `test`, and `clippy -D warnings` are covered.
+- Secret scanning covers both working-tree content and Git/PR metadata:
+  commit message file, outbound commit subjects/bodies, PR title/body, release
+  notes, changelog text, generated summaries, and logs. Findings must identify
+  the field and rule without printing the secret value.
+- At least one protection runs before remote publication: server-side push
+  protection or pre-receive hook when available; otherwise `commit-msg` plus
+  `pre-push` hooks. CI is still required because local hooks can be bypassed.
 
 ## Speed Rules
 
@@ -29,7 +40,7 @@ For Harness Kit, default CI lives in
 
 | Severity | Meaning | Action |
 |---|---|---|
-| high | Missing local gate, hook still calls Dagger, or source changes bypass checks | Fix inline |
+| high | Missing local gate, hook still calls Dagger, source changes bypass checks, or secrets can reach remote commit/PR metadata unscanned | Fix inline |
 | med | Gate is too slow, noisy, or duplicates an invariant | Simplify inline or file backlog |
 | low | Naming/docs drift | Fix when touching nearby files |
 

--- a/skills/groom/SKILL.md
+++ b/skills/groom/SKILL.md
@@ -134,8 +134,9 @@ decorrelate judgment, not to fill a roster.
   routes/commands (the highest-impact skill category)? Verified build/test/
   lint commands and conventions an agent can discover cold? Runbooks for
   its deployed surfaces? A CI gate that would catch the likely failure?
-  Stale AGENTS/CLAUDE prose? Product context a cold agent would need? Each
-  gap is a ticket like any other.
+  Security gates that catch secret leaks in files and Git/PR metadata before
+  publication? Stale AGENTS/CLAUDE prose? Product context a cold agent would
+  need? Each gap is a ticket like any other.
 - **Vet findings before presenting them.** Re-check each claim against the
   live repo — open the file, run the command. A plausible finding that
   doesn't survive a second look is noise that erodes trust in the whole

--- a/skills/groom/references/mega-groom.md
+++ b/skills/groom/references/mega-groom.md
@@ -30,9 +30,9 @@ Every strategic groom accounts for these surfaces. Mark a surface `complete`,
 | Architecture and system design | Are the deep modules deep, the boundaries honest, and the interfaces small? |
 | Code quality and simplicity | What can be deleted, flattened, clarified, or made harder to misuse? |
 | Runtime reliability | What fails under load, restart, queue pressure, retries, or partial outages? |
-| Security and privacy | Where can secrets, tokens, user data, or authority leak or overreach? |
+| Security and privacy | Where can secrets, tokens, user data, metadata, logs, or authority leak or overreach? |
 | Observability and ops | Can an operator see state, cost, queue pressure, incidents, and recovery actions? |
-| Tests and verification | Do gates prove the live behavior that matters, not just units? |
+| Tests and verification | Do gates prove the live behavior that matters, not just units, and do they fail the likely security mistakes before publication? |
 | Documentation and onboarding | Can a cold agent or human understand, run, extend, and debug the project? |
 | Agent readiness | Are skills, AGENTS, lane cards, receipts, and CLI JSON surfaces first-class? |
 | Infrastructure and delivery | Are deploys, rollbacks, backups, hosted checks, and local dev boring? |
@@ -99,7 +99,10 @@ The final groom report should include:
 3. **World-Class Target**: the best version of the project in concrete terms.
 4. **Gap Map**: what live evidence says is missing or weak by surface.
 5. **Verification Map**: missing or weak gates, QA paths, evals, benchmarks,
-   probes, and repo-local verification skills.
+   probes, repo-local verification skills, and secret/content/metadata leak
+   checks. Treat missing commit-message, outbound-range, PR-body, log, and
+   generated-artifact scanning as agent-readiness gaps unless the repo has a
+   stronger server-side control.
 6. **Strategy Themes**: 4-8 themes, each with recommendation first and evidence
    second.
 7. **Backlog Diff**: applied ticket edits/emissions and proposed deletions.


### PR DESCRIPTION
## Summary
- require CI/groom audits to treat secret leaks in source, generated artifacts, logs, and Git/PR metadata as in-scope gate failures
- clarify consumer-repo CI audits so agents read the repo-owned gate instead of assuming Harness Kit's Rust gate exists everywhere
- fix Harness Kit pre-push classification so conservative/new-ref pushes run the full local gate even when Git reports no changed paths
- stabilize the roster timeout test so full-suite timing jitter does not flap CI while still catching hangs near the fake 60s child process

## Verification
- cargo test --locked -p harness-kit-checks git_hooks -- --nocapture
- cargo test --locked -p harness-kit-checks agent_roster::tests::dispatch_timeout_kills_process_group_and_records_transcript -- --nocapture
- cargo run --locked -p harness-kit-checks -- check --repo .
- pre-push hook on force-with-lease push ran full local gate and passed