### PR TITLE
ci: run harness kit gate in hosted ci

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-if command -v harness-kit-checks >/dev/null 2>&1; then
-  exec harness-kit-checks git-hook post-commit "$@"
-fi
 if command -v cargo >/dev/null 2>&1 && [ -f "$repo_root/Cargo.toml" ]; then
   exec cargo run --quiet --locked -p harness-kit-checks -- git-hook post-commit "$@"
+fi
+if command -v harness-kit-checks >/dev/null 2>&1; then
+  exec harness-kit-checks git-hook post-commit "$@"
 fi
 echo "post-commit: harness-kit-checks unavailable; install the Rust CLI or cargo." >&2
 exit 1

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-if command -v harness-kit-checks >/dev/null 2>&1; then
-  exec harness-kit-checks git-hook post-merge "$@"
-fi
 if command -v cargo >/dev/null 2>&1 && [ -f "$repo_root/Cargo.toml" ]; then
   exec cargo run --quiet --locked -p harness-kit-checks -- git-hook post-merge "$@"
+fi
+if command -v harness-kit-checks >/dev/null 2>&1; then
+  exec harness-kit-checks git-hook post-merge "$@"
 fi
 echo "post-merge: harness-kit-checks unavailable; install the Rust CLI or cargo." >&2
 exit 1

--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-if command -v harness-kit-checks >/dev/null 2>&1; then
-  exec harness-kit-checks git-hook post-rewrite "$@"
-fi
 if command -v cargo >/dev/null 2>&1 && [ -f "$repo_root/Cargo.toml" ]; then
   exec cargo run --quiet --locked -p harness-kit-checks -- git-hook post-rewrite "$@"
+fi
+if command -v harness-kit-checks >/dev/null 2>&1; then
+  exec harness-kit-checks git-hook post-rewrite "$@"
 fi
 echo "post-rewrite: harness-kit-checks unavailable; install the Rust CLI or cargo." >&2
 exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,12 +3,12 @@ set -euo pipefail
 
 repo_root="$(git rev-parse --show-toplevel)"
 
-if command -v harness-kit-checks >/dev/null 2>&1; then
-  exec harness-kit-checks git-hook pre-commit
-fi
-
 if command -v cargo >/dev/null 2>&1 && [ -f "$repo_root/Cargo.toml" ]; then
   exec cargo run --quiet --locked -p harness-kit-checks -- git-hook pre-commit
+fi
+
+if command -v harness-kit-checks >/dev/null 2>&1; then
+  exec harness-kit-checks git-hook pre-commit
 fi
 
 echo "pre-commit: harness-kit-checks unavailable; install the Rust CLI or cargo." >&2

--- a/.githooks/pre-merge-commit
+++ b/.githooks/pre-merge-commit
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
-if command -v harness-kit-checks >/dev/null 2>&1; then
-  exec harness-kit-checks git-hook pre-merge-commit "$@"
-fi
 if command -v cargo >/dev/null 2>&1 && [ -f "$repo_root/Cargo.toml" ]; then
   exec cargo run --quiet --locked -p harness-kit-checks -- git-hook pre-merge-commit "$@"
+fi
+if command -v harness-kit-checks >/dev/null 2>&1; then
+  exec harness-kit-checks git-hook pre-merge-commit "$@"
 fi
 echo "pre-merge-commit: harness-kit-checks unavailable; install the Rust CLI or cargo." >&2
 exit 1

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
-if command -v harness-kit-checks >/dev/null 2>&1; then
-  exec harness-kit-checks git-hook pre-push "$@"
-fi
 if command -v cargo >/dev/null 2>&1 && [ -f "$repo_root/Cargo.toml" ]; then
   exec cargo run --quiet --locked -p harness-kit-checks -- git-hook pre-push "$@"
+fi
+if command -v harness-kit-checks >/dev/null 2>&1; then
+  exec harness-kit-checks git-hook pre-push "$@"
 fi
 echo "pre-push: harness-kit-checks unavailable; install the Rust CLI or cargo." >&2
 exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  harness-kit-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: oven-sh/setup-bun@v2
+      - name: Install gate tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          cargo install cargo-deny --version 0.19.9 --locked
+      - run: cargo run --locked -p harness-kit-checks -- check --repo .

