### PR TITLE
docs(interrogate-first): fix dead petekp-grill-me reference

### DIFF
--- a/backlog.d/_done/135-fix-dead-grill-me-reference-post-cull.md
+++ b/backlog.d/_done/135-fix-dead-grill-me-reference-post-cull.md
@@ -1,6 +1,6 @@
 # Fix dead petekp-grill-me reference in interrogate-first.md
 
-Priority: P2 · Status: ready · Estimate: S
+Priority: P2 (shipped) · Status: done · Estimate: S · Shipped: 2026-07-02
 
 ## Goal
 
@@ -10,17 +10,23 @@ behind by tonight's zero-use vendored skill cull (backlog 127, `_done/`).
 
 ## Oracle
 
-- [ ] `harnesses/shared/references/interrogate-first.md:5-7` no longer cites
+- [x] `harnesses/shared/references/interrogate-first.md:5-7` no longer cites
       `skills/.external/petekp-grill-me/SKILL.md` as a live exemplar (the
       directory is confirmed gone from `skills/.external/`).
-- [ ] The "interview, not questionnaire" posture keeps its exemplar sentence —
+- [x] The "interview, not questionnaire" posture keeps its exemplar sentence —
       either point it at a first-party skill that still embodies the stance
       (`/shape`'s grill step, per `skills/shape/SKILL.md:98`, was named as the
       redundant survivor in the cull's own evidence) or drop the file
-      reference and keep the prose description.
-- [ ] `grep -rn "petekp-grill-me" harnesses/ skills/ docs/` returns nothing
-      outside `backlog.d/_done/` and `.evidence/`.
-- [ ] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
+      reference and keep the prose description. (Repointed to
+      `skills/shape/SKILL.md` — `/shape` loads this reference and is the
+      primary consumer of the stance, not a co-equal external exemplar.)
+- [x] `grep -rn "petekp-grill-me" harnesses/ skills/ docs/` returns nothing
+      outside `backlog.d/_done/` and `.evidence/`. (One hit remains,
+      `docs/site/manifest.json` — the generated backlog index echoing this
+      ticket's own title text, not a doctrine reference; the actual
+      `interrogate-first.md` citation is gone, confirmed by a targeted grep
+      against that file alone.)
+- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
 
 ## Notes
 

--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -53,10 +53,6 @@
       "title": "Declare and verify the greenfield Factory template"
     },
     {
-      "source": "backlog.d/135-fix-dead-grill-me-reference-post-cull.md",
-      "title": "Fix dead petekp-grill-me reference in interrogate-first.md"
-    },
-    {
       "source": "backlog.d/136-codebase-md-stale-post-crate-split.md",
       "title": "Update CODEBASE.md for the harness-kit-hooks / harness-kit-roster split"
     },

--- a/harnesses/shared/references/interrogate-first.md
+++ b/harnesses/shared/references/interrogate-first.md
@@ -2,9 +2,9 @@
 
 Use before shaping a contestable idea or framing a strategic groom. The posture
 is an interview, not a questionnaire: walk the operator down the decision tree
-until the hidden choices are visible and resolved. The vendored `grill-me` skill
-(`skills/.external/petekp-grill-me/SKILL.md`) is the named exemplar of this
-stance.
+until the hidden choices are visible and resolved. `/shape`'s own grill step
+(`skills/shape/SKILL.md`) loads this reference and is the primary consumer of
+the stance.
 
 1. **One question at a time.** Never batch. Each answer reshapes the next
    question; a wall of questions is a form, and forms get skimmed.


### PR DESCRIPTION
## Summary

Closes backlog.d/135. The vendored `petekp-grill-me` skill was culled (backlog 127), leaving `interrogate-first.md` pointing at a deleted `SKILL.md` as its named exemplar. Repointed to `skills/shape/SKILL.md`, the actual primary consumer that loads this reference — the file itself is the canonical spec `/shape`'s grill step follows, not a co-equal external exemplar.

## Test plan

- [x] `grep -n "petekp-grill-me\|grill-me" harnesses/shared/references/interrogate-first.md` returns nothing.
- [x] Only remaining repo-wide hit is `docs/site/manifest.json` echoing this ticket's own title text in the generated backlog index — not a doctrine reference.
- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)