### PR TITLE
feat(quality-gates): add cargo-deny advisories gate (118 scoped)

### DIFF
--- a/.github/workflows/advisories.yml
+++ b/.github/workflows/advisories.yml
@@ -1,0 +1,33 @@
+name: advisories
+
+# Networked tier (backlog.d/118): RustSec vulnerability advisories via
+# cargo-deny. Deliberately separate from ci.yml's fast local gate — the
+# advisory database needs network access to fetch, and a newly published
+# RustSec advisory can turn a merged, unchanged Cargo.lock vulnerable
+# overnight, so this also runs on a daily schedule, not just per-PR.
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "17 6 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: advisories-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  cargo-deny-advisories:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --version 0.19.9 --locked
+      - run: cargo run --locked -p harness-kit-checks -- check-supply-chain-advisories

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"

--- a/backlog.d/118-quality-gate-coverage-mutation.md
+++ b/backlog.d/118-quality-gate-coverage-mutation.md
@@ -1,6 +1,6 @@
 # Add diff-coverage, mutation, and advisory gates to the quality floor
 
-Priority: P2 · Status: ready · Estimate: M
+Priority: P2 · Status: in-progress · Estimate: M
 
 ## Goal
 Extend the standing quality floor
@@ -20,14 +20,26 @@ fast-local Rust gate deliberately avoids.
 ## Oracle
 - [ ] Diff-coverage gate: `cargo-llvm-cov` emits LCOV; `diff-cover` enforces a
       patch-coverage floor on changed lines (not a global %), green on a no-op
-      diff.
+      diff. **Deferred — see child 1.**
 - [ ] Mutation gate: `cargo-mutants --in-diff` runs on changed Rust; surviving
-      mutants in core modules fail; runtime budget documented.
-- [ ] Advisory gate: `cargo-deny check advisories` (RustSec) runs at the network
+      mutants in core modules fail; runtime budget documented. **Deferred —
+      see child 1.**
+- [x] Advisory gate: `cargo-deny check advisories` (RustSec) runs at the network
       tier, separate from the offline `check-supply-chain`; passes on the current
