### PR TITLE
docs(README): document bootstrap --bundle/--dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ is already on `PATH`. Bootstrap from a stable checkout (set
 `HARNESS_KIT_DIR=/path/to/harness-kit` to pin one), never a disposable
 worktree.
 
+By default bootstrap installs the full skill catalog (51 skills, ~21.4k
+description bytes standing in every session's system prompt). Pass
+`--bundle NAME` for a role-scoped subset instead — same install, fewer
+skills:
+
+```bash
+harness-kit-checks bootstrap --bundle lead        # 11 skills, ~5.2k bytes
+harness-kit-checks bootstrap --bundle implementer # 12 skills, ~5.2k bytes
+harness-kit-checks bootstrap --bundle critic       # 10 skills, ~4.2k bytes
+harness-kit-checks bootstrap --bundle designer     # 21 skills, ~7.8k bytes
+harness-kit-checks bootstrap --bundle vault        #  8 skills, ~4.0k bytes
+```
+
+Add `--dry-run` to preview the projected skill count and byte estimate
+without touching the filesystem (works with or without `--bundle`).
+Bundles are opt-in — omitting `--bundle` keeps today's full-catalog
+behavior unchanged; membership is defined in `.harness-kit/bundles.yaml`
+(backlog 130).
+
 ## Skills
 
 | Skill | Purpose |

--- a/backlog.d/_done/138-document-bootstrap-bundle-flag.md
+++ b/backlog.d/_done/138-document-bootstrap-bundle-flag.md
@@ -1,6 +1,6 @@
 # Document bootstrap --bundle/--dry-run in the README Quick Start
 
-Priority: P2 · Status: ready · Estimate: S
+Priority: P2 (shipped) · Status: done · Estimate: S · Shipped: 2026-07-02
 
 ## Goal
 
@@ -11,17 +11,22 @@ no way to discover the feature exists.
 
 ## Oracle
 
-- [ ] `README.md`'s Quick Start section documents `--bundle NAME` and
+- [x] `README.md`'s Quick Start section documents `--bundle NAME` and
       `--dry-run` alongside the existing bootstrap one-liner, naming the
       available bundles (`lead`, `implementer`, `critic`, `designer`,
       `vault`) and the default (full catalog, unchanged) behavior when the
       flag is omitted.
-- [ ] The doc states the measured effect from 130's own oracle (full catalog
+- [x] The doc states the measured effect from 130's own oracle (full catalog
       ~21.4k description bytes vs. ~4-8k per bundle) so the value proposition
-      is legible without reading `bundles.yaml`.
-- [ ] `cargo run --locked -p harness-kit-checks -- bootstrap --help` output
+      is legible without reading `bundles.yaml`. (Used fresh live numbers
+      from `bootstrap --bundle <name> --dry-run` for all 5 bundles rather
+      than trusting 130's possibly-stale estimate: full catalog is 51
+      skills/~21471 bytes; bundles range 8–21 skills/~4.0–7.8k bytes today.)
+- [x] `cargo run --locked -p harness-kit-checks -- bootstrap --help` output
       and the README stay consistent (cross-check by hand, not just gate).
-- [ ] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
+      (`--help`'s usage line reads `bootstrap [--repo PATH] [--bundle NAME]
+      [--dry-run]` — README's flag names/casing match exactly.)
+- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` passes.
 
 ## Notes
 

--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -51,10 +51,6 @@
     {
       "source": "backlog.d/132-greenfield-template-ci.md",
       "title": "Declare and verify the greenfield Factory template"
-    },
-    {
-      "source": "backlog.d/138-document-bootstrap-bundle-flag.md",
-      "title": "Document bootstrap --bundle/--dry-run in the README Quick Start"
     }
   ],
   "copy_source": "docs/copy/site.json",


### PR DESCRIPTION
## Summary

Closes backlog.d/138. Role-scoped bootstrap bundles (backlog 130) shipped tonight with zero mention in `README.md` — a cold operator following the Quick Start had no way to discover the feature exists, which was itself the blocker to the usage evidence 130's own notes say bundles need before they can become a default.

Documented all 5 bundles with fresh live numbers from `bootstrap --bundle <name> --dry-run` rather than trusting a possibly-stale estimate: full catalog is 51 skills/~21.4k description bytes; bundles range 8–21 skills/~4.0–7.8k bytes. Cross-checked flag names against `--help`'s actual usage line by hand, not just the gate.

## Test plan

- [x] `README.md`'s Quick Start now documents `--bundle NAME`/`--dry-run`, all 5 bundle names, and the measured byte savings.
- [x] Flag names/casing verified against `harness-kit-checks bootstrap --help`'s real usage line.
- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)