### PR TITLE
fix(external-sync): fix root-skill sparse checkout, decompose git plumbing

### DIFF
--- a/backlog.d/122-root-skill-vendoring-followups.md
+++ b/backlog.d/122-root-skill-vendoring-followups.md
@@ -1,6 +1,6 @@
 # Root-skill vendoring follow-ups (from the herdr cross-model review)
 
-Priority: P3 · Status: open · Estimate: S
+Priority: P3 · Status: in-progress · Estimate: S
 
 ## Goal
 Three improvements to the root-level external-skill vendoring shipped in 120
@@ -15,20 +15,46 @@ earns its own small change.
    silently break. Add an explicit `skill_includes: [paths]` field for
    `skill_name` sources rather than a name-based heuristic (the first cut wrongly
    swept herdr's app `assets/`/`scripts/`). Until then, root skills must be
-   single-file + license.
+   single-file + license. **Deliberately deferred, not attempted.** Speculative
+   schema addition for a root skill that doesn't exist yet — no current source
+   needs `skill_includes`, and the ticket's own fallback ("until then, root
+   skills must be single-file + license") is a genuinely acceptable interim
+   state, not a real gap. Building the field now would be designing a schema
+   around a hypothetical future consumer. Revisit when a real root-skill source
+   actually needs companion files.
 
-2. **Sparse-checkout the skill files, not the whole app.** For `skills_path: "."`,
-   `set_sparse` disables sparse, so each root-skill sync clones the full upstream
-   working tree into the (gitignored) `_checkouts` cache — for herdr, the entire
-   Rust app. Sparse-checkout just `SKILL.md` (+ LICENSE), or fetch via `git
-   show`, to keep the cache minimal. Correctness is unaffected; disk/time only.
-
-3. **Decompose `external_sync.rs` production logic.** The file mixes registry
+2. [x] **Sparse-checkout the skill files, not the whole app.** For
+   `skills_path: "."`, `set_sparse` disables sparse, so each root-skill sync
+   clones the full upstream working tree into the (gitignored) `_checkouts`
+   cache — for herdr, the entire Rust app. Sparse-checkout just `SKILL.md`
+   (+ LICENSE), or fetch via `git show`, to keep the cache minimal.
+   Correctness is unaffected; disk/time only.
+   (Root cause found live: `git clone --filter=blob:none --sparse` already
+   defaults cone-mode sparse-checkout to top-level-files-only — the bug was
+   that `set_sparse`'s `"."` branch actively called `sparse-checkout disable`,
+   undoing that default and pulling the whole tree. Fix: `sparse-checkout set`
+   with no path args, which re-asserts top-level-only explicitly and
+   idempotently regardless of prior sparse state on a reused cached checkout.
+   Live-verified against the real herdr checkout, not a synthetic fixture:
+   re-ran `sync-external --only ogulcancelik/herdr` against the existing
+   already-fully-cloned 44M cache — shrank to 12M, working tree now shows only
+   top-level files, no `src/`/`.github/`/subdirectory content. Vendored output
+   (`skills/.external/herdr-herdr/SKILL.md` + `LICENSE`) confirmed
+   byte-identical via `git status` before/after.)
+3. [x] **Decompose `external_sync.rs` production logic.** The file mixes registry
    parsing, git plumbing (`ensure_checkout`/`set_sparse`/`resolve_ref_to_sha`/
    `checkout_sha`), install, and cleanup. The 120 change tripped the god-file
    ratchet; extracting the inline tests to `external_sync_tests.rs` bought
    headroom but did not decompose the production logic (~800 lines, near the 850
    baseline). Extract the git-plumbing helpers into a submodule as a real cut.
+   (New `external_sync_git.rs` submodule — `ensure_checkout`, `set_sparse`,
+   `resolve_ref_to_sha`, `checkout_sha`, and their shared `run_checked` helper
+   — registered via `#[path = ...] mod git;`, same convention this file
+   already used for its own test submodule. `external_sync.rs` dropped from
+   821 to 716 lines — comfortably under the general 800-line ceiling, so its
+   god-file baseline entry was removed entirely rather than just updated;
+   `check-godfiles` no longer needs to grandfather it. All 8 existing
+   `external_sync` tests pass unmodified.)
 
 ## Non-Goals
 - Reworking the vendoring of herdr itself (shipped, correct, gate-green).
@@ -37,3 +63,9 @@ earns its own small change.
 Filed from the `Closes-backlog: 120` cross-model review (grok-4.3, 2026-06-24):
 items 1, 2, and the production-decomposition half of item 4. License/idempotency/
 bail-and-collision logic were reviewed and confirmed sound.
+
+**2026-07-02 — items 2 and 3 shipped; item 1 stays deliberately deferred.**
+Epic stays `in-progress` — item 1 has no current consumer and its own
+fallback behavior is acceptable, so there's nothing blocking it, just
+nothing yet motivating it. Re-open the item when a real root-skill source
+needs companion files.

--- a/crates/harness-kit-checks/baselines/godfiles.txt
+++ b/crates/harness-kit-checks/baselines/godfiles.txt
@@ -3,7 +3,6 @@
 # Regenerate intentionally: harness-kit-checks check-godfiles --write-baseline
 859 crates/harness-kit-checks/src/config_loader.rs
 1883 crates/harness-kit-checks/src/docs_site.rs
-821 crates/harness-kit-checks/src/external_sync.rs
 1240 crates/harness-kit-checks/src/main.rs
 1014 crates/harness-kit-checks/src/skill_invocation_analytics.rs
 2465 crates/harness-kit-hooks/src/claude_hooks.rs

--- a/crates/harness-kit-checks/src/external_sync.rs
+++ b/crates/harness-kit-checks/src/external_sync.rs
@@ -9,6 +9,9 @@ use regex::Regex;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+#[path = "external_sync_git.rs"]
+mod git;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SyncMode {
     Sync,
@@ -398,11 +401,11 @@ fn sync_source(
         );
     }
 
-    let checkout_dir = ensure_checkout(checkout_root, &source.repo)?;
-    set_sparse(&checkout_dir, &source.skills_path)?;
+    let checkout_dir = git::ensure_checkout(checkout_root, &source.repo)?;
+    git::set_sparse(&checkout_dir, &source.skills_path)?;
     let want_ref = source.pin.as_deref().unwrap_or(&source.ref_name);
-    let sha = resolve_ref_to_sha(&checkout_dir, want_ref)?;
-    checkout_sha(&checkout_dir, &sha)?;
+    let sha = git::resolve_ref_to_sha(&checkout_dir, want_ref)?;
+    git::checkout_sha(&checkout_dir, &sha)?;
     // Repo root of the checkout — the license fallback for subdir skills whose
     // upstream keeps a single LICENSE at the root rather than in each skill dir.
     let license_root = checkout_dir.clone();
@@ -474,106 +477,6 @@ fn sync_source(
         if options.mode == SyncMode::Sync {
             carry_license(&external_root.join(&alias), &license_root)?;
         }
-    }
-    Ok(())
-}
-
-fn ensure_checkout(checkout_root: &Path, repo: &str) -> Result<PathBuf> {
-    let dir = checkout_root.join(slugify_repo(repo));
-    if !dir.join(".git").is_dir() {
-        fs::create_dir_all(checkout_root)?;
-        let url = format!("https://github.com/{repo}.git");
-        run_checked(
-            Command::new("git")
-                .args(["clone", "--filter=blob:none", "--sparse", &url])
-                .arg(&dir),
-            &format!("clone failed: {url} (unreachable or auth required)"),
-        )?;
-    }
-    Ok(dir)
-}
-
-fn set_sparse(dir: &Path, skills_path: &str) -> Result<()> {
-    if skills_path == "." || skills_path.is_empty() {
-        let _ = Command::new("git")
-            .args(["-C"])
-            .arg(dir)
-            .args(["sparse-checkout", "disable"])
-            .status();
-    } else {
-        run_checked(
-            Command::new("git")
-                .args(["-C"])
-                .arg(dir)
-                .args(["sparse-checkout", "set", skills_path]),
-            &format!(
-                "sparse-checkout failed in {} for {skills_path}",
-                dir.display()
-            ),
-        )?;
-    }
-    Ok(())
-}
-
-fn resolve_ref_to_sha(dir: &Path, ref_name: &str) -> Result<String> {
-    if Regex::new(r"^[0-9a-f]{40}$").unwrap().is_match(ref_name) {
-        return Ok(ref_name.to_string());
-    }
-    for pattern in [
-        format!("refs/tags/{ref_name}"),
-        format!("refs/heads/{ref_name}"),
-        ref_name.to_string(),
-    ] {
-        let output = Command::new("git")
-            .args(["-C"])
-            .arg(dir)
-            .args(["ls-remote", "origin", &pattern])
-            .output()
-            .with_context(|| format!("failed to resolve ref '{ref_name}' in {}", dir.display()))?;
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            if let Some(sha) = stdout
-                .lines()
-                .filter_map(|line| line.split_whitespace().next())
-                .find(|sha| !sha.is_empty())
-            {
-                return Ok(sha.to_string());
-            }
-        }
-    }
-    bail!("cannot resolve ref '{ref_name}' in {}", dir.display());
-}
-
-fn checkout_sha(dir: &Path, sha: &str) -> Result<()> {
-    let shallow = Command::new("git")
-        .args(["-C"])
-        .arg(dir)
-        .args(["fetch", "--depth=1", "--filter=blob:none", "origin", sha])
-        .status();
-    let fetched = shallow.is_ok_and(|status| status.success())
-        || Command::new("git")
-            .args(["-C"])
-            .arg(dir)
-            .args(["fetch", "--filter=blob:none", "origin"])
-            .status()
-            .is_ok_and(|status| status.success());
-    if !fetched {
-        bail!("fetch failed in {}", dir.display());
-    }
-    let checked_out = Command::new("git")
-        .args(["-C"])
-        .arg(dir)
-        .args(["checkout", "--quiet", sha])
-        .status()
-        .is_ok_and(|status| status.success())
-        || Command::new("git")
-            .args(["-C"])
-            .arg(dir)
-            .args(["checkout", "--quiet", "-B", "harness-kit-sync", sha])
-            .status()
-            .is_ok_and(|status| status.success());
-    if !checked_out {
-        bail!("checkout {sha} failed in {}", dir.display());
     }
     Ok(())
 }
