### PR TITLE
chore(backlog): import overnight refill tickets

### DIFF
--- a/backlog.d/135-fix-dead-grill-me-reference-post-cull.md
+++ b/backlog.d/135-fix-dead-grill-me-reference-post-cull.md
@@ -1,0 +1,40 @@
+# Fix dead petekp-grill-me reference in interrogate-first.md
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+Remove or replace the dangling reference to the culled `petekp-grill-me`
+vendored skill in `harnesses/shared/references/interrogate-first.md`, left
+behind by tonight's zero-use vendored skill cull (backlog 127, `_done/`).
+
+## Oracle
+
+- [ ] `harnesses/shared/references/interrogate-first.md:5-7` no longer cites
+      `skills/.external/petekp-grill-me/SKILL.md` as a live exemplar (the
+      directory is confirmed gone from `skills/.external/`).
+- [ ] The "interview, not questionnaire" posture keeps its exemplar sentence —
+      either point it at a first-party skill that still embodies the stance
+      (`/shape`'s grill step, per `skills/shape/SKILL.md:98`, was named as the
+      redundant survivor in the cull's own evidence) or drop the file
+      reference and keep the prose description.
+- [ ] `grep -rn "petekp-grill-me" harnesses/ skills/ docs/` returns nothing
+      outside `backlog.d/_done/` and `.evidence/`.
+- [ ] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
+
+## Notes
+
+This file is loaded as shared, always-on reference material
+(`harnesses/shared/references/`), not a one-off doc — a dangling path to a
+deleted skill is exactly the kind of stale doctrine the repo's own gates
+(`check-no-claims`, portable-paths family) are supposed to catch, but this
+one is prose-only and slipped through since no gate checks reference-file
+prose against `skills/.external/` contents.
+
+**Why:** verified live — `test -d skills/.external/petekp-grill-me` returns
+false (directory absent, confirming the cull landed), while `grep -n
+"petekp-grill-me" harnesses/shared/references/interrogate-first.md` still
+returns the citation at lines 5-6. This is the only surviving dead reference
+found in a full repo grep for all six culled aliases (mattpocock suite,
+steipete-skill-cleaner, openai-gh-address-comments, openai-gh-fix-ci,
+petekp-grill-me, every-ce-dogfood-beta) across `*.md`/`*.yaml`/`*.rs`.

--- a/backlog.d/136-codebase-md-stale-post-crate-split.md
+++ b/backlog.d/136-codebase-md-stale-post-crate-split.md
@@ -1,0 +1,42 @@
+# Update CODEBASE.md for the harness-kit-hooks / harness-kit-roster split
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+Bring `CODEBASE.md`'s "The Rust Crate" section back in sync with the
+checks-crate diet (backlog 129, `_done/`, closed tonight): `claude_hooks` and
+the `agent_roster`/`lane_harness`/`source_refs`/`summarize_delegations`
+cluster no longer live in `crates/harness-kit-checks` — they moved to
+`crates/harness-kit-hooks` and `crates/harness-kit-roster` respectively.
+
+## Oracle
+
+- [ ] `CODEBASE.md`'s crate section lists three crates
+      (`harness-kit-checks`, `harness-kit-hooks`, `harness-kit-roster`)
+      matching `ls crates/`, each with its actual module contents.
+- [ ] The `git_hooks` + `claude_hooks` bullet (currently `CODEBASE.md:45-47`)
+      is corrected: `git_hooks` stays in `harness-kit-checks`
+      (pre-commit/pre-push/etc. dispatch), `claude_hooks` moved to
+      `harness-kit-hooks`.
+- [ ] The `agent_roster` + `lane_harness` + `source_refs` +
+      `summarize_delegations` bullet (currently `CODEBASE.md:53-55`) is moved
+      under a `harness-kit-roster` heading.
+- [ ] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
+
+## Notes
+
+Confirmed live: `ls crates/` shows `harness-kit-checks`, `harness-kit-hooks`,
+`harness-kit-roster`; `grep -rn "harness_kit_checks::claude_hooks\|harness_kit_checks::agent_roster"`
+across `*.rs`/`*.md`/`*.sh` returns nothing, i.e. the split itself is clean —
+only the prose map in `CODEBASE.md` still describes the pre-split boundary.
+129's own closing note (`backlog.d/_done/129-diet-checks-crate-boundaries.md`)
+reports the post-split LOC count (12.3k/24 files, down from 18.1k/26) but the
+PR that landed the split (#147, #154 per `git log`) did not touch
+`CODEBASE.md`, so the source-of-truth map is now the one place still
+describing the old, pre-diet crate boundary.
+
+**Why:** `CODEBASE.md` is the file a cold agent reads first to understand
+crate ownership; it currently tells that agent to look for `claude_hooks` and
+`agent_roster` inside `harness-kit-checks`, which is now false and will send
+the next session down the wrong module path.

--- a/backlog.d/137-retire-stale-project-md.md
+++ b/backlog.d/137-retire-stale-project-md.md
@@ -1,0 +1,39 @@
+# Retire or fold stale project.md into VISION.md/README
+
+Priority: P3 · Status: ready · Estimate: S
+
+## Goal
+
+Resolve the duplicate, stale north-star document at repo-root `project.md` —
+it predates the current `VISION.md` and still carries pre-June themes
+(rebrand, "remove global static agents," Antigravity framing) that no longer
+match the shipped repo.
+
+## Oracle
+
+- [ ] `project.md` is either deleted (its live content is fully superseded by
+      `VISION.md` + `README.md`) or reduced to a stub pointer at `VISION.md`
+      — pick one and state which in the PR, do not leave both as competing
+      sources of truth.
+- [ ] Anything in `project.md`'s "Domain Glossary" section still accurate and
+      not already covered by `CODEBASE.md`/`README.md` is preserved
+      (migrated, not silently dropped).
+- [ ] No remaining file references `project.md` as the current vision/status
+      doc (`grep -rn "project.md" --include='*.md' .` reviewed by hand).
+- [ ] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
+
+## Notes
+
+Confirmed live: `project.md`'s "Current Focus" line reads "Rebrand, remove
+global static agents, and make skills + AGENTS.md the durable layer" — themes
+`git log` shows resolved months ago (harness-kit v2 Mode A/B consolidation,
+917b152a). `VISION.md` (root) is the actively maintained, richly cross-linked
+north star (`Where The Depth Lives` section, 35 doctrine commits/month per
+tonight's earlier groom teardown) and has fully superseded `project.md`'s
+role.
+
+**Why:** the teardown that seeded tonight's decisions flagged this exact file
+("`project.md` claims 'last updated 2026-03-16,' content is pre-June themes
+… delete it or fold into VISION.md/README") as a docs-staleness finding; it
+was not in the decisions-overlay action list for tonight and remains
+unresolved on the live tree as of this grooming pass.

--- a/backlog.d/138-document-bootstrap-bundle-flag.md
+++ b/backlog.d/138-document-bootstrap-bundle-flag.md
@@ -1,0 +1,39 @@
+# Document bootstrap --bundle/--dry-run in the README Quick Start
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+
+Role-scoped bootstrap bundles (backlog 130, landed tonight — `.harness-kit/bundles.yaml`,
+`bootstrap --bundle NAME [--dry-run]`) shipped with zero mention in
+`README.md`. A cold operator or agent following the README's Quick Start has
+no way to discover the feature exists.
+
+## Oracle
+
+- [ ] `README.md`'s Quick Start section documents `--bundle NAME` and
+      `--dry-run` alongside the existing bootstrap one-liner, naming the
+      available bundles (`lead`, `implementer`, `critic`, `designer`,
+      `vault`) and the default (full catalog, unchanged) behavior when the
+      flag is omitted.
+- [ ] The doc states the measured effect from 130's own oracle (full catalog
+      ~21.4k description bytes vs. ~4-8k per bundle) so the value proposition
+      is legible without reading `bundles.yaml`.
+- [ ] `cargo run --locked -p harness-kit-checks -- bootstrap --help` output
+      and the README stay consistent (cross-check by hand, not just gate).
+- [ ] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
+
+## Notes
+
+Confirmed live: `harness-kit-checks --help` lists
+`bootstrap [--repo PATH] [--bundle NAME] [--dry-run]` as a real, working
+flag; `grep -rn "bundle" README.md CODEBASE.md bootstrap.sh` returns nothing.
+`backlog.d/130-role-scoped-bootstrap-bundles.md` itself is still
+`Status: in-progress` (child 5 — telemetry-driven default correction — is the
+only remaining gap) and its own notes call this "opt-in only until usage
+evidence exists," which makes discoverability the actual blocker to that
+usage evidence ever accumulating.
+
+**Why:** a feature that reduces standing session tax by 60-81% (130's own
+measured numbers) is unreachable by any reader who only follows the README —
+the single most-read entry point for a cold clone.

--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -51,6 +51,22 @@
     {
       "source": "backlog.d/132-greenfield-template-ci.md",
       "title": "Declare and verify the greenfield Factory template"
+    },
+    {
+      "source": "backlog.d/135-fix-dead-grill-me-reference-post-cull.md",
+      "title": "Fix dead petekp-grill-me reference in interrogate-first.md"
+    },
+    {
+      "source": "backlog.d/136-codebase-md-stale-post-crate-split.md",
+      "title": "Update CODEBASE.md for the harness-kit-hooks / harness-kit-roster split"
+    },
+    {
+      "source": "backlog.d/137-retire-stale-project-md.md",
+      "title": "Retire or fold stale project.md into VISION.md/README"
+    },
+    {
+      "source": "backlog.d/138-document-bootstrap-bundle-flag.md",
+      "title": "Document bootstrap --bundle/--dry-run in the README Quick Start"
     }
   ],
   "copy_source": "docs/copy/site.json",


### PR DESCRIPTION
## Summary

Imports 4 tickets from tonight's refill sweep, no ID collisions with the live backlog (highest existing was 133):

- **135** — dead `petekp-grill-me` reference left in `harnesses/shared/references/interrogate-first.md` after tonight's vendored-skill cull (backlog 127).
- **136** — `CODEBASE.md`'s crate map is stale after tonight's `harness-kit-hooks`/`harness-kit-roster` split (backlog 129).
- **137** — retire or fold the stale root `project.md` (pre-June themes, superseded by `VISION.md`).
- **138** — README Quick Start never documents `bootstrap --bundle/--dry-run` (backlog 130), so the feature is undiscoverable from a cold clone.

All four are real, live-verified, P2/P3, S-estimate — no renumbering needed.

## Test plan

- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` green.
- [x] `docs/site` regenerated (backlog listing feeds the generated site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)