### PR TITLE
docs(verification): codify the live-diff pattern for coverage-poor refactors

### DIFF
--- a/backlog.d/_done/115-live-diff-refactor-verification.md
+++ b/backlog.d/_done/115-live-diff-refactor-verification.md
@@ -1,8 +1,9 @@
 # Context Packet: Document the "live-diff" verification pattern for behavior-preserving refactors
 
-Priority: P2
-Status: shaped
+Priority: P2 (shipped)
+Status: done
 Estimate: S
+Shipped: 2026-07-02
 
 ## PRD Summary
 - User: any agent running `/deliver` or `/qa` on a behavior-preserving
@@ -68,3 +69,20 @@ Estimate: S
 - Origin detail for whoever writes it: Habitat HA-034 close-out evidence —
   modules/cycles/sprints list GETs (21/4/10 rows) + a detail GET + a bogus-id
   404, all byte-identical local-branch vs prod against the shared DB.
+
+## Resolution
+
+**2026-07-02 — shipped.** New "Live-Diff For Behavior-Preserving Refactors"
+subsection added to `harnesses/shared/references/verification-system-first.md`
+(placed after "What Counts", before "Design Rules") covering when/how/why-it-
+bites/precondition-and-limits/pair-don't-replace exactly as specified, phrased
+in the file's own claim/falsifier/grader vocabulary (deployed build = grader's
+reference oracle, the diff = the falsifier), closing with the real Habitat
+HA-034 evidence from the ticket's own Notes.
+
+P1 cross-links added to both named skills, not just one: `/deliver`'s
+"Refactor at three altitudes" section (the natural point-of-use — refactors
+are exactly where this pattern applies) and `/qa`'s Gotchas section (a new
+bullet next to the existing "Generic QA is a stopgap" gotcha, since QAing a
+coverage-poor refactor is precisely the failure mode both bullets address).
+`cargo run --locked -p harness-kit-checks -- check --repo .` green.

--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -5,10 +5,6 @@
       "title": "Context Packet: Harness eval bench against raw runs and alternative primitives"
     },
     {
-      "source": "backlog.d/115-live-diff-refactor-verification.md",
-      "title": "Context Packet: Document the \"live-diff\" verification pattern for behavior-preserving refactors"
-    },
-    {
       "source": "backlog.d/116-opencode-review-runner-bakeoff.md",
       "title": "Context Packet: Evaluate OpenCode as the code-review runner substrate"
     },

--- a/harnesses/shared/references/verification-system-first.md
+++ b/harnesses/shared/references/verification-system-first.md
@@ -45,6 +45,39 @@ Use multiple systems when one boundary cannot see the failure. Unit tests,
 typechecks, and lint catch structural regressions; QA, evals, benchmarks, and
 probes catch failures at runtime, judgment, scale, or integration boundaries.
 
+## Live-Diff For Behavior-Preserving Refactors
+
+When the oracle is "identical to before" and the target has no
+characterization tests to pin current behavior (extract-to-module,
+route-thinning, dedup, lifts), "unit tests pass" cannot catch the seam a lift
+most often breaks — the integration between the refactored layer and its real
+dependencies, which unit tests mock away.
+
+**Technique:** exercise the same representative inputs against (a) the local
+refactor branch and (b) the deployed or pre-refactor build, both pointed at
+the same backing store. Diff responses byte-for-byte, including error and
+not-found paths, not just the happy path. Identical responses across the set
+= behavior preserved; any divergence is the bug, located precisely at the
+diverging input. In verification-system terms: the deployed/pre-refactor
+build is the grader's reference oracle; the diff itself is the falsifier.
+
+**Precondition:** the pre-refactor behavior must still be runnable against the
+same data — a deployed prod instance, a pinned build, or `git stash` + rerun
+locally.
+
+**Does not apply when:** the refactor is meant to change output (pin a golden
+instead); or for write-path side effects, since a read-only diff says nothing
+about them — diff those via post-state reads or a transaction-scoped probe.
+
+**Pair, don't replace.** Live-diff is the integration net; keep
+repository/unit tests as the structural net underneath it.
+
+Proven live 2026-06-17/18 on a 6-route rewrite with zero route-level tests:
+repository unit tests plus a before/after live diff (local branch vs deployed
+prod, same backing store → byte-identical list/detail/404 responses across
+representative reads) was the only thing that actually proved the rewrite
+preserved behavior.
+
 ## Design Rules
 
 - **Falsifiability first.** A system that passes when the values are wrong is

--- a/index.yaml
+++ b/index.yaml
@@ -1,5 +1,5 @@
 # Harness Kit Index
-# Generated: 2026-07-02T04:15:50Z
+# Generated: 2026-07-02T05:08:52Z
 # Do not edit manually. Run: harness-kit-checks generate-index --repo .
 
 skills:

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -81,7 +81,12 @@ the claim is checkable after you're gone.
 
 ## Refactor at three altitudes
 
-With working code in hand, ask at each level — and act on what you find:
+With working code in hand, ask at each level — and act on what you find. When
+the refactor must prove it changed *nothing observable* and the target has no
+characterization tests, "unit tests pass" cannot see the seam a lift most
+often breaks — reach for the live-diff pattern in
+`harnesses/shared/references/verification-system-first.md` (diff the local
+branch against the deployed/pre-refactor build over the same backing store).
 
 1. **The diff.** Would we write it this way from scratch? Duplicate code to
    DRY out? Conditionals to collapse? Slop to delete (unnecessary comments,

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -89,5 +89,11 @@ that fresh pass-claim attack.
   first (shared AGENTS.md, Layer 1) — don't just file the gap. Build it by
   interviewing the operator: the manual checks they run before merging are
   the spec. Ad-hoc QA evaporates; a harness compounds.
+- **QAing a behavior-preserving refactor with no characterization tests?**
+  "Tests pass" proves nothing when there are no tests pinning the current
+  behavior. Reach for the live-diff pattern in
+  `harnesses/shared/references/verification-system-first.md`: diff the local
+  branch against the deployed/pre-refactor build over the same backing store,
+  byte-for-byte, including error paths.
 - Browser tool selection and evidence conventions: `references/browser-tools.md`,
   `references/evidence-capture.md`.


### PR DESCRIPTION
## Summary

Closes backlog.d/115. The verification-system-first reference covered building a driver + grader for *new* behavior, but the hardest refactors — lifts, route-thinning, dedup — have no characterization tests to pin current behavior, so "unit tests pass" cannot catch the seam a lift most often breaks: the integration between the refactored layer and its real dependencies, which unit tests mock away.

- New "Live-Diff For Behavior-Preserving Refactors" subsection in `harnesses/shared/references/verification-system-first.md`: diff the local branch against the deployed/pre-refactor build over the same backing store, byte-for-byte including error/404 paths — the deployed build is the grader's reference oracle, the diff is the falsifier. Names the precondition, the limits (doesn't apply when output is meant to change; read-only diff says nothing about write-path side effects), and pairs it with unit tests rather than replacing them. Closes with the real Habitat HA-034 evidence from the ticket's own notes.
- Cross-linked from both named skills: `/deliver`'s "Refactor at three altitudes" (the natural point of use) and `/qa`'s Gotchas (next to the existing "Generic QA is a stopgap" bullet — QAing a coverage-poor refactor is exactly this failure mode).

## Test plan

- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` green.
- [x] `docs/site` regenerated (reference feeds the generated site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)