### PR TITLE
docs(harness): bound non-skill tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,13 @@ disk; do not restate obvious filesystem facts.
 - `index.yaml` is generated. Never edit it by hand.
 - `harnesses/claude/settings.json` is copied by bootstrap; changes require
   re-bootstrap.
-- Durable tooling is Rust in `crates/harness-kit-checks`. The only allowed
-  non-Rust implementation surface is `bootstrap.sh` as the curl-compatible
-  Rust launcher. Every gate must name a real failure it catches; gates that
-  enforce prose structure are the historical failure mode here.
+- Skill scripts/libs/references live under the skill they serve. Code outside a
+  skill must serve only this source repo's maintenance, generated artifacts,
+  bootstrap/install, or harness configuration.
+- Durable repo/install tooling is Rust in `crates/harness-kit-checks`. The only
+  allowed non-Rust implementation surface is `bootstrap.sh` as the
+  curl-compatible Rust launcher. Every gate must name a real failure it catches;
+  gates that enforce prose structure are the historical failure mode here.
 - Harness Kit source skills live only in `skills/`. Do not commit source-repo
   `.agents/skills/`, `.codex/skills/`, `.claude/skills/`, `.pi/skills/`, or
   `.antigravitycli/skills/` bridges; those duplicate the global install here.

--- a/backlog.d/115-live-diff-refactor-verification.md
+++ b/backlog.d/115-live-diff-refactor-verification.md
@@ -1,0 +1,70 @@
+# Context Packet: Document the "live-diff" verification pattern for behavior-preserving refactors
+
+Priority: P2
+Status: shaped
+Estimate: S
+
+## PRD Summary
+- User: any agent running `/deliver` or `/qa` on a behavior-preserving
+  refactor (extract-to-module, route-thinning, dedup) whose target has little
+  or no automated test coverage — i.e. the refactor must prove it changed
+  *nothing observable*, but there is no test suite that pins the current
+  behavior.
+- Problem: the verification-system-first reference covers building a driver +
+  grader for *new* behavior, but the hardest refactors are the ones where the
+  oracle is "identical to before" and the codebase gives you no characterization
+  net. Agents default to "unit tests pass" — which structurally cannot catch the
+  integration bug between the refactored layer and its real dependencies, the
+  exact thing a lift is most likely to break.
+- Goal: name the **live-diff** technique as a first-class verification pattern so
+  it gets reached for by default on coverage-poor refactors: prove equivalence by
+  byte-diffing the live surface — the local refactor branch vs the already-deployed
+  prod build — both pointed at the **same backing store**. Identical responses
+  across a representative set of reads, plus error/404 parity, = behavior
+  preserved. Divergence is the bug, located precisely.
+- Why now: used live on 2026-06-17/18 to ship Habitat HA-033 (work-items lift)
+  and HA-034 (planning lift). The planning routes had **zero** route-level tests;
+  repository unit tests + a before/after live diff (local branch vs deployed
+  prod, same Supabase DB → byte-identical list/detail/404 responses) was the only
+  thing that actually proved the 6-route rewrite preserved behavior. It worked and
+  should be codified rather than re-derived.
+- Success signal: the reference names the pattern, its precondition (old code
+  still running against the same store), its failure mode (drift = located bug),
+  and when it does NOT apply — and an agent facing a coverage-poor refactor picks
+  it without being told.
+
+## Product Requirements
+- P0: add a short subsection to
+  `harnesses/shared/references/verification-system-first.md` — call it
+  "Live-diff for behavior-preserving refactors" — covering:
+  - **When**: the oracle is "identical to before" AND the target lacks
+    characterization tests (lifts, route-thinning, convergence, dedup).
+  - **How**: exercise the same representative inputs against (a) the local
+    refactor branch and (b) the deployed/old build, both against the same
+    backing store; diff responses byte-for-byte; include error and not-found
+    paths, not just the happy path.
+  - **Why it bites**: it exercises the real integration the refactor touches —
+    the seam unit tests mock away — which is where lifts actually break.
+  - **Precondition / limits**: needs the pre-refactor behavior still runnable
+    against the same data (deployed prod, a pinned build, or `git stash`+rerun);
+    does NOT apply when the refactor is *meant* to change output (then pin a
+    golden instead), and a read-only diff says nothing about write-path
+    side-effects — diff those via post-state reads or a transaction-scoped probe.
+  - Pair it with repository/unit tests as the structural net; live-diff is the
+    integration net, not a replacement.
+- P1: cross-link from the `/deliver` and `/qa` skills' refactor guidance so the
+  pattern is discoverable at the point of use (or note why a link is not added).
+- Verification: `cargo run --locked -p harness-kit-checks -- check --repo .`
+  green after the doc edit; the reference renders and the new subsection is
+  reachable from its table of contents / heading structure.
+
+## Notes
+- Keep it tight — this is one pattern added to an existing reference, not a new
+  reference file. The reference already establishes claim/falsifier/driver/
+  grader/evidence vocabulary; phrase live-diff in those terms (the deployed build
+  is the grader's reference oracle; the diff is the falsifier).
+- Related existing references: `verification-system-first.md` (host),
+  `quality-system.md` (proof methods), `delete-first.md` (refactor pressure).
+- Origin detail for whoever writes it: Habitat HA-034 close-out evidence —
+  modules/cycles/sprints list GETs (21/4/10 rows) + a detail GET + a bogus-id
+  404, all byte-identical local-branch vs prod against the shared DB.

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Harness Kit Index
-# Generated: 2026-06-19T19:18:17Z
+# Generated: 2026-06-19T19:53:21Z
 # Do not edit manually. Run: harness-kit-checks generate-index --repo .
 
 skills:

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Harness Kit Index
-# Generated: 2026-06-19T19:53:21Z
+# Generated: 2026-06-19T19:57:59Z
 # Do not edit manually. Run: harness-kit-checks generate-index --repo .
 
 skills:

--- a/skills/harness-engineering/SKILL.md
+++ b/skills/harness-engineering/SKILL.md
@@ -61,8 +61,11 @@ not skills.
   smoke-tested open-model peer lanes through Pi, Goose, and OpenCode on
   OpenRouter; keep Claude, Antigravity, Cursor, and Grok conditional unless
   their specific surface answers the task.
-- Skills stay self-contained: scripts/references under the skill; state roots
-  from invoking repo.
+- Skills stay self-contained: scripts/libs/references under the skill; state
+  roots from invoking repo.
+- Code outside a skill serves only Harness Kit source-repo maintenance,
+  generated artifacts, bootstrap/install, or harness configuration. It is not a
+  place for skill behavior.
 - Treat a skill as a folder, not a markdown file. Use scripts, references,
   examples, templates, assets, evals, or append-only data when prose would
   make the agent reconstruct repeatable work.

--- a/skills/next/SKILL.md
+++ b/skills/next/SKILL.md
@@ -32,12 +32,19 @@ Read the smallest useful surface for the scope:
 - `git status --short --branch --untracked-files=all` when in a repo
 - active branch, upstream, dirty/unpushed state, and recent commits
 - open `backlog.d/*.md` titles when backlog priority is in scope
+- live tracker queues across delivery states when an external tracker is in
+  scope: at minimum `ready_for_dev`, `verification`, `in_progress`, and
+  `blocked`/prerequisite-bearing items
 - current plan, goal, PR, issue, or acceptance oracle when present
 - recent closeout signal: shipped commit, archived backlog, PR status, or
   blocker note
 
 Prefer live files and commands over remembered thread state. If external facts
 would determine the next move, say which fact is missing rather than guessing.
+Do not treat one empty scoped filter as absence of work. If a module/repo
+filter returns nothing but the operator asked for that product area, broaden by
+status, prefix, module id/name, open PRs, and verification/residual items before
+recommending work outside that area.
 
 ## Report Shape
 
@@ -63,6 +70,7 @@ Keep it compact. The default answer should fit on one screen.
 | Clean feature branch, work complete | `/ship` or PR closeout |
 | Unshaped idea, unclear acceptance | `/shape` |
 | Open prioritized backlog, no active branch | `/groom` summary, then one pickup |
+| Item already in verification | `/qa` or closeout before new delivery |
 | Broken gate, failing app, unclear root cause | `/diagnose` |
 | Running surface needs proof | `/qa` |
 | User asks "what do I need to do?" | Separate user external action from agent action |
@@ -76,6 +84,12 @@ Keep it compact. The default answer should fit on one screen.
   an agent task unless the tool can actually do it.
 - Do not redefine success around what is easy to do locally. Name the real
   acceptance or blocker.
+- Do not recommend a new repo just because the active repo has no
+  `ready_for_dev` items. Check verification, in-progress, recently shipped PRs,
+  and blocked/prerequisite items first; finishing or proving existing work
+  usually beats starting a new ticket.
+- Treat title/description blockers as real even when status says ready. Name the
+  prerequisite instead of presenting the item as immediately deliverable.
 - Do not start a delivery workflow unless the user asked you to act or passed
   `--act-if-safe` and the first step is reversible.
 - Do not answer from stale memory when a live repo/status read is cheap.


### PR DESCRIPTION
## Summary
- codify that skill scripts/libs/references must live under the skill they serve
- limit non-skill code to Harness Kit source maintenance, generated artifacts, bootstrap/install, and harness configuration
- add shaped backlog 115 for live-diff refactor verification

## Verification
- `cargo run --locked -p harness-kit-checks -- check --repo .`

## Notes
- Pre-push classified the new remote ref as no-op and skipped local gates; the full Harness Kit gate was run manually before push.