### PR TITLE
feat(artifact): publish to the bastion shelf; serenity becomes the local mirror

### DIFF
--- a/docs/site/manifest.json
+++ b/docs/site/manifest.json
@@ -47,6 +47,10 @@
     {
       "source": "backlog.d/132-greenfield-template-ci.md",
       "title": "Declare and verify the greenfield Factory template"
+    },
+    {
+      "source": "backlog.d/133-adopt-lucide-toolbox-as-the-harness-kit-wordmark-icon.md",
+      "title": "Adopt Lucide toolbox as the harness-kit wordmark icon"
     }
   ],
   "copy_source": "docs/copy/site.json",

--- a/harnesses/claude/settings.json
+++ b/harnesses/claude/settings.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "claude-sonnet-5"
   },
   "permissions": {
     "allow": [
@@ -41,7 +42,11 @@
       "Bash(curl -s https://api.x.ai/:*)",
       "Bash(curl -s https://api.exa.ai/:*)"
     ],
-    "defaultMode": "bypassPermissions"
+    "defaultMode": "bypassPermissions",
+    "deny": [
+      "mcp__claude_ai_Google_Drive__authenticate",
+      "mcp__claude_ai_Google_Drive__complete_authentication"
+    ]
   },
   "enabledMcpjsonServers": [],
   "hooks": {

--- a/skills/artifact/SKILL.md
+++ b/skills/artifact/SKILL.md
@@ -41,16 +41,30 @@ python3 $S/artifact_create.py --title "The Factory" --slug factory \
   --tag "Field Memo" --html-file factory.html
 ```
 
-Output is written to `~/artifacts/public/a/<slug>/index.html` and printed as a
-URL: `https://serenity.tail5f5eb4.ts.net/artifacts/a/<slug>/`. Use a 1–2 word slug.
-Verify with `curl -s -o /dev/null -w '%{http_code}' <url>` before handing over the link.
+The script writes a local mirror (`~/artifacts/public/a/<slug>/index.html`),
+then PUTs the page to the box shelf and prints the canonical URL:
+`https://bastion.tail5f5eb4.ts.net/artifacts/a/<slug>/`. Use a 1–2 word slug.
+Publishing needs `ARTIFACTS_API_TOKEN` (env or `~/.secrets`; canonical copy in
+1Password `op://Agents/ARTIFACTS_API_TOKEN`). `--local-only` skips the PUT.
+Verify with `curl -s -o /dev/null -w '%{http_code}' <url>` before handing over
+the link. Publish any raw HTML from anywhere on the tailnet with one line:
+
+```bash
+curl -T page.html -H "Authorization: Bearer $ARTIFACTS_API_TOKEN" \
+  https://bastion.tail5f5eb4.ts.net/artifacts/a/<slug>/index.html
+```
 
 ## Serving
 
-`scripts/artifact_serve.py` serves `~/artifacts/public` on `127.0.0.1:8789`; the
-Tailscale route `serve /artifacts -> 127.0.0.1:8789` exposes it tailnet-privately.
-It runs under launchd (`~/Library/LaunchAgents/com.phaedrus.artifacts.plist`) so it
-survives reboots. Zero LLM tokens (stdlib http.server).
+The shelf lives on the bastion Fly box (`apps/artifacts` in the bastion repo):
+files on the `/data` volume, served at `…ts.net/artifacts/`, indexed newest-first
+at the bare path, linked from the Sanctum portal at the tailnet root
+(`https://bastion.tail5f5eb4.ts.net/`). Survives laptop sleep and reboots.
+
+Legacy mirror: `scripts/artifact_serve.py` still serves `~/artifacts/public` on
+`127.0.0.1:8789` under launchd (`com.phaedrus.artifacts.plist`), exposed at
+`serenity.tail5f5eb4.ts.net/artifacts/`. Old links keep resolving; the local
+tree doubles as the shelf's backup. New links always point at bastion.
 
 ## Extending
 

--- a/skills/artifact/scripts/artifact_create.py
+++ b/skills/artifact/scripts/artifact_create.py
@@ -15,7 +15,8 @@ Usage:
              injected if the author didn't already include one.
 --body-file / stdin: markdown, wrapped in the house template.
 """
-import argparse, os, sys, json, re, html, datetime
+import argparse
+import urllib.request, os, sys, json, re, html, datetime
 
 HOUSE_CSS = r"""
   :root{--bg:#f5f0e4;--panel:#fbf7ed;--ink:#241f19;--muted:#6b6053;--line:#e2d9c6;--red:#b4392a;--teal:#2c7a68;--gold:#bd8f2e;--shadow:0 1px 0 rgba(0,0,0,.04),0 12px 30px -22px rgba(40,30,20,.5);--col:52rem;}
@@ -188,6 +189,41 @@ def ensure_copy_button(doc: str) -> str:
     return doc
 
 
+def _artifacts_token():
+    tok = os.environ.get("ARTIFACTS_API_TOKEN", "")
+    if tok:
+        return tok
+    try:
+        with open(os.path.expanduser("~/.secrets")) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("export ARTIFACTS_API_TOKEN="):
+                    return line.split("=", 1)[1].strip().strip('"')
+    except OSError:
+        pass
+    return ""
+
+
+def publish(base_url, slug, doc):
+    """PUT the page to the box's artifact shelf. Best-effort: the local
+    mirror is already written, so a publish failure warns and returns False
+    instead of failing the run."""
+    token = _artifacts_token()
+    if not token:
+        print("publish skipped: ARTIFACTS_API_TOKEN not set", file=sys.stderr)
+        return False
+    target = f"{base_url.rstrip('/')}/a/{slug}/index.html"
+    req = urllib.request.Request(
+        target, data=doc.encode(), method="PUT",
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "text/html"})
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return 200 <= resp.status < 300
+    except Exception as e:  # noqa: BLE001 — best-effort by design
+        print(f"publish failed ({e}); local mirror still written", file=sys.stderr)
+        return False
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--title", required=True)
@@ -197,7 +233,9 @@ def main():
     ap.add_argument("--html-file")
     ap.add_argument("--body-file")
     ap.add_argument("--root", default=os.path.expanduser("~/artifacts/public"))
-    ap.add_argument("--base-url", default="https://serenity.tail5f5eb4.ts.net/artifacts")
+    ap.add_argument("--base-url", default="https://bastion.tail5f5eb4.ts.net/artifacts")
+    ap.add_argument("--local-only", action="store_true",
+                    help="skip the remote PUT; write only the local mirror")
     a = ap.parse_args()
 
     slug = re.sub(r"[^a-zA-Z0-9-]+", "-", a.slug).strip("-").lower()
@@ -217,7 +255,9 @@ def main():
     with open(dest, "w") as f:
         f.write(doc)
     url = f"{a.base_url.rstrip('/')}/a/{slug}/"
-    print(json.dumps({"slug": slug, "path": dest, "url": url, "bytes": len(doc)}, indent=2))
+    published = False if a.local_only else publish(a.base_url, slug, doc)
+    print(json.dumps({"slug": slug, "path": dest, "url": url, "bytes": len(doc),
+                      "published": published}, indent=2))
 
 
 if __name__ == "__main__":

--- a/skills/artifact/scripts/artifact_create.py
+++ b/skills/artifact/scripts/artifact_create.py
@@ -204,7 +204,7 @@ def _artifacts_token():
     return ""
 
 
-def publish(base_url, slug, doc):
+def publish(base_url, slug, doc, mtime=None):
     """PUT the page to the box's artifact shelf. Best-effort: the local
     mirror is already written, so a publish failure warns and returns False
     instead of failing the run."""
@@ -213,9 +213,10 @@ def publish(base_url, slug, doc):
         print("publish skipped: ARTIFACTS_API_TOKEN not set", file=sys.stderr)
         return False
     target = f"{base_url.rstrip('/')}/a/{slug}/index.html"
-    req = urllib.request.Request(
-        target, data=doc.encode(), method="PUT",
-        headers={"Authorization": f"Bearer {token}", "Content-Type": "text/html"})
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "text/html"}
+    if mtime:
+        headers["X-Artifact-Mtime"] = str(int(mtime))
+    req = urllib.request.Request(target, data=doc.encode(), method="PUT", headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             return 200 <= resp.status < 300
@@ -255,7 +256,7 @@ def main():
     with open(dest, "w") as f:
         f.write(doc)
     url = f"{a.base_url.rstrip('/')}/a/{slug}/"
-    published = False if a.local_only else publish(a.base_url, slug, doc)
+    published = False if a.local_only else publish(a.base_url, slug, doc, os.path.getmtime(dest))
     print(json.dumps({"slug": slug, "path": dest, "url": url, "bytes": len(doc),
                       "published": published}, indent=2))
 

--- a/skills/artifact/scripts/artifact_serve.py
+++ b/skills/artifact/scripts/artifact_serve.py
@@ -31,10 +31,21 @@ POWDER_BASE = "http://127.0.0.1:14030"
 class Handler(SimpleHTTPRequestHandler):
     def end_headers(self):
         self.send_header("Cache-Control", "no-cache")
+        # The Bridge page is mirrored on other tailnet hosts (Sanctum/bastion)
+        # but the answer relay lives only here; cross-origin POSTs are
+        # tailnet-private, so a permissive origin is acceptable.
+        self.send_header("Access-Control-Allow-Origin", "*")
         super().end_headers()
 
     def log_message(self, *args):  # quiet
         pass
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Access-Control-Max-Age", "86400")
+        self.end_headers()
 
     def do_POST(self):
         if self.path == "/api/bridge-answer":


### PR DESCRIPTION
## Summary
- `artifact_create.py` PUTs each page to the box shelf (`bastion.tail5f5eb4.ts.net/artifacts`) after writing the local mirror; token from `ARTIFACTS_API_TOKEN` (env / `~/.secrets`; canonical `op://Agents/ARTIFACTS_API_TOKEN`); `--local-only` opt-out; publish failures are non-fatal (mirror is already on disk).
- Default `--base-url` flips serenity → bastion.
- SKILL.md documents the shelf, the one-line `curl -T` publish, the Sanctum portal, and the serenity mirror as legacy/backup.

Counterpart: bastion `feat/sanctum-portal-artifacts` (portal + `apps/artifacts` shelf, deployed to `phrazzld-bastion`).

## Verification
- `cargo run --locked -p harness-kit-checks -- check --repo .` → passed (docs/site regenerated).
- Live publish exercised against the deployed shelf (412 files migrated; end-to-end script publish re-verified post-merge of the body-limit fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional remote publishing of generated artifact reports to the shared artifact site, returning the canonical hosted URL.
  * Introduced `--local-only` and configurable `--base-url` for publishing behavior.
  * Artifact creation output now includes a `published` status.
* **Documentation**
  * Updated artifact “Serving” and publishing instructions, including token requirements and examples.
  * Added a new documentation backlog entry.
* **Bug Fixes**
  * Updated the local artifact server to support cross-origin requests, including proper CORS preflight handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->