--- a/crates/harness-kit-checks/src/ci_check.rs
+++ b/crates/harness-kit-checks/src/ci_check.rs
@@ -1,10 +1,9 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
-use crate::{docs_site, frontmatter, generate_index, lint_gates, quality_gates};
+use crate::{docs_site, frontmatter, generate_index, lint_gates, process, quality_gates};
 
 pub fn run(repo: &Path) -> Result<Vec<String>> {
     let repo = repo.canonicalize().unwrap_or_else(|_| repo.to_path_buf());
@@ -122,6 +121,9 @@ fn lint_yaml(repo: &Path) -> Result<()> {
 
 fn lint_shell(repo: &Path) -> Result<()> {
     if !command_exists("shellcheck") {
+        if std::env::var_os("CI").is_some() {
+            bail!("shellcheck is required in CI but was not found on PATH");
+        }
         return Ok(());
     }
     let mut paths = Vec::new();
@@ -193,7 +195,8 @@ fn run_command(repo: &Path, command: &str, args: &[&str]) -> Result<()> {
 }
 
 fn run_command_in(cwd: &Path, command: &str, args: &[&str]) -> Result<()> {
-    let output = Command::new(command)
+    let mut process = process::command(command);
+    let output = process
         .args(args)
         .current_dir(cwd)
         .output()

--- a/crates/harness-kit-checks/src/docs_site.rs
+++ b/crates/harness-kit-checks/src/docs_site.rs
@@ -227,7 +227,7 @@ pub fn validate_site(options: &CheckOptions) -> Result<()> {
     if options.compare_to_rebuild {
         let temp = tempfile::tempdir().context("failed to create temporary directory")?;
         let rebuilt = temp.path().join("site");
-        let output = Command::new("cargo")
+        let output = crate::process::command("cargo")
             .args([
                 "run",
                 "--locked",
@@ -397,7 +397,7 @@ pub fn self_test(repo: &Path) -> Result<()> {
             fs::remove_dir_all(image_root)?;
         }
         run_checked(
-            Command::new("cargo")
+            crate::process::command("cargo")
                 .args([
                     "run",
                     "--locked",
@@ -410,7 +410,7 @@ pub fn self_test(repo: &Path) -> Result<()> {
             "harness-kit-checks build-docs-site",
         )?;
         run_checked(
-            Command::new("cargo")
+            crate::process::command("cargo")
                 .args([
                     "run",
                     "--locked",

--- a/crates/harness-kit-checks/src/lib.rs
+++ b/crates/harness-kit-checks/src/lib.rs
@@ -13,6 +13,7 @@ pub mod git_hooks;
 pub mod lane_harness;
 pub mod lint_gates;
 pub mod pr_reviews;
+pub mod process;
 pub mod quality_gates;
 pub mod scout_skills;
 pub mod skill_invocation_analytics;

--- a/crates/harness-kit-checks/src/main.rs
+++ b/crates/harness-kit-checks/src/main.rs
@@ -11,7 +11,7 @@ use harness_kit_checks::{
 
 fn main() {
     if let Err(error) = run(env::args().skip(1).collect()) {
-        eprintln!("{error}");
+        eprintln!("{error:#}");
         std::process::exit(1);
     }
 }
@@ -310,12 +310,12 @@ fn print_lines_or_exit(result: anyhow::Result<Vec<String>>) {
                 println!("{line}");
             }
         }
-        Err(_) => std::process::exit(1),
+        Err(error) => exit_error(error),
     }
 }
 
 fn exit_error<T>(error: anyhow::Error) -> T {
-    eprintln!("{error}");
+    eprintln!("{error:#}");
     std::process::exit(1);
 }
 

--- a/crates/harness-kit-checks/src/process.rs
+++ b/crates/harness-kit-checks/src/process.rs
@@ -1,0 +1,65 @@
+use std::process::Command;
+
+pub fn command(program: &str) -> Command {
+    let mut command = Command::new(program);
+    clear_git_local_env(&mut command);
+    command
+}
+
+pub fn clear_git_local_env(command: &mut Command) {
+    // Git exports these to hooks; child gates must rediscover the repo from cwd
+    // or their own temp checkouts instead of inheriting the hook's gitdir.
+    for key in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_COMMON_DIR",
+        "GIT_CONFIG",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_COUNT",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_PREFIX",
+        "GIT_IMPLICIT_WORK_TREE",
+        "GIT_GRAFT_FILE",
+        "GIT_NO_REPLACE_OBJECTS",
+        "GIT_REPLACE_REF_BASE",
+        "GIT_SHALLOW_FILE",
+    ] {
+        command.env_remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commands_strip_git_hook_environment() {
+        let mut command = Command::new("sh");
+        command
+            .env("GIT_DIR", "/tmp/outer/.git")
+            .env("GIT_WORK_TREE", "/tmp/outer")
+            .env("GIT_CONFIG_COUNT", "1")
+            .env("GIT_INDEX_FILE", "/tmp/outer/.git/index")
+            .env("PATH", "/tmp/bin");
+
+        clear_git_local_env(&mut command);
+
+        let envs = command
+            .get_envs()
+            .map(|(key, value)| {
+                (
+                    key.to_string_lossy().to_string(),
+                    value.map(|value| value.to_string_lossy().to_string()),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert!(envs.contains(&("GIT_DIR".to_string(), None)));
+        assert!(envs.contains(&("GIT_WORK_TREE".to_string(), None)));
+        assert!(envs.contains(&("GIT_CONFIG_COUNT".to_string(), None)));
+        assert!(envs.contains(&("GIT_INDEX_FILE".to_string(), None)));
+        assert!(envs.contains(&("PATH".to_string(), Some("/tmp/bin".to_string()))));
+    }
+}

--- a/crates/harness-kit-checks/src/quality_gates.rs
+++ b/crates/harness-kit-checks/src/quality_gates.rs
@@ -7,11 +7,10 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use anyhow::{Context, Result};
 
-use crate::lint_gates::GateReport;
+use crate::{lint_gates::GateReport, process};
 
 /// Extensions the structural gates treat as "code".
 const SOURCE_EXTENSIONS: &[&str] = &["rs", "ts", "tsx", "js", "py"];
@@ -165,11 +164,16 @@ pub fn check_source_markers(root: &Path) -> Result<GateReport> {
 /// precedent), so the aggregate gate stays runnable without the extra tool.
 pub fn check_supply_chain(root: &Path) -> Result<GateReport> {
     if !command_exists("cargo-deny") {
+        if std::env::var_os("CI").is_some() {
+            return Ok(GateReport::failure(vec![
+                "cargo-deny is required in CI but was not found on PATH.".to_string(),
+            ]));
+        }
         return Ok(GateReport::success(
             "cargo-deny not installed; supply-chain gate skipped (cargo install cargo-deny to enforce).",
         ));
     }
-    let output = Command::new("cargo")
+    let output = process::command("cargo")
         .args(["deny", "check", "bans", "licenses", "sources"])
         .current_dir(root)
         .output()

--- a/meta/INTEGRATION_GUIDE.md
+++ b/meta/INTEGRATION_GUIDE.md
@@ -10,8 +10,8 @@ order:
 This guide is for external systems: SaaS APIs, internal services,
 authenticated data stores, design tools, calendars, mailboxes, issue trackers,
 CI providers, and production systems. Internal Harness Kit tooling such as
-`bootstrap.sh`, `scripts/generate-index.sh`, local Dagger gates, and one-repo
-maintenance helpers do not need MCP-ification.
+`bootstrap.sh`, the Rust-owned local gate, and one-repo maintenance helpers do
+not need MCP-ification.
 
 ## Reach For MCP
 
@@ -39,8 +39,8 @@ Use a simpler shape when the work is local and single-purpose:
 
 - **One-off script:** a migration, cleanup, report, or data transform that will
   run once or a few times.
-- **Inner-loop only:** a repository-local test, formatter, index generator,
-  Dagger gate, or bootstrap helper.
+- **Inner-loop only:** a repository-local test, formatter, generated-artifact
+  check, Rust gate, or bootstrap helper.
 - **Local-dev-only:** a command whose value is direct terminal feedback and
   whose inputs are local files.
 - **No external trust boundary:** the code does not cross auth, user-consent,

--- a/skills/council/scripts/council.sh
+++ b/skills/council/scripts/council.sh
@@ -41,9 +41,15 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-[ -n "$TASK_FILE" ] && [ -f "$TASK_FILE" ] || die "missing/unreadable --task file"
-[ -n "$MEMBERS_FILE" ] && [ -f "$MEMBERS_FILE" ] || die "missing/unreadable --members file"
-[ "$TIMEOUT" -eq "$TIMEOUT" ] 2>/dev/null && [ "$TIMEOUT" -gt 0 ] || die "--timeout must be a positive integer"
+if [ -z "$TASK_FILE" ] || [ ! -f "$TASK_FILE" ]; then
+  die "missing/unreadable --task file"
+fi
+if [ -z "$MEMBERS_FILE" ] || [ ! -f "$MEMBERS_FILE" ]; then
+  die "missing/unreadable --members file"
+fi
+if ! [ "$TIMEOUT" -eq "$TIMEOUT" ] 2>/dev/null || [ "$TIMEOUT" -le 0 ]; then
+  die "--timeout must be a positive integer"
+fi
 [ -n "$OUTDIR" ] || OUTDIR="$(dirname "$MEMBERS_FILE")/council-out"
 mkdir -p "$OUTDIR" || die "cannot create outdir: $OUTDIR"
 


### PR DESCRIPTION
## Summary
- add a thin hosted GitHub Actions caller for the canonical Rust-owned Harness Kit gate
- clarify the integration guide so Dagger is not treated as the local source of truth
- harden child CI commands against Git hook-local env leakage
- make repo-local hooks prefer the checkout's Rust gate over a potentially stale installed binary

## Verification
- `cargo test --locked -p harness-kit-checks ci_check::tests::child_gate_commands_strip_git_hook_environment`
- `cargo run --locked -p harness-kit-checks -- check --repo .`
- direct `.githooks/pre-push` new-branch simulation ran the full Rust gate
- real `git push -u origin HEAD` pre-push path ran the full Rust gate and passed
- `git diff --check`

## Review
- thermo-nuclear review approved the branch with no blockers
- non-blocking risks noted: hard-coded Git-local env list, tag-pinned actions, and existing new-branch log wording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Actions CI workflow to run automated harness checks on pull requests and pushes.
* **Bug Fixes**
  * Updated local Git hooks to prefer the Rust/cargo-based harness when available, with the same fallback/error behavior.
  * Prevented Git-local environment settings from leaking into validation runs.
  * In CI, missing `shellcheck`/`cargo-deny` now fails with clear guidance; improved CLI error formatting.
* **Documentation**
  * Refreshed integration guidance examples and wording.
* **Refactor**
  * Improved argument validation readability in the council script without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->