### PR TITLE
feat(artifact): scoped relay for the Bridge's inline answer form

### DIFF
--- a/skills/artifact/scripts/artifact_serve.py
+++ b/skills/artifact/scripts/artifact_serve.py
@@ -5,9 +5,27 @@ Hermes-independent replacement for hermes_artifact_server.py. Serves
 ~/artifacts/public on 127.0.0.1:<port>; Tailscale `serve` maps
 https://<host>.ts.net/artifacts -> this. Zero LLM tokens; stdlib only.
 Directory requests resolve to index.html.
+
+Also carries one scoped relay route, /api/bridge-answer, so the Bridge
+page (~/.factory-lanes/scripts/bridge.py) can let the operator answer a
+NEEDS YOU question from a text box instead of a copy-pasted curl command.
+The relay forwards to exactly one upstream shape -- POST a powder run
+answer -- using a key read server-side; it is not a general proxy.
+/api/bridge-refresh re-runs bridge.py so the page reflects the answer.
 """
-import argparse, os, functools
+import argparse
+import functools
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
 from http.server import ThreadingHTTPServer, SimpleHTTPRequestHandler
+
+HOME = os.path.expanduser("~")
+BRIDGE_KEY_PATH = os.path.join(HOME, ".factory-lanes", ".powder-bridge-key")
+BRIDGE_SCRIPT = os.path.join(HOME, ".factory-lanes", "scripts", "bridge.py")
+POWDER_BASE = "http://127.0.0.1:14030"
 
 
 class Handler(SimpleHTTPRequestHandler):
@@ -17,6 +35,62 @@ class Handler(SimpleHTTPRequestHandler):
 
     def log_message(self, *args):  # quiet
         pass
+
+    def do_POST(self):
+        if self.path == "/api/bridge-answer":
+            return self._bridge_answer()
+        self.send_error(404)
+
+    def do_GET(self):
+        if self.path == "/api/bridge-refresh":
+            return self._bridge_refresh()
+        return super().do_GET()
+
+    def _bridge_answer(self):
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        try:
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            return self._json(400, {"error": "invalid json"})
+        run_id = str(body.get("run_id") or "").strip()
+        answer = str(body.get("answer") or "").strip()
+        actor = str(body.get("actor") or "operator").strip()
+        if not run_id or not answer:
+            return self._json(400, {"error": "run_id and answer are required"})
+        try:
+            key = open(BRIDGE_KEY_PATH).read().strip()
+        except OSError as err:
+            return self._json(500, {"error": f"no bridge key: {err}"})
+        req = urllib.request.Request(
+            f"{POWDER_BASE}/api/v1/runs/{run_id}/answer",
+            data=json.dumps({"actor": actor, "answer": answer}).encode(),
+            method="POST",
+        )
+        req.add_header("Authorization", f"Bearer {key}")
+        req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req, timeout=8) as resp:
+                return self._json(resp.status, json.loads(resp.read()))
+        except urllib.error.HTTPError as err:
+            return self._json(err.code, json.loads(err.read() or b"{}"))
+        except (urllib.error.URLError, TimeoutError) as err:
+            return self._json(502, {"error": f"powder unreachable: {err}"})
+
+    def _bridge_refresh(self):
+        r = subprocess.run(
+            ["python3", BRIDGE_SCRIPT], capture_output=True, text=True, timeout=30
+        )
+        if r.returncode != 0:
+            return self._json(500, {"error": (r.stderr or r.stdout).strip()[:500]})
+        return self._json(200, {"ok": True})
+
+    def _json(self, status, payload):
+        data = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
 
 
 def main():


### PR DESCRIPTION
## Summary
- Adds two routes to the stdlib-only artifact server (`skills/artifact/scripts/artifact_serve.py`): `POST /api/bridge-answer` relays exactly one upstream shape (a powder run answer), reading the bridge key server-side so it never reaches the browser; `GET /api/bridge-refresh` re-runs `bridge.py` so the page reflects the answer immediately.
- Companion change in `factory-ops` (`scripts/bridge.py`, pushed separately) replaces the curl-only NEEDS YOU workflow with an inline textarea + Answer button, collapses the curl one-liner as a fallback, and gates the "open in board" link on a live-at-generation-time check of the powder-ui board route.
- Not a general proxy: the relay only ever calls the one upstream answer endpoint; no other powder API surface is reachable through it.

## Test plan
- [x] `cargo run --locked -p harness-kit-checks -- check --repo .` — full gate green (lint, frontmatter, docs, supply-chain, cargo fmt/test/clippy)
- [x] Restarted `com.phaedrus.artifacts` launchd service; confirmed static serving still 200s locally (`127.0.0.1:8789/a/bridge/`) and via Tailscale (`serenity.tail5f5eb4.ts.net/artifacts/a/bridge/`)
- [x] Round-tripped a throwaway powder card through the actual relay endpoint (simulated the browser form's POST): answer landed in powder (`"answered by operator: ..."` activity), `bridge-poll.py` emitted the `{"type":"answer",...}` event on the next poll
- [x] Verified relay input validation (400 on invalid JSON / missing fields, 502 shape on upstream unreachable)
- [x] Test cards abandoned via powder's `status` transition; `.bridge-poll-state` restored to the pre-test baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)