### PR TITLE
fix(telemetry): classify skill invocations as direct vs routed

### DIFF
--- a/crates/harness-kit-checks/baselines/godfiles.txt
+++ b/crates/harness-kit-checks/baselines/godfiles.txt
@@ -2,12 +2,12 @@
 # Files over the line ceiling when baselined; they may only shrink.
 # Regenerate intentionally: harness-kit-checks check-godfiles --write-baseline
 1975 crates/harness-kit-checks/src/agent_roster.rs
-2421 crates/harness-kit-checks/src/claude_hooks.rs
+2465 crates/harness-kit-checks/src/claude_hooks.rs
 859 crates/harness-kit-checks/src/config_loader.rs
 1883 crates/harness-kit-checks/src/docs_site.rs
-850 crates/harness-kit-checks/src/external_sync.rs
+821 crates/harness-kit-checks/src/external_sync.rs
 811 crates/harness-kit-checks/src/lane_harness.rs
 1202 crates/harness-kit-checks/src/main.rs
-972 crates/harness-kit-checks/src/skill_invocation_analytics.rs
+1014 crates/harness-kit-checks/src/skill_invocation_analytics.rs
 1155 crates/harness-kit-checks/src/summarize_delegations.rs
 866 skills/research/providers.ts

--- a/crates/harness-kit-checks/src/claude_hooks.rs
+++ b/crates/harness-kit-checks/src/claude_hooks.rs
@@ -1697,6 +1697,10 @@ pub fn build_skill_invocation_entry(data: &Value) -> Option<Value> {
     );
     entry.insert("cwd".to_string(), json!(cwd));
     entry.insert("project".to_string(), json!(project));
+    entry.insert(
+        "invocation_kind".to_string(),
+        json!(crate::invocation_kind::classify(data)),
+    );
 
     for field in ["model_id", "outcome", "duration_ms", "usage"] {
         if let Some(value) = data.get(field) {
@@ -1817,6 +1821,46 @@ mod tests {
             .map(|row| row["skill"].as_str().unwrap().to_string())
             .collect();
         assert_eq!(skills, ["commit", "review", "investigate"]);
+    }
+
+    #[test]
+    fn invocation_kind_falls_back_to_unknown_without_a_readable_transcript() {
+        let entry = build_skill_invocation_entry(&serde_json::json!({
+            "tool_name": "Skill",
+            "tool_input": {"skill": "commit", "args": ""},
+        }))
+        .unwrap();
+        assert_eq!(entry["invocation_kind"], "unknown");
+    }
+
+    #[test]
+    fn invocation_kind_flows_through_build_skill_invocation_entry() {
+        let temp = TempDir::new().unwrap();
+        let transcript_path = temp.path().join("transcript.jsonl");
+        let rows = [
+            json!({"type": "user", "message": {"content": "make this look brutalist"}}),
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "design", "args": ""}}
+            ]}}),
+            // The routed call itself, mirroring what the real transcript
+            // looks like by the time PostToolUse fires.
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "leon-brutalist-skill", "args": ""}}
+            ]}}),
+        ]
+        .into_iter()
+        .map(|row| serde_json::to_string(&row).unwrap())
+        .collect::<Vec<_>>()
+        .join("\n");
+        fs::write(&transcript_path, rows).unwrap();
+
+        let entry = build_skill_invocation_entry(&json!({
+            "tool_name": "Skill",
+            "tool_input": {"skill": "leon-brutalist-skill", "args": ""},
+            "transcript_path": transcript_path.display().to_string(),
+        }))
+        .unwrap();
+        assert_eq!(entry["invocation_kind"], "routed");
     }
 
     #[test]