@@ -787,14 +690,6 @@ fn sorted_dirs(root: &Path) -> Result<Vec<PathBuf>> {
     }
     dirs.sort();
     Ok(dirs)
-}
-
-fn run_checked(command: &mut Command, message: &str) -> Result<()> {
-    let status = command.status().with_context(|| message.to_string())?;
-    if !status.success() {
-        bail!("{message}");
-    }
-    Ok(())
 }
 
 fn ensure_command(name: &str) -> Result<()> {

--- a/crates/harness-kit-checks/src/external_sync_git.rs
+++ b/crates/harness-kit-checks/src/external_sync_git.rs
@@ -1,0 +1,134 @@
+//! Git plumbing for `external_sync`: clone/sparse-checkout/resolve/checkout
+//! against an upstream repo cache. Split out of `external_sync.rs`
+//! (backlog.d/122 item 3) purely to keep that file under the god-file
+//! ceiling — registry parsing, staging, and cleanup stay there; the raw git
+//! subprocess calls live here.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+
+use super::slugify_repo;
+
+pub(super) fn ensure_checkout(checkout_root: &Path, repo: &str) -> Result<PathBuf> {
+    let dir = checkout_root.join(slugify_repo(repo));
+    if !dir.join(".git").is_dir() {
+        std::fs::create_dir_all(checkout_root)?;
+        let url = format!("https://github.com/{repo}.git");
+        run_checked(
+            Command::new("git")
+                .args(["clone", "--filter=blob:none", "--sparse", &url])
+                .arg(&dir),
+            &format!("clone failed: {url} (unreachable or auth required)"),
+        )?;
+    }
+    Ok(dir)
+}
+
+pub(super) fn set_sparse(dir: &Path, skills_path: &str) -> Result<()> {
+    if skills_path == "." || skills_path.is_empty() {
+        // A root-level skill (`stage_root_skill`) needs only SKILL.md + a
+        // license file, both top-level. `ensure_checkout`'s clone already
+        // sets cone-mode sparse-checkout to top-level-files-only by default
+        // (`git clone --sparse`'s own behavior) — disabling it here, as this
+        // branch used to, actively undoes that and checks out the entire
+        // upstream working tree (verified live: for a Rust app source, this
+        // pulled the whole crate tree into the gitignored `_checkouts`
+        // cache). `sparse-checkout set` with no path args re-asserts
+        // top-level-only explicitly and idempotently, regardless of
+        // whatever sparse state a prior sync of this same cached checkout
+        // (possibly for a different skills_path) left behind.
+        run_checked(
+            Command::new("git")
+                .args(["-C"])
+                .arg(dir)
+                .args(["sparse-checkout", "set"]),
+            &format!("sparse-checkout failed in {} for root skill", dir.display()),
+        )?;
+    } else {
+        run_checked(
+            Command::new("git")
+                .args(["-C"])
+                .arg(dir)
+                .args(["sparse-checkout", "set", skills_path]),
+            &format!(
+                "sparse-checkout failed in {} for {skills_path}",
+                dir.display()
+            ),
+        )?;
+    }
+    Ok(())
+}
+
+pub(super) fn resolve_ref_to_sha(dir: &Path, ref_name: &str) -> Result<String> {
+    if Regex::new(r"^[0-9a-f]{40}$").unwrap().is_match(ref_name) {
+        return Ok(ref_name.to_string());
+    }
+    for pattern in [
+        format!("refs/tags/{ref_name}"),
+        format!("refs/heads/{ref_name}"),
+        ref_name.to_string(),
+    ] {
+        let output = Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .args(["ls-remote", "origin", &pattern])
+            .output()
+            .with_context(|| format!("failed to resolve ref '{ref_name}' in {}", dir.display()))?;
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Some(sha) = stdout
+                .lines()
+                .filter_map(|line| line.split_whitespace().next())
+                .find(|sha| !sha.is_empty())
+            {
+                return Ok(sha.to_string());
+            }
+        }
+    }
+    bail!("cannot resolve ref '{ref_name}' in {}", dir.display());
+}
+
+pub(super) fn checkout_sha(dir: &Path, sha: &str) -> Result<()> {
+    let shallow = Command::new("git")
+        .args(["-C"])
+        .arg(dir)
+        .args(["fetch", "--depth=1", "--filter=blob:none", "origin", sha])
+        .status();
+    let fetched = shallow.is_ok_and(|status| status.success())
+        || Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .args(["fetch", "--filter=blob:none", "origin"])
+            .status()
+            .is_ok_and(|status| status.success());
+    if !fetched {
+        bail!("fetch failed in {}", dir.display());
+    }
+    let checked_out = Command::new("git")
+        .args(["-C"])
+        .arg(dir)
+        .args(["checkout", "--quiet", sha])
+        .status()
+        .is_ok_and(|status| status.success())
+        || Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .args(["checkout", "--quiet", "-B", "harness-kit-sync", sha])
+            .status()
+            .is_ok_and(|status| status.success());
+    if !checked_out {
+        bail!("checkout {sha} failed in {}", dir.display());
+    }
+    Ok(())
+}
+
+fn run_checked(command: &mut Command, message: &str) -> Result<()> {
+    let status = command.status().with_context(|| message.to_string())?;
+    if !status.success() {
+        bail!("{message}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Scoped slice of backlog 122 (items 2–3). Item 1 (`skill_includes` companion-file field) stays deliberately deferred — speculative schema for a root skill that doesn't exist yet, no current consumer, and the code's own comment already documents this as an acceptable interim state.

**Item 2**: for `skills_path: "."` root-skill sources, `set_sparse` called `git sparse-checkout disable`, which undoes the cone-mode top-level-files-only default `git clone --sparse` already sets and pulls the entire upstream working tree into the gitignored `_checkouts` cache — for herdr, the whole Rust app. Fix: `sparse-checkout set` with no path args, which re-asserts top-level-only explicitly and idempotently regardless of prior sparse state on a reused cached checkout.

**Item 3**: `external_sync.rs` mixed registry parsing, git plumbing, install, and cleanup, sitting near the god-file ceiling. Extracted `ensure_checkout`/`set_sparse`/`resolve_ref_to_sha`/`checkout_sha` and their shared `run_checked` helper into a new `external_sync_git.rs` submodule — the same `#[path = ...]` convention the file already used for its own test submodule.

## Test plan

- [x] **Live-verified against the real herdr checkout, not a synthetic fixture**: re-ran `sync-external --only ogulcancelik/herdr` against the existing already-fully-cloned 44M cache — shrank to 12M, working tree now shows only top-level files (no `src/`/`.github/`/subdirectory content). Vendored output (`skills/.external/herdr-herdr/SKILL.md` + `LICENSE`) confirmed byte-identical before/after via `git status`.
- [x] `external_sync.rs` dropped from 821 to 716 lines — comfortably under the general 800-line ceiling, so its god-file baseline entry was removed entirely rather than updated.
- [x] All 8 existing `external_sync` tests pass unmodified.
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` green (all 21 gate lanes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)