### PR TITLE
chore(release): adopt Landmark synthesis

### DIFF
--- a/.github/workflows/landmark-release.yml
+++ b/.github/workflows/landmark-release.yml
@@ -1,0 +1,28 @@
+name: Synthesize Release Notes
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: misty-step/landmark@v1
+        with:
+          mode: synthesis-only
+          healthcheck: "true"
+          node-version: "24"
+          release-tag: ${{ github.event.release.tag_name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          changelog-source: auto

--- a/.landmark.yml
+++ b/.landmark.yml
@@ -1,0 +1,14 @@
+product:
+  name: Harness Kit
+  description: Version-controlled primitive layer for portable, evidence-backed agent work.
+audience: developer
+voice: Practical, evidence-backed, and specific to agent operator outcomes.
+changelog:
+  source: auto
+release:
+  profile: synthesis-only
+model:
+  policy: balanced
+budget:
+  max_input_tokens: 12000
+  max_output_tokens: 1200


### PR DESCRIPTION
Adds Landmark release intelligence in synthesis-only mode:

- adds `.landmark.yml`
- adds `.github/workflows/landmark-release.yml` on `release.published`
- keeps existing release ownership unchanged

Verification:
- `/Users/phaedrus/Development/landmark/target/debug/landmark doctor --repo-root /tmp/landmark-fleet.E9PmHX/harness-kit` => manifest ok
- `cargo run --locked -p harness-kit-checks -- check --repo .` => pass
- `HARNESS_KIT_PRE_PUSH=full harness-kit-checks check --repo .` => pass

Agent: Codex
Agent-Surface: Codex API
Agent-Model: GPT-5
Agent-Task: factory Landmark lane