--- a/crates/harness-kit-checks/src/invocation_kind.rs
+++ b/crates/harness-kit-checks/src/invocation_kind.rs
@@ -1,0 +1,179 @@
+use std::fs;
+
+use serde_json::Value;
+
+/// Classifies a Skill-tool invocation as "direct" (the nearest preceding
+/// notable transcript event is a genuine human/system-authored user turn —
+/// e.g. the user typed `/some-skill` or a natural-language request that
+/// triggered this skill first), "routed" (the nearest preceding notable event
+/// is another Skill invocation with no fresh user turn in between — e.g.
+/// `/design`'s own prose telling the agent to invoke `leon-brutalist-skill`
+/// mid-turn), or "unknown" when no transcript is available to classify from.
+///
+/// This closes the routed-invocation blind spot: without it, a vendored
+/// skill only ever reachable via another skill's routing table looks
+/// identical in telemetry to one invoked directly, and a zero-count skill
+/// could mean either "never used" (strong signal to cull) or "used, but only
+/// ever as an invisible sub-call" (weak signal — do not cull).
+pub fn classify(data: &Value) -> &'static str {
+    let Some(transcript_path) = data.get("transcript_path").and_then(Value::as_str) else {
+        return "unknown";
+    };
+    let Ok(transcript) = fs::read_to_string(transcript_path) else {
+        return "unknown";
+    };
+    classify_from_transcript(&transcript)
+}
+
+fn classify_from_transcript(transcript: &str) -> &'static str {
+    let entries: Vec<Value> = transcript
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line.trim()).ok())
+        .collect();
+
+    // The current invocation is the last Skill tool_use in the transcript —
+    // PostToolUse fires immediately after this call completes, so it is the
+    // most recently appended one. Everything before it is prior history.
+    let Some(current_index) = entries
+        .iter()
+        .rposition(|entry| assistant_invokes_skill(transcript_content(entry)))
+    else {
+        return "unknown";
+    };
+
+    for entry in entries[..current_index].iter().rev() {
+        let entry_type = entry.get("type").and_then(Value::as_str).unwrap_or("");
+        let content = transcript_content(entry);
+        match entry_type {
+            "assistant" if assistant_invokes_skill(content) => return "routed",
+            "user" if is_genuine_user_turn(content) => return "direct",
+            _ => {}
+        }
+    }
+    // No prior notable event: this is the first skill call the transcript
+    // has any record of, which only happens in direct response to a user turn.
+    "direct"
+}
+
+fn transcript_content(entry: &Value) -> Option<&Value> {
+    entry
+        .get("message")
+        .and_then(|message| message.get("content"))
+}
+
+/// A "genuine" user turn is fresh human/system input — a string prompt, a
+/// slash-command marker, or a text block — as opposed to a `tool_result`
+/// loopback (the agent's own tool output being fed back to it mid-turn),
+/// which is not a new turn at all.
+fn is_genuine_user_turn(content: Option<&Value>) -> bool {
+    match content {
+        Some(Value::String(_)) => true,
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .any(|block| block.get("type").and_then(Value::as_str) != Some("tool_result")),
+        _ => false,
+    }
+}
+
+fn assistant_invokes_skill(content: Option<&Value>) -> bool {
+    match content {
+        Some(Value::Array(blocks)) => blocks.iter().any(|block| {
+            block.get("type").and_then(Value::as_str) == Some("tool_use")
+                && block.get("name").and_then(Value::as_str) == Some("Skill")
+        }),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn transcript(rows: Vec<Value>) -> String {
+        rows.into_iter()
+            .map(|row| serde_json::to_string(&row).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn direct_invocation_after_genuine_user_message_is_classified_direct() {
+        let transcript = transcript(vec![
+            json!({"type": "user", "message": {"content": "please run /design brutalist"}}),
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "design", "args": "brutalist"}}
+            ]}}),
+        ]);
+        assert_eq!(classify_from_transcript(&transcript), "direct");
+    }
+
+    #[test]
+    fn nested_invocation_with_no_intervening_user_turn_is_classified_routed() {
+        let transcript = transcript(vec![
+            json!({"type": "user", "message": {"content": "please run /design brutalist"}}),
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "design", "args": "brutalist"}}
+            ]}}),
+            json!({"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "Launching skill: design"}
+            ]}}),
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Read", "input": {"file_path": "SKILL.md"}}
+            ]}}),
+            json!({"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "t2", "content": "file contents"}
+            ]}}),
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "leon-brutalist-skill", "args": ""}}
+            ]}}),
+        ]);
+        assert_eq!(classify_from_transcript(&transcript), "routed");
+    }
+
+    #[test]
+    fn fresh_user_turn_between_skill_calls_resets_to_direct() {
+        let transcript = transcript(vec![
+            json!({"type": "user", "message": {"content": "run /harness-engineering"}}),
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "harness-engineering", "args": ""}}
+            ]}}),
+            json!({"type": "user", "message": {"content": "actually, run /shape instead"}}),
+            json!({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "shape", "args": ""}}
+            ]}}),
+        ]);
+        assert_eq!(classify_from_transcript(&transcript), "direct");
+    }
+
+    #[test]
+    fn first_ever_skill_call_with_no_prior_history_is_direct() {
+        let transcript = serde_json::to_string(&json!({
+            "type": "assistant",
+            "message": {"content": [
+                {"type": "tool_use", "name": "Skill", "input": {"skill": "orient", "args": ""}}
+            ]}
+        }))
+        .unwrap();
+        assert_eq!(classify_from_transcript(&transcript), "direct");
+    }
+
+    #[test]
+    fn empty_or_garbage_transcript_is_unknown() {
+        assert_eq!(classify_from_transcript(""), "unknown");
+        assert_eq!(classify_from_transcript("not json\nat all"), "unknown");
+    }
+
+    #[test]
+    fn missing_transcript_path_is_unknown() {
+        assert_eq!(classify(&json!({})), "unknown");
+    }
+
+    #[test]
+    fn unreadable_transcript_path_is_unknown() {
+        assert_eq!(
+            classify(&json!({"transcript_path": "/nonexistent/path.jsonl"})),
+            "unknown"
+        );
+    }
+}