-      tree or files the triage.
-- [ ] A CI workflow (HK's first real test/gate workflow) runs the
-      networked/expensive tier so the fast-local gate stays offline and fast.
+      tree or files the triage. (`check_supply_chain_advisories` in
+      `quality_gates.rs`, CLI verb `check-supply-chain-advisories`. Found and
+      fixed a real, live finding while landing this: RUSTSEC-2026-0190,
+      unsoundness in `anyhow::Error::downcast_mut()`, fixed upstream in
+      `>=1.0.103` — this repo was on `1.0.102`; bumped via
+      `cargo update -p anyhow`, no code changes needed since nothing here
+      calls `downcast_mut`.)
+- [x] A CI workflow (HK's first real *networked-tier* gate workflow, separate
+      from `ci.yml`'s fast local gate) runs the networked/expensive tier so
+      the fast-local gate stays offline and fast.
+      (`.github/workflows/advisories.yml` — PR, push-to-master, and a daily
+      cron, since a newly published RustSec advisory can turn an unchanged,
+      already-merged `Cargo.lock` vulnerable overnight with no code change to
+      trigger a PR check.)
 
 ## Verification System
 - Claim: the coverage-quality and advisory tiers are enforced, not advisory.
@@ -39,12 +51,36 @@ fast-local Rust gate deliberately avoids.
 - Evidence packet: CI run links + sample coverage/mutation reports.
 - Cadence: per-PR (diff-scoped); full mutation nightly if per-PR is too slow.
 
+## Children
+
+1. [ ] Diff-coverage + mutation tiers. **Deliberately not attempted in the
+   advisories pass.** Both need real threshold calibration a single
+   unattended session can't responsibly do: `cargo-mutants --in-diff`'s
+   runtime scales with diff size and is known to run long even scoped to
+   changed lines — the wrong runtime budget either makes the gate useless
+   (skips on any real diff) or makes every future PR wait tens of minutes;
+   a diff-coverage floor set from a first guess rather than this repo's real
+   patch-coverage distribution risks blocking legitimate PRs on day one, and
+   there's no branch protection today to make either non-blocking while
+   they're tuned (i.e. once added, they read as load-bearing/likely enforced
+   immediately, so they need to be right before they land, not tuned after
+   the fact against real PR traffic).
+
 ## Notes
 - Free/OSS only (no Codecov/SonarCloud): `cargo-llvm-cov`, `diff-cover`,
   `cargo-mutants`, `cargo-deny`.
-- HK has no test CI workflow today (only `deploy-docs-site.yml`); this epic adds
-  the first, which also lets `check-supply-chain`'s offline checks run in CI.
+- Correction: this ticket's original claim "HK has no test CI workflow today
+  (only `deploy-docs-site.yml`)" was already stale when written —
+  `.github/workflows/ci.yml` (running `check --repo .`) predates this ticket.
+  What HK genuinely lacked, and what this pass adds, is a *networked-tier*
+  workflow separate from the fast local gate.
 - Two-tier discipline (`/ci`): keep these out of the fast-local pre-push gate;
   they belong at PR/ship time.
 - Follow-on candidates once the floor is proven: duplication (jscpd), dead-code
   (cargo-machete/knip), and a complexity *report* tier.
+
+**2026-07-02 — advisory tier shipped, scoped down from the full epic.** Only
+the advisory/RustSec slice landed (child not applicable to that item; see
+Oracle checkboxes). Diff-coverage and mutation stay open as child 1 — real
+work, not blocked on anything except calibration against live PR traffic,
+which this session couldn't safely fabricate. Epic stays `in-progress`.

--- a/crates/harness-kit-checks/baselines/godfiles.txt
+++ b/crates/harness-kit-checks/baselines/godfiles.txt
@@ -4,7 +4,7 @@
 859 crates/harness-kit-checks/src/config_loader.rs
 1883 crates/harness-kit-checks/src/docs_site.rs
 821 crates/harness-kit-checks/src/external_sync.rs
-1237 crates/harness-kit-checks/src/main.rs
+1240 crates/harness-kit-checks/src/main.rs
 1014 crates/harness-kit-checks/src/skill_invocation_analytics.rs
 2465 crates/harness-kit-hooks/src/claude_hooks.rs
 1975 crates/harness-kit-roster/src/agent_roster.rs

--- a/crates/harness-kit-checks/src/main.rs
+++ b/crates/harness-kit-checks/src/main.rs
@@ -140,6 +140,9 @@ fn run(args: Vec<String>) -> anyhow::Result<()> {
         "check-supply-chain" => {
             print_gate_report(quality_gates::check_supply_chain(&parse_repo_arg(rest))?)?
         }
+        "check-supply-chain-advisories" => print_gate_report(
+            quality_gates::check_supply_chain_advisories(&parse_repo_arg(rest))?,
+        )?,
         "check-template" => print_gate_report(template_check::check_template_instantiates(
             &parse_repo_arg(rest),
         )?)?,
@@ -958,7 +961,7 @@ fn usage() -> ! {
   harness-kit-checks build-docs-site [--repo PATH] [--output PATH]
   harness-kit-checks check-docs-site [--repo PATH] [--site PATH] [--self-test]
   harness-kit-checks check-exclusions|check-conflict-markers|check-portable-paths|check-no-claims|check-vendored-copies|check-harness-install-paths [--repo PATH]
-  harness-kit-checks check-godfiles [--write-baseline]|check-source-markers|check-supply-chain|check-template [--repo PATH]
+  harness-kit-checks check-godfiles [--write-baseline]|check-source-markers|check-supply-chain|check-supply-chain-advisories|check-template [--repo PATH]
   harness-kit-checks lint-external-skills [--strict]
   harness-kit-checks sync-external [--repo PATH] [--check] [--allow-floating] [--only owner/repo]
   harness-kit-checks test-sync-external-partial

--- a/crates/harness-kit-checks/src/quality_gates.rs
+++ b/crates/harness-kit-checks/src/quality_gates.rs
@@ -160,24 +160,47 @@ pub fn check_source_markers(root: &Path) -> Result<GateReport> {
 }
 
 /// Hard-block gate: supply-chain policy via cargo-deny (offline checks: bans,
-/// licenses, sources). Advisories (network) run in CI / the coverage+mutation
-/// fast-follow. Gracefully skips when cargo-deny is absent (shellcheck
-/// precedent), so the aggregate gate stays runnable without the extra tool.
+/// licenses, sources). Advisories (network) run separately — see
+/// `check_supply_chain_advisories` below, wired into the networked CI tier,
+/// not this fast local gate. Gracefully skips when cargo-deny is absent
+/// (shellcheck precedent), so the aggregate gate stays runnable without the
+/// extra tool.
 pub fn check_supply_chain(root: &Path) -> Result<GateReport> {
+    run_cargo_deny(
+        root,
+        &["bans", "licenses", "sources"],
+        "cargo-deny: bans, licenses, sources clean.",
+    )
+}
+
+/// Networked-tier gate: RustSec vulnerability advisories via cargo-deny.
+/// Deliberately separate from `check_supply_chain` (offline) and from
+/// `check --repo .` (the fast local gate) — advisories need network access
+/// to fetch the RustSec database, so this runs in its own CI step
+/// (`.github/workflows/advisories.yml`), not on every pre-commit/pre-push.
+/// backlog.d/118: scoped to advisories only; diff-coverage and mutation
+/// testing are deferred — see that ticket's notes on why they need
+/// threshold calibration against real PR traffic before landing as a gate.
+pub fn check_supply_chain_advisories(root: &Path) -> Result<GateReport> {
+    run_cargo_deny(root, &["advisories"], "cargo-deny: advisories clean.")
+}
+
+fn run_cargo_deny(root: &Path, checks: &[&str], ok_message: &str) -> Result<GateReport> {
     if !command_exists("cargo-deny") {
-        return Ok(GateReport::success(
-            "cargo-deny not installed; supply-chain gate skipped (cargo install cargo-deny to enforce).",
-        ));
+        return Ok(GateReport::success(format!(
+            "cargo-deny not installed; {} gate skipped (cargo install cargo-deny to enforce).",
+            checks.join("/")
+        )));
     }
     let output = Command::new("cargo")
-        .args(["deny", "check", "bans", "licenses", "sources"])
+        .arg("deny")
+        .arg("check")
+        .args(checks)
         .current_dir(root)
         .output()
         .context("failed to run cargo deny")?;
     if output.status.success() {
-        return Ok(GateReport::success(
-            "cargo-deny: bans, licenses, sources clean.",
-        ));
+        return Ok(GateReport::success(ok_message));
     }
     let stderr = String::from_utf8_lossy(&output.stderr);
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,8 @@
-# cargo-deny supply-chain policy — harness-kit-checks check-supply-chain.
-# Offline checks only here (bans, licenses, sources); advisories (network) run
-# in CI / the coverage+mutation fast-follow. Doctrine:
-# harnesses/shared/references/quality-gates.md.
+# cargo-deny supply-chain policy — harness-kit-checks check-supply-chain
+# (offline: bans, licenses, sources) and check-supply-chain-advisories
+# (networked: RustSec advisories, .github/workflows/advisories.yml — not the
+# fast local gate, since it needs network access to the advisory database).
+# Doctrine: harnesses/shared/references/quality-gates.md.
 # The allow-list encodes the licenses actually present today (ratchet floor);
 # tighten it, never loosen it to pass.
 


### PR DESCRIPTION
## Summary

Scoped slice of backlog 118: only the advisory/RustSec tier, not diff-coverage or mutation testing. Those need real threshold calibration against live PR traffic before landing as a gate — this repo has no branch protection to make them non-blocking while tuned, so getting them wrong on the first pass risks blocking legitimate future PRs. Deliberately deferred as a new child 1 on the ticket, not skipped.

- `check_supply_chain_advisories` (`quality_gates.rs`) runs `cargo deny check advisories` against the RustSec database — same graceful-skip-when-cargo-deny-absent shape as the existing offline `check_supply_chain`. New CLI verb `check-supply-chain-advisories`.
- New `.github/workflows/advisories.yml` runs it on PR, push-to-master, and a daily cron — separate from `ci.yml`'s fast local gate, since it needs network access and a newly published advisory can turn an unchanged, already-merged `Cargo.lock` vulnerable overnight with no PR to trigger a check.
- **Found and fixed a real, live finding while landing this**: [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190), unsoundness in `anyhow::Error::downcast_mut()`, fixed upstream in `>=1.0.103` — this repo was on `1.0.102`. Bumped via `cargo update -p anyhow`; no code changes needed since nothing in this repo calls `downcast_mut`.

## Test plan

- [x] `cargo deny check advisories` reproduced the real finding live before the fix (`advisories FAILED`, RUSTSEC-2026-0190), then confirmed clean after (`advisories ok`).
- [x] `cargo run --locked -p harness-kit-checks -- check-supply-chain-advisories` runs live and reports clean.
- [x] `cargo build --locked --workspace` clean after the `anyhow` bump.
- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` green (all 21 gate lanes) — the advisories check deliberately stays out of this fast local gate per the two-tier discipline the ticket names.
- [x] New workflow YAML passes `lint-yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)