### PR TITLE
Bake Fly Litestream deploy layer into one-core template

### DIFF
--- a/skills/harness-engineering/references/one-core-many-faces.md
+++ b/skills/harness-engineering/references/one-core-many-faces.md
@@ -1,7 +1,8 @@
 # One Core, Many Faces
 
 Use when a factory repo should expose one product through API, CLI, MCP, SDK,
-human UI, and a shipped skill without duplicating business logic.
+human UI, deploy runtime, and a shipped skill without duplicating business
+logic.
 
 ## Source Signals
 
@@ -17,10 +18,10 @@ human UI, and a shipped skill without duplicating business logic.
 ## Target Shape
 
 ```text
-AGENTS FIRST                                      HUMANS THIN
-api   cli   mcp   sdk   web/control   SKILL.md   AGENTS.md
- |     |     |     |        |            |          |
- +-----+-----+-----+--------+------------+----------+
+AGENTS FIRST                                             HUMANS THIN
+api   cli   mcp   sdk   web/control   deploy   SKILL.md   AGENTS.md
+ |     |     |     |        |          |          |          |
+ +-----+-----+-----+--------+----------+----------+----------+
                   shell / ports / use cases
                          |
                       core crate
@@ -57,6 +58,11 @@ SDK over hand-rolled JSON-RPC.
 : Consumer package over the stable API or generated schema. Keep non-Rust SDKs
 tiny unless a real consumer requires them. Generate when the schema is stable
 enough; otherwise ship a typed minimal client.
+
+`deploy`
+: Process edge: Docker image, Fly runtime config, `/data` mount, Litestream
+restore/replicate wrapper, and typed config-from-env. No product policy and no
+business logic.
 
 `SKILL.md`
 : Agent judgment: when to use the tool, what evidence to capture, safety
@@ -100,6 +106,8 @@ repo or planning branch and replace:
 - `{{base_branch}}` with the repository base branch, for example `main` or
   `master`.
 - `{{npm_scope}}` with the npm scope, for example `misty-step`.
+- `{{fly_app}}` with the Fly.io app name.
+- `{{fly_region}}` with the Fly.io primary region.
 - `{{description}}` with one concrete product sentence.
 
 Then delete every face the first slice cannot verify. The template is a menu,
@@ -118,6 +126,9 @@ Minimum proof for the scaffold itself:
   a read tool, and one structured error.
 - SDK: throwaway consumer build that imports the package and calls one public
   method.
+- Deploy: materialized Docker build, `fly.toml` validation, `/healthz` and
+  `/readyz` smoke, and Litestream restore drill against a non-production
+  database or explicit pre-production waiver.
 - Skill: cold-agent smoke: ask the agent to use the product from only the
   skill and repo docs, then inspect the evidence it leaves.
 
@@ -134,3 +145,5 @@ Minimum proof for the scaffold itself:
   boundaries.
 - Human UI that tries to match every API operation instead of owning oversight,
   approval, trace, and recovery.
+- Deploy files copied without typed env parsing, readiness probes, and restore
+  evidence.

--- a/skills/harness-engineering/templates/one-core-many-faces/.dockerignore.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/.dockerignore.tmpl
@@ -1,0 +1,7 @@
+/target
+/.git
+/.github
+/docs/releases
+/**/*.db
+/**/*.db-shm
+/**/*.db-wal

--- a/skills/harness-engineering/templates/one-core-many-faces/.env.example.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/.env.example.tmpl
@@ -1,0 +1,14 @@
+PORT=8080
+DATABASE_PATH=./{{binary}}_dev.db
+
+# Optional: Fly Tigris-backed Litestream (not needed for local dev).
+# Provision with:
+#   fly storage create --app {{fly_app}} --name {{fly_app}}-backups --yes
+# Then set these values as Fly secrets for production.
+# BUCKET_NAME={{fly_app}}-backups
+# AWS_ACCESS_KEY_ID=tid_xxx
+# AWS_SECRET_ACCESS_KEY=tsec_xxx
+#
+# Set REQUIRE_LITESTREAM=1 in production only after the bucket and credentials
+# have passed a restore drill and an initial replica snapshot exists.
+# REQUIRE_LITESTREAM=1

--- a/skills/harness-engineering/templates/one-core-many-faces/AGENTS.md.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/AGENTS.md.tmpl
@@ -10,6 +10,9 @@
 - Effects and use cases live in `crates/shell`.
 - API, CLI, MCP, SDK, UI, and skills are adapters. They must not duplicate
   business rules.
+- Deploy runtime is Fly + SQLite under `/data` + Litestream to Fly Tigris. No
+  production-ready claim without Docker build, Fly config validation,
+  `/healthz`, `/readyz`, and a restore drill or explicit waiver.
 - Release intelligence uses Landmark; see `.github/workflows/landmark-release.yml`
   and `.landmark.yml`.
 
@@ -23,10 +26,14 @@
 - SDK changes: build a throwaway consumer.
 - Skill changes: run a cold-agent smoke using only `skills/{{binary}}/SKILL.md`
   and this repo.
+- Deploy changes: build the Docker image, validate `fly.toml`, smoke
+  `/healthz` and `/readyz`, and prove Litestream restore behavior against a
+  non-production database before enabling `REQUIRE_LITESTREAM=1`.
 
 ## Red Lines
 
 - No 1:1 endpoint dumps as MCP tools.
 - No adapter-specific policy forks.
 - No generated SDK/client claim without a consumer build.
+- No deploy claim that skips restore-on-boot evidence.
 - No weakening the gate to land release automation.

--- a/skills/harness-engineering/templates/one-core-many-faces/Cargo.toml.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/Cargo.toml.tmpl
@@ -18,4 +18,4 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal"] }

--- a/skills/harness-engineering/templates/one-core-many-faces/Dockerfile.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/Dockerfile.tmpl
@@ -1,0 +1,34 @@
+FROM rust:1.88-bookworm AS build
+
+WORKDIR /app
+COPY . .
+RUN cargo build --release --locked -p {{crate_prefix}}-api --bin {{binary}}-server
+
+FROM debian:bookworm-slim
+
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=litestream/litestream@sha256:5572700ba18710cb010a0e415e36abf5cc0b4d74a2ad7b6d6a387142c0c99604 /usr/local/bin/litestream /usr/local/bin/litestream
+
+WORKDIR /app
+
+RUN useradd --create-home app && \
+    mkdir -p /app/bin /data && \
+    chown -R app:app /app /data
+
+COPY --from=build --chown=app:app /app/target/release/{{binary}}-server /app/bin/{{binary}}-server
+COPY --chown=app:app litestream.yml /etc/litestream.yml
+COPY --chown=app:app bin/entrypoint.sh /app/bin/entrypoint.sh
+RUN chmod +x /app/bin/entrypoint.sh /app/bin/{{binary}}-server
+
+USER app
+
+ENV APP_BIN=/app/bin/{{binary}}-server
+ENV DATABASE_PATH=/data/{{binary}}.db
+ENV PORT=8080
+
+EXPOSE 8080
+
+CMD ["/app/bin/entrypoint.sh"]

--- a/skills/harness-engineering/templates/one-core-many-faces/README.md
+++ b/skills/harness-engineering/templates/one-core-many-faces/README.md
@@ -16,6 +16,8 @@ make the first verified slice work before adding surface.
 - `{{repo}}` - GitHub repository, for example `misty-step/example`.
 - `{{base_branch}}` - repository base branch, for example `main` or `master`.
 - `{{npm_scope}}` - npm scope without `@`, for example `misty-step`.
+- `{{fly_app}}` - Fly.io app name, for example `example-prod`.
+- `{{fly_region}}` - Fly.io primary region, for example `iad`.
 - `{{description}}` - one concrete product sentence.
 
 ## Target Tree
@@ -24,6 +26,12 @@ make the first verified slice work before adding surface.
 .
 ├── AGENTS.md
 ├── Cargo.toml
+├── Dockerfile
+├── fly.toml
+├── litestream.yml
+├── .env.example
+├── bin
+│   └── entrypoint.sh
 ├── .landmark.yml
 ├── crates
 │   ├── core
@@ -44,7 +52,8 @@ make the first verified slice work before adding surface.
 2. Fill `shell` with one use case and fake external ports.
 3. Add only the first adapter that has a real consumer.
 4. Add the verification path for that adapter.
-5. Delete the adapter folders not exercised by the first acceptance oracle.
+5. Run `cargo generate-lockfile` before locked gates or Docker builds.
+6. Delete the adapter folders not exercised by the first acceptance oracle.
 
 ## Proof Before Expansion
 
@@ -54,6 +63,9 @@ make the first verified slice work before adding surface.
 - SDK face: throwaway consumer build.
 - Skill face: cold-agent use smoke.
 - Web face: browser path with screenshot or trace.
+- Deploy face: Docker image build, `fly.toml` validation, `/healthz` and
+  `/readyz` smoke, and Litestream restore drill or explicit pre-production
+  waiver.
 
 ## Guardrails
 
@@ -62,3 +74,5 @@ make the first verified slice work before adding surface.
 - MCP tools are intent-shaped, not endpoint-shaped.
 - Non-Rust SDKs stay tiny unless a consumer needs them.
 - Landmark release intelligence is part of the shipped product surface.
+- Litestream runs only at the process edge; business logic never shells out to
+  backup tooling.

--- a/skills/harness-engineering/templates/one-core-many-faces/bin/entrypoint.sh.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/bin/entrypoint.sh.tmpl
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+DB_PATH="${DATABASE_PATH:-/data/{{binary}}.db}"
+APP_BIN="${APP_BIN:-/app/bin/{{binary}}-server}"
+
+LITESTREAM_READY=0
+if [ -z "${BUCKET_NAME:-}" ]; then
+  echo "WARNING: Litestream replication NOT configured - BUCKET_NAME missing; running without backups" >&2
+else
+  MISSING=""
+  [ -z "${AWS_ACCESS_KEY_ID:-}" ] && MISSING="$MISSING AWS_ACCESS_KEY_ID"
+  [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] && MISSING="$MISSING AWS_SECRET_ACCESS_KEY"
+
+  if [ -n "$MISSING" ]; then
+    echo "WARNING: Fly Tigris bucket set but missing required variables:$MISSING" >&2
+  else
+    LITESTREAM_READY=1
+  fi
+fi
+
+if [ "${REQUIRE_LITESTREAM:-0}" = "1" ] && [ "$LITESTREAM_READY" != "1" ]; then
+  echo "ERROR: Litestream replication required but backup configuration is incomplete" >&2
+  exit 1
+fi
+
+if [ ! -f "$DB_PATH" ] && [ "$LITESTREAM_READY" = "1" ]; then
+  echo "Restoring database from Litestream..."
+  litestream restore -if-replica-exists -o "$DB_PATH" -config /etc/litestream.yml "$DB_PATH"
+
+  if [ ! -s "$DB_PATH" ]; then
+    echo "ERROR: Litestream restore did not materialize $DB_PATH - refusing to start on an empty database" >&2
+    echo "HINT: for a first production boot with no replica yet, unset REQUIRE_LITESTREAM until an initial snapshot exists" >&2
+    exit 1
+  fi
+fi
+
+if [ "$LITESTREAM_READY" = "1" ]; then
+  exec litestream replicate -exec "$APP_BIN" -config /etc/litestream.yml
+else
+  exec "$APP_BIN"
+fi

--- a/skills/harness-engineering/templates/one-core-many-faces/crates/api/Cargo.toml.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/crates/api/Cargo.toml.tmpl
@@ -6,11 +6,15 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[[bin]]
+name = "{{binary}}-server"
+path = "src/main.rs"
+
 [dependencies]
 {{crate_prefix}}-core = { path = "../core" }
 {{crate_prefix}}-shell = { path = "../shell" }
 anyhow.workspace = true
+axum = "0.8"
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-axum = "0.8"

--- a/skills/harness-engineering/templates/one-core-many-faces/crates/api/src/config.rs.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/crates/api/src/config.rs.tmpl
@@ -1,0 +1,117 @@
+use std::{collections::BTreeMap, fmt, net::SocketAddr, path::PathBuf};
+
+const DEFAULT_DATABASE_PATH: &str = "/data/{{binary}}.db";
+const DEFAULT_PORT: u16 = 8080;
+
+/// Fully parsed process configuration for the HTTP server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerProcessConfig {
+    /// SQLite database path used by the shell/store adapter.
+    pub database_path: PathBuf,
+    /// Socket address the process should bind.
+    pub listen_addr: SocketAddr,
+}
+
+impl ServerProcessConfig {
+    /// Build process configuration from key/value environment pairs.
+    pub fn from_env<I, K, V>(vars: I) -> Result<Self, RuntimeEnvError>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let vars = vars
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect::<BTreeMap<_, _>>();
+
+        let database_path = env_value(&vars, "DATABASE_PATH")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(DEFAULT_DATABASE_PATH));
+        let port = parse_port(env_value(&vars, "PORT"))?;
+
+        Ok(Self {
+            database_path,
+            listen_addr: SocketAddr::from(([0, 0, 0, 0], port)),
+        })
+    }
+}
+
+/// Invalid process environment for the HTTP server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeEnvError {
+    variable: &'static str,
+    detail: String,
+}
+
+impl RuntimeEnvError {
+    fn new(variable: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            variable,
+            detail: detail.into(),
+        }
+    }
+
+    /// Environment variable that failed validation.
+    pub const fn variable(&self) -> &'static str {
+        self.variable
+    }
+}
+
+impl fmt::Display for RuntimeEnvError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "invalid {} environment variable: {}",
+            self.variable, self.detail
+        )
+    }
+}
+
+impl std::error::Error for RuntimeEnvError {}
+
+fn env_value<'a>(vars: &'a BTreeMap<String, String>, key: &str) -> Option<&'a str> {
+    vars.get(key)
+        .map(String::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_port(value: Option<&str>) -> Result<u16, RuntimeEnvError> {
+    match value {
+        Some(value) => value.parse::<u16>().map_err(|error| {
+            RuntimeEnvError::new("PORT", format!("expected TCP port 0-65535 ({error})"))
+        }),
+        None => Ok(DEFAULT_PORT),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_config_uses_deploy_defaults() -> Result<(), RuntimeEnvError> {
+        let config = ServerProcessConfig::from_env(Vec::<(String, String)>::new())?;
+
+        assert_eq!(config.database_path, PathBuf::from("/data/{{binary}}.db"));
+        assert_eq!(config.listen_addr, SocketAddr::from(([0, 0, 0, 0], 8080)));
+        Ok(())
+    }
+
+    #[test]
+    fn process_config_reads_production_environment() -> Result<(), RuntimeEnvError> {
+        let config =
+            ServerProcessConfig::from_env([("DATABASE_PATH", "/tmp/{{binary}}.db"), ("PORT", "9090")])?;
+
+        assert_eq!(config.database_path, PathBuf::from("/tmp/{{binary}}.db"));
+        assert_eq!(config.listen_addr, SocketAddr::from(([0, 0, 0, 0], 9090)));
+        Ok(())
+    }
+
+    #[test]
+    fn process_config_rejects_invalid_port() {
+        let error = ServerProcessConfig::from_env([("PORT", "70000")]).unwrap_err();
+
+        assert_eq!(error.variable(), "PORT");
+    }
+}

--- a/skills/harness-engineering/templates/one-core-many-faces/crates/api/src/lib.rs.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/crates/api/src/lib.rs.tmpl
@@ -1,14 +1,41 @@
-use axum::{routing::get, Json, Router};
+use axum::{Json, Router, routing::get};
+use serde::Serialize;
 use {{crate_prefix}}_core::WorkItem;
+
+mod config;
+
+pub use config::{RuntimeEnvError, ServerProcessConfig};
 
 pub fn router() -> Router {
     Router::new()
         .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
         .route("/items", get(list_items).post(create_item))
 }
 
-async fn healthz() -> &'static str {
-    "ok"
+#[derive(Debug, Serialize)]
+struct Healthz {
+    status: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct Readyz {
+    status: &'static str,
+    database: &'static str,
+    supervisor: &'static str,
+}
+
+async fn healthz() -> Json<Healthz> {
+    Json(Healthz { status: "ok" })
+}
+
+async fn readyz() -> Json<Readyz> {
+    // Replace this placeholder with a live store probe in the first persisted slice.
+    Json(Readyz {
+        status: "ready",
+        database: "not_wired",
+        supervisor: "ok",
+    })
 }
 
 async fn list_items() -> Json<Vec<WorkItem>> {

--- a/skills/harness-engineering/templates/one-core-many-faces/crates/api/src/main.rs.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/crates/api/src/main.rs.tmpl
@@ -1,0 +1,57 @@
+use std::{error::Error, process};
+
+use {{crate_prefix}}_api::ServerProcessConfig;
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("{{binary}}-server: {error}");
+        process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn Error>> {
+    let config = ServerProcessConfig::from_env(std::env::vars())?;
+    let listener = tokio::net::TcpListener::bind(config.listen_addr).await?;
+    let local_addr = listener.local_addr()?;
+
+    eprintln!(
+        "{{binary}}-server listening on {local_addr}; database={}",
+        config.database_path.display()
+    );
+
+    axum::serve(listener, {{crate_prefix}}_api::router())
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(error) = tokio::signal::ctrl_c().await {
+            eprintln!("{{binary}}-server: failed to install Ctrl-C handler: {error}");
+        }
+    };
+
+    #[cfg(unix)]
+    {
+        let terminate = async {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut signal) => {
+                    signal.recv().await;
+                }
+                Err(error) => {
+                    eprintln!("{{binary}}-server: failed to install SIGTERM handler: {error}");
+                }
+            }
+        };
+
+        tokio::select! {
+            () = ctrl_c => {}
+            () = terminate => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    ctrl_c.await;
+}

--- a/skills/harness-engineering/templates/one-core-many-faces/crates/cli/src/main.rs.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/crates/cli/src/main.rs.tmpl
@@ -2,7 +2,11 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
-#[command(name = "{{binary}}", version, about = "{{description}}")]
+#[command(
+    name = "{{binary}}",
+    version,
+    about = "{{description}}"
+)]
 struct Cli {
     #[command(subcommand)]
     command: Command,

--- a/skills/harness-engineering/templates/one-core-many-faces/crates/shell/src/lib.rs.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/crates/shell/src/lib.rs.tmpl
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use {{crate_prefix}}_core::{normalize_item, WorkItem};
+use {{crate_prefix}}_core::{WorkItem, normalize_item};
 
 pub trait ItemStore {
     fn save(&self, item: &WorkItem) -> Result<()>;

--- a/skills/harness-engineering/templates/one-core-many-faces/fly.toml.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/fly.toml.tmpl
@@ -1,0 +1,40 @@
+app = "{{fly_app}}"
+primary_region = "{{fly_region}}"
+kill_signal = "SIGTERM"
+kill_timeout = "30s"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[mounts]
+  source = "data"
+  destination = "/data"
+
+[env]
+  DATABASE_PATH = "/data/{{binary}}.db"
+  PORT = "8080"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "off"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [[http_service.checks]]
+    grace_period = "15s"
+    interval = "30s"
+    method = "GET"
+    path = "/healthz"
+    timeout = "5s"
+
+  [[http_service.checks]]
+    grace_period = "15s"
+    interval = "30s"
+    method = "GET"
+    path = "/readyz"
+    timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/skills/harness-engineering/templates/one-core-many-faces/litestream.yml.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/litestream.yml.tmpl
@@ -1,0 +1,10 @@
+dbs:
+  - path: /data/{{binary}}.db
+    replicas:
+      - type: s3
+        bucket: ${BUCKET_NAME}
+        path: {{binary}}.db
+        endpoint: https://fly.storage.tigris.dev
+        region: auto
+        force-path-style: true
+        snapshot-interval: 1h


### PR DESCRIPTION
## Summary
- Add the deploy face to the one-core-many-faces template: Dockerfile, Fly config, Litestream/Tigris config, entrypoint wrapper, .env example, and .dockerignore.
- Make the generated API crate runnable as a {{binary}}-server with typed config-from-env for PORT and DATABASE_PATH.
- Document deploy as an earned face with Docker/Fly/health/readiness/restore proof, while keeping downstream base branch parameterized as {{base_branch}}.

## Verification
- Materialized template into /tmp/one-core-deploy-smoke with tokens including base_branch=main.
- cargo fmt --all -- --check
- cargo test --workspace --locked
- shellcheck -s sh bin/entrypoint.sh
- flyctl config validate
- docker build -t one-core-deploy-smoke:template .
- docker run smoke: /healthz => {"status":"ok"}; /readyz => {"status":"ready","database":"not_wired","supervisor":"ok"}
- docker run REQUIRE_LITESTREAM=1 fail-closed smoke exits 1 when backup secrets are absent.
- docker run --entrypoint litestream one-core-deploy-smoke:template version => v0.5.11
- cargo run --locked -p harness-kit-checks -- check --repo .
- Fresh Pi critic, no tools/extensions: no blocking findings.

Agent: Codex
Agent-Surface: Codex CLI
Agent-Runner: GPT-5 Codex
Agent-Model: GPT-5
Agent-Task: one-core deploy layer template