### PR TITLE
fix(bootstrap): fix installed CLI self-update blind spot

### DIFF
--- a/backlog.d/_done/133-installed-cli-self-update-blind-spot.md
+++ b/backlog.d/_done/133-installed-cli-self-update-blind-spot.md
@@ -1,6 +1,6 @@
 # Fix installed harness-kit-checks CLI self-update blind spot
 
-Priority: P2 · Status: pending · Estimate: S
+Priority: P2 (shipped) · Status: done · Estimate: S · Shipped: 2026-07-02
 
 ## Goal
 
@@ -10,14 +10,21 @@ instead of permanently freezing at whatever version first got installed.
 
 ## Oracle
 
-- [ ] After a source change + `cargo build`, running the *installed* binary
+- [x] After a source change + `cargo build`, running the *installed* binary
       (`~/.harness-kit/bin/harness-kit-checks check --repo .` or via
       `command -v harness-kit-checks` on `PATH`) reflects the new build —
-      not just `cargo run -p harness-kit-checks`.
-- [ ] `bootstrap`'s `install_cli` step distinguishes "the running binary is
+      not just `cargo run -p harness-kit-checks`. (Verified live: reproduced
+      the bug with the old installed binary — "already current" while
+      `target/debug` held a genuinely different build — then proved the fix
+      by running the *newly-fixed installed binary's own* `bootstrap` against
+      a simulated newer `target/debug` build and watching it correctly
+      refresh itself.)
+- [x] `bootstrap`'s `install_cli` step distinguishes "the running binary is
       already the freshest build" from "the running binary happens to be the
-      installed copy, which may itself be stale."
-- [ ] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
+      installed copy, which may itself be stale." (Option (a) from the notes:
+      sha256 content comparison between the freshest `target/{release,debug}`
+      build and the installed destination, never `current_exe()` identity.)
+- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
 
 ## Verification System
 
@@ -68,3 +75,25 @@ timestamp instead of path identity, (b) always building fresh
 than trusting `current_exe()`, or (c) a version/build-id stamp compiled into
 the binary that `install_cli` can compare without relying on which copy
 happens to be running.
+
+**2026-07-02 — fixed.** Implemented option (a): `crates/harness-kit-checks/src/cli_install.rs`
+(split out of `bootstrap.rs`, see below) picks the newest-by-mtime of
+`target/release/harness-kit-checks` / `target/debug/harness-kit-checks` as
+the install *source* (falling back to `current_exe()` only when neither
+exists), then compares its sha256 against the installed destination's —
+content identity, never path/process identity. Live reproduction-then-fix
+transcript: with the pre-fix installed binary, running its own `bootstrap`
+against a `target/debug` build with different content still reported
+"already current" (bug reproduced). After installing the fix via
+`cargo run -- bootstrap`, running the *newly-installed, now-fixed* binary's
+own `bootstrap` against a simulated newer `target/debug` build correctly
+detected the content mismatch and refreshed itself. 3 fixture tests added
+(`cli_install::tests`) covering: stale-installed-vs-fresh-debug-build,
+identical-content-skip (with an mtime-untouched assertion proving it's a
+true no-op, not just idempotent), and release-preferred-over-debug-when-newer.
+
+Incidental fix: extracting `install_cli` into its own module was required
+to keep `bootstrap.rs` under the repo's 800-line god-file ceiling (adding the
+fix + tests in place would have pushed it to 848 lines) — a small, welcome
+head start on `backlog.d/129`'s "repeat by domain" child 4, though the
+roster-cluster split that ticket actually tracks is separate and unstarted.

--- a/crates/harness-kit-checks/BOUNDARIES.md
+++ b/crates/harness-kit-checks/BOUNDARIES.md
@@ -31,7 +31,8 @@ and stay installed correctly. ~10,000 LOC.
 | `generate_index.rs` | 376 | Catalog integrity (`index.yaml` generation + drift check) |
 | `docs_site.rs` | 1883 | Site generator — kept here (not split-to-site-analytics) because `check-docs-site` is a core gate lane and `ci_check.rs` calls it directly; splitting it would make the core crate depend on a "site" crate for a gate it owns |
 | `git_hooks.rs` | 682 | General repo pre-commit/post-commit hooks (NOT Claude-specific — imports `bootstrap, ci_check, docs_site, frontmatter, generate_index, lint_gates` directly, i.e. it orchestrates the gate/index/docs machinery on every commit) |