--- a/crates/harness-kit-checks/src/lib.rs
+++ b/crates/harness-kit-checks/src/lib.rs
@@ -11,6 +11,7 @@ pub mod external_sync;
 pub mod frontmatter;
 pub mod generate_index;
 pub mod git_hooks;
+pub mod invocation_kind;
 pub mod lane_harness;
 pub mod lint_gates;
 pub mod pr_reviews;

--- a/crates/harness-kit-checks/src/skill_invocation_analytics.rs
+++ b/crates/harness-kit-checks/src/skill_invocation_analytics.rs
@@ -82,6 +82,7 @@ pub fn analyze(options: &AnalyzeOptions) -> Result<Value> {
             "last_used": timestamps.last().map(DateTime::<Utc>::to_rfc3339).unwrap_or_else(|| "unknown".to_string()),
             "projects": projects.into_iter().collect::<Vec<_>>(),
             "usage": usage_summary(&rows)?,
+            "invocation_kinds": invocation_kind_counts(&rows),
         }));
     }
     skills.sort_by(|left, right| {
@@ -224,6 +225,7 @@ pub fn self_test() -> Result<()> {
                 "project": "harness-kit",
                 "backlog_ref": "088",
                 "work_id": "work-088",
+                "invocation_kind": "direct",
                 "usage": {
                     "input_tokens": 10,
                     "output_tokens": 5,
@@ -256,6 +258,7 @@ pub fn self_test() -> Result<()> {
                 "session_id": "s2",
                 "cwd": "/tmp/harness-kit",
                 "project": "harness-kit",
+                "invocation_kind": "routed",
             }),
         ]
         .into_iter()
@@ -332,6 +335,19 @@ pub fn self_test() -> Result<()> {
     ensure(
         render_markdown(&report)?.contains("unknown"),
         "markdown should include unknown",
+    )?;
+    ensure(
+        report["skills"].as_array().is_some_and(|rows| {
+            rows.iter().any(|row| {
+                row["skill"] == "shape"
+                    && row["invocation_kinds"] == json!({"direct": 1, "routed": 1})
+            })
+        }),
+        "shape invocation_kinds should split direct/routed",
+    )?;
+    ensure(
+        render_markdown(&report)?.contains("Direct/Routed/Unknown"),
+        "markdown should surface the invocation-kind breakdown",
     )?;
 
     let missing_report = analyze(&AnalyzeOptions {
@@ -444,6 +460,20 @@ fn passes_filters(row: &Value, options: &AnalyzeOptions, since: Option<&DateTime
         return false;
     }
     true
+}
+
+/// Breaks a skill's rows down by `invocation_kind` (see `invocation_kind::classify`)
+/// so routed-only use (e.g. a `/design` bench specialist) is visibly distinct
+/// from zero use, rather than collapsing into the same flat `count`.
+fn invocation_kind_counts(rows: &[Value]) -> Value {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for row in rows {
+        let kind = value_str(row, "invocation_kind")
+            .unwrap_or("unknown")
+            .to_string();
+        *counts.entry(kind).or_default() += 1;
+    }
+    json!(counts)
 }
 
 fn usage_summary(rows: &[Value]) -> Result<Value> {
@@ -635,16 +665,20 @@ fn render_markdown(report: &Value) -> Result<String> {
         "## Skill Frequency".to_string(),
         String::new(),
     ];
-    lines.push("| Skill | Count | Health | Last Used | Projects | Tokens | Cost |".to_string());
-    lines.push("|---|---:|---|---|---|---:|---:|".to_string());
+    lines.push(
+        "| Skill | Count | Health | Direct/Routed/Unknown | Last Used | Projects | Tokens | Cost |"
+            .to_string(),
+    );
+    lines.push("|---|---:|---|---|---|---|---:|---:|".to_string());
     let skills = array(report, "skills");
     for row in skills {
         let usage = &row["usage"];
         lines.push(format!(
-            "| {} | {} | {} | {} | {} | {} | {} |",
+            "| {} | {} | {} | {} | {} | {} | {} | {} |",
             string_value(&row["skill"]),
             number_or_zero(&row["count"]),
             string_value(&row["health"]),
+            invocation_kinds_summary(&row["invocation_kinds"]),
             string_value(&row["last_used"]),
             row["projects"]
                 .as_array()
@@ -659,7 +693,9 @@ fn render_markdown(report: &Value) -> Result<String> {
         ));
     }
     if skills.is_empty() {
-        lines.push("| none | 0 | dead | unknown | unknown | unknown | unknown |".to_string());
+        lines.push(
+            "| none | 0 | dead | unknown | unknown | unknown | unknown | unknown |".to_string(),
+        );
     }
     lines.extend(
         [
@@ -803,10 +839,11 @@ fn render_text(report: &Value) -> Result<String> {
             })
             .unwrap_or_default();
         lines.push(format!(
-            "- {}: count={} health={} projects={} total_tokens={} cost_usd={}",
+            "- {}: count={} health={} direct/routed/unknown={} projects={} total_tokens={} cost_usd={}",
             string_value(&row["skill"]),
             number_or_zero(&row["count"]),
             string_value(&row["health"]),
+            invocation_kinds_summary(&row["invocation_kinds"]),
             projects,
             unknown(&usage["total_tokens"]),
             unknown(&usage["cost_usd"])
@@ -917,6 +954,11 @@ fn number_or_zero(value: &Value) -> String {
         .as_u64()
         .map(|value| value.to_string())
         .unwrap_or_else(|| "0".to_string())
+}
+
+fn invocation_kinds_summary(value: &Value) -> String {
+    let get = |kind: &str| value.get(kind).and_then(Value::as_u64).unwrap_or(0);
+    format!("{}/{}/{}", get("direct"), get("routed"), get("unknown"))
 }
 
 fn array<'a>(report: &'a Value, key: &str) -> &'a Vec<Value> {


### PR DESCRIPTION
## Summary
- `skill_invocation_analytics` only ever recorded a flat per-skill count, so a vendored specialist reachable only through another skill's routing table (e.g. `/design` invoking `leon-brutalist-skill`) was indistinguishable from one never invoked at all — the exact blind spot the 2026-07-01 groom teardown flagged, making the zero-count cull ratchet unsafe for routed skills.
- Adds `invocation_kind` classification (`direct` / `routed` / `unknown`) to the skill-invocation-tracker hook: reads the PostToolUse `transcript_path` and walks backward from the current Skill call to the nearest notable prior event — another Skill invocation with no fresh user turn in between means "routed"; a genuine user turn means "direct"; no/unreadable transcript means "unknown" (the honest default for all historical data, which never carried this field — verified against live telemetry, see test plan).
- Extracted the classifier into its own `invocation_kind` module rather than growing the already-oversized `claude_hooks.rs`/`skill_invocation_analytics.rs` further than necessary; the two remaining god-file baseline bumps (`claude_hooks.rs` +44, `skill_invocation_analytics.rs` +42 lines) are the irreducible cost of the new field's production wiring plus real regression tests — flagging this explicitly for review rather than quietly bumping the ratchet. (`external_sync.rs`'s baseline entry also drops 850→821 as a side effect of `--write-baseline` picking up an already-shrunk file unrelated to this change.)
- Surfaces a per-skill `direct/routed/unknown` breakdown in the telemetry report (markdown + text renderers).

Part of `backlog.d/128-scale-skill-eval-integration.md` (EVALS-PER-SKILL), child 4.

## Test plan
- [x] `cargo test --locked -p harness-kit-checks` — 166 tests pass, including new classifier unit tests (direct/routed/reset-to-direct/first-call/garbage-transcript) and two hook-integration tests
- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` — all lanes PASS on this branch alone (based on `origin/master`, independent of #143)
- [x] `cargo run --locked -p harness-kit-checks -- telemetry --format markdown` against the real local `~/.claude/skill-invocations.jsonl` — all historical rows correctly report `0/0/N` (unknown), confirming the change is additive/non-breaking for pre-existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)