-| `bootstrap.rs` | 660 | Install/sync logic |
+| `bootstrap.rs` | 677 | Install/sync logic |
+| `cli_install.rs` | 188 | Split out of `bootstrap.rs` (backlog.d/133) purely to stay under the god-file ceiling after fixing the CLI self-update blind spot; imports `bootstrap::{blue, green}` for shared output formatting — a one-directional dependency on core, same shape as `source_refs.rs`'s cross-boundary note below |
 | `config_loader.rs` | 859 | Config loading for bootstrap/deploy targets |
 | `backlog.rs` | 457 | Backlog trailer/ID parsing (`/ship` trailer canon); standalone, no internal deps |
 | `source_refs.rs` | 260 | Validates backlog/external ref shape; standalone, but **imported by `summarize_delegations.rs`** (roster cluster) — see cross-boundary note below |

--- a/crates/harness-kit-checks/src/bootstrap.rs
+++ b/crates/harness-kit-checks/src/bootstrap.rs
@@ -108,7 +108,7 @@ fn run_unix(options: &BootstrapOptions) -> Result<String> {
         lines.push(String::new());
     }
     install_system_roster(&repo, &options.home, &mut lines)?;
-    install_cli(&options.home, &mut lines)?;
+    crate::cli_install::install_cli(&repo, &options.home, &mut lines)?;
 
     let mut installed = 0usize;
     for harness in [
@@ -266,37 +266,6 @@ fn cleanup_retired_system_examples(
         fs::remove_file(&path)?;
         lines.push(green("    removed retired examples/"));
     }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn install_cli(home: &Path, lines: &mut Vec<String>) -> Result<()> {
-    lines.push(blue("Installing Rust CLI..."));
-    let bin_dir = home.join(".harness-kit/bin");
-    fs::create_dir_all(&bin_dir)?;
-    let destination = bin_dir.join("harness-kit-checks");
-    let current = env::current_exe()?;
-    // When the running binary IS the installed one (invoked via PATH or a
-    // symlink into bin_dir), fs::copy(src, src) truncates it to zero bytes.
-    // Skip the self-copy; there is nothing newer to install.
-    let same_file = match (current.canonicalize(), destination.canonicalize()) {
-        (Ok(a), Ok(b)) => a == b,
-        _ => false,
-    };
-    if same_file {
-        lines.push(green("    bin/harness-kit-checks (already current)"));
-        lines.push(String::new());
-        return Ok(());
-    }
-    // Copy via temp + rename so a concurrent invocation never sees a
-    // half-written binary.
-    let staging = bin_dir.join(".harness-kit-checks.tmp");
-    fs::copy(&current, &staging)
-        .with_context(|| format!("failed to stage {}", staging.display()))?;
-    fs::rename(&staging, &destination)
-        .with_context(|| format!("failed to install {}", destination.display()))?;
-    lines.push(green("    bin/harness-kit-checks"));
-    lines.push(String::new());
     Ok(())
 }
 
@@ -670,11 +639,11 @@ fn set_hooks_path(repo: &Path, lines: &mut Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn blue(message: impl AsRef<str>) -> String {
+pub(crate) fn blue(message: impl AsRef<str>) -> String {
     format!("\x1b[0;34m{}\x1b[0m", message.as_ref())
 }
 
-fn green(message: impl AsRef<str>) -> String {
+pub(crate) fn green(message: impl AsRef<str>) -> String {
     format!("\x1b[0;32m{}\x1b[0m", message.as_ref())
 }
 

--- a/crates/harness-kit-checks/src/cli_install.rs
+++ b/crates/harness-kit-checks/src/cli_install.rs
@@ -1,0 +1,188 @@
+//! Installs the `harness-kit-checks` binary into `~/.harness-kit/bin/`.
+//!
+//! Split out of `bootstrap.rs` (backlog.d/133) because freshness here is
+//! surprisingly subtle: see `freshest_cli_build`'s doc comment.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use crate::bootstrap::{blue, green};
+
+/// Picks the freshest build to install. `env::current_exe()` is NOT a
+/// reliable source of truth here: once `~/.harness-kit/bin/harness-kit-checks`
+/// is on `PATH`, git hooks invoke it directly (see `.githooks/pre-commit`'s
+/// `command -v harness-kit-checks` preference), so `bootstrap::run` executes
+/// *as* the installed binary and `current_exe()` permanently points at the
+/// install destination — even when a newer `cargo build` sits in `target/`
+/// untouched. Prefer the repo's own fresh build artifacts; fall back to
+/// `current_exe()` only when neither exists (e.g. a bare install with no
+/// local `target/` directory).
+fn freshest_cli_build(repo: &Path) -> Result<PathBuf> {
+    let candidates = [
+        repo.join("target/release/harness-kit-checks"),
+        repo.join("target/debug/harness-kit-checks"),
+    ];
+    let mut newest: Option<(PathBuf, std::time::SystemTime)> = None;
+    for candidate in candidates {
+        let Ok(metadata) = fs::metadata(&candidate) else {
+            continue;
+        };
+        let Ok(modified) = metadata.modified() else {
+            continue;
+        };
+        if newest.as_ref().is_none_or(|(_, t)| modified > *t) {
+            newest = Some((candidate, modified));
+        }
+    }
+    match newest {
+        Some((path, _)) => Ok(path),
+        None => Ok(env::current_exe()?),
+    }
+}
+
+fn file_sha256(path: &Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    Ok(format!("{:x}", Sha256::digest(fs::read(path)?)))
+}
+
+#[cfg(unix)]
+pub(crate) fn install_cli(repo: &Path, home: &Path, lines: &mut Vec<String>) -> Result<()> {
+    lines.push(blue("Installing Rust CLI..."));
+    let bin_dir = home.join(".harness-kit/bin");
+    fs::create_dir_all(&bin_dir)?;
+    let destination = bin_dir.join("harness-kit-checks");
+    let source = freshest_cli_build(repo)?;
+
+    // When the source IS the installed one (e.g. no local target/ build
+    // exists and current_exe() falls back to the destination itself),
+    // fs::copy(src, src) truncates it to zero bytes. Skip the self-copy.
+    let same_file = match (source.canonicalize(), destination.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    };
+    // Content identity, not path identity: the installed binary staying
+    // "current" must depend on whether its bytes match the freshest build,
+    // never on which process happens to be executing this bootstrap run.
+    let up_to_date = same_file
+        || match (file_sha256(&source), file_sha256(&destination)) {
+            (Ok(a), Ok(b)) => a == b,
+            _ => false,
+        };
+    if up_to_date {
+        lines.push(green("    bin/harness-kit-checks (already current)"));
+        lines.push(String::new());
+        return Ok(());
+    }
+    // Copy via temp + rename so a concurrent invocation never sees a
+    // half-written binary.
+    let staging = bin_dir.join(".harness-kit-checks.tmp");
+    fs::copy(&source, &staging)
+        .with_context(|| format!("failed to stage {}", staging.display()))?;
+    fs::rename(&staging, &destination)
+        .with_context(|| format!("failed to install {}", destination.display()))?;
+    lines.push(green("    bin/harness-kit-checks"));
+    lines.push(String::new());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // backlog.d/133: install_cli must refresh the installed binary based on
+    // build content, not on whether the *running* process happens to be the
+    // installed copy — current_exe() is not a reliable freshness signal once
+    // hooks invoke the installed binary directly.
+    #[test]
+    fn install_cli_refreshes_stale_installed_binary_from_fresh_build() -> Result<()> {
+        let repo = tempfile::tempdir()?;
+        let home = tempfile::tempdir()?;
+
+        fs::create_dir_all(repo.path().join("target/debug"))?;
+        fs::write(
+            repo.path().join("target/debug/harness-kit-checks"),
+            b"fresh-build-content",
+        )?;
+
+        let bin_dir = home.path().join(".harness-kit/bin");
+        fs::create_dir_all(&bin_dir)?;
+        fs::write(
+            bin_dir.join("harness-kit-checks"),
+            b"stale-installed-content",
+        )?;
+
+        let mut lines = Vec::new();
+        install_cli(repo.path(), home.path(), &mut lines)?;
+
+        let installed = fs::read(bin_dir.join("harness-kit-checks"))?;
+        assert_eq!(installed, b"fresh-build-content");
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("bin/harness-kit-checks"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn install_cli_skips_rewrite_when_content_already_matches() -> Result<()> {
+        let repo = tempfile::tempdir()?;
+        let home = tempfile::tempdir()?;
+
+        fs::create_dir_all(repo.path().join("target/debug"))?;
+        fs::write(
+            repo.path().join("target/debug/harness-kit-checks"),
+            b"identical-content",
+        )?;
+
+        let bin_dir = home.path().join(".harness-kit/bin");
+        fs::create_dir_all(&bin_dir)?;
+        let destination = bin_dir.join("harness-kit-checks");
+        fs::write(&destination, b"identical-content")?;
+        let before = fs::metadata(&destination)?.modified()?;
+
+        let mut lines = Vec::new();
+        install_cli(repo.path(), home.path(), &mut lines)?;
+
+        assert_eq!(fs::read(&destination)?, b"identical-content");
+        assert!(lines.iter().any(|line| line.contains("already current")));
+        // No rewrite happened at all (not just same content) — mtime is untouched.
+        assert_eq!(fs::metadata(&destination)?.modified()?, before);
+        Ok(())
+    }
+
+    #[test]
+    fn install_cli_prefers_release_build_over_debug_when_newer() -> Result<()> {
+        let repo = tempfile::tempdir()?;
+        let home = tempfile::tempdir()?;
+
+        fs::create_dir_all(repo.path().join("target/debug"))?;
+        fs::write(
+            repo.path().join("target/debug/harness-kit-checks"),
+            b"stale-debug-build",
+        )?;
+        // Ensure the release build's mtime is observably newer than debug's.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::create_dir_all(repo.path().join("target/release"))?;
+        fs::write(
+            repo.path().join("target/release/harness-kit-checks"),
+            b"fresh-release-build",
+        )?;
+
+        let bin_dir = home.path().join(".harness-kit/bin");
+        fs::create_dir_all(&bin_dir)?;
+        fs::write(bin_dir.join("harness-kit-checks"), b"stale-installed")?;
+
+        let mut lines = Vec::new();
+        install_cli(repo.path(), home.path(), &mut lines)?;
+
+        assert_eq!(
+            fs::read(bin_dir.join("harness-kit-checks"))?,
+            b"fresh-release-build"
+        );
+        Ok(())
+    }
+}

--- a/crates/harness-kit-checks/src/lib.rs
+++ b/crates/harness-kit-checks/src/lib.rs
@@ -3,6 +3,7 @@ pub mod backlog;
 pub mod bootstrap;
 mod bundles;
 pub mod ci_check;
+mod cli_install;
 pub mod config_loader;
 pub mod docs_site;
 pub mod error_report;

--- a/crates/harness-kit-checks/src/lint_gates.rs
+++ b/crates/harness-kit-checks/src/lint_gates.rs
@@ -467,7 +467,11 @@ pub fn check_harness_install_paths(root: &Path) -> Result<GateReport> {
     if !matches_any_file(
         root,
         r"cargo install --quiet --locked --path.*crates/harness-kit-checks|bin/harness-kit-checks",
-        &["bootstrap.sh", "crates/harness-kit-checks/src/bootstrap.rs"],
+        &[
+            "bootstrap.sh",
+            "crates/harness-kit-checks/src/bootstrap.rs",
+            "crates/harness-kit-checks/src/cli_install.rs",
+        ],
     )? {
         failures.push(
             "bootstrap must install the Rust Harness Kit CLI into the system-wide Harness Kit location"

--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -63,10 +63,6 @@
     {
       "source": "backlog.d/132-greenfield-template-ci.md",
       "title": "Declare and verify the greenfield Factory template"
-    },
-    {
-      "source": "backlog.d/133-installed-cli-self-update-blind-spot.md",
-      "title": "Fix installed harness-kit-checks CLI self-update blind spot"
     }
   ],
   "copy_source": "docs/copy/site.json",

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Harness Kit Index
-# Generated: 2026-07-02T01:08:00Z
+# Generated: 2026-07-02T03:19:17Z
 # Do not edit manually. Run: harness-kit-checks generate-index --repo .
 
 skills:


### PR DESCRIPTION
## Summary

- Fixes backlog.d/133: `install_cli` compared `env::current_exe()` against the install destination for "already current" — but once the installed binary is on `PATH`, git hooks invoke it directly (`.githooks/pre-commit` prefers `command -v harness-kit-checks` over `cargo run`), so `current_exe()` IS the destination forever, regardless of whether a newer `target/debug` build exists. This is a self-perpetuating staleness trap: every subsequent `bootstrap` run silently skipped the refresh.
- Fix: pick the freshest `target/{release,debug}` build as the install source and compare its **sha256 content** against the destination's — never path/process identity.
- Split `install_cli` into a new `cli_install.rs` module — required to keep `bootstrap.rs` under the repo's 800-line god-file ceiling after adding the fix + tests (848 lines pre-split). Small incidental head start on `backlog.d/129` child 4 (checks-crate diet), though the actual roster-cluster split that ticket tracks is separate work, not started here.
- Updated `check-harness-install-paths`' file list in `lint_gates.rs` to scan the new `cli_install.rs` module too.

## Test plan

- [x] 3 new fixture tests (`cli_install::tests`): stale-installed-vs-fresh-debug-build refresh, identical-content skip (asserts mtime untouched — a true no-op, not just idempotent), release-preferred-over-debug-when-newer.
- [x] **Live bug reproduction, then live fix verification** (not just unit tests): with the pre-fix installed binary, running its own `bootstrap` against a `target/debug` build with different content still reported "already current" — bug reproduced exactly as described in the ticket. After installing the fix, running the *newly-installed, now-fixed* binary's own `bootstrap` against a simulated newer `target/debug` build correctly detected the mismatch and refreshed itself (verified via sha256 before/after).
- [x] `cargo test --locked -p harness-kit-checks` — 139/139 pass.
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` green (all 21 gate lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)