### PR TITLE
build(release): pin landmark@v0 and release with the workflow token

### DIFF
--- a/.github/workflows/landmark-release.yml
+++ b/.github/workflows/landmark-release.yml
@@ -32,9 +32,9 @@ jobs:
           persist-credentials: false
 
       - name: Run Landmark
-        uses: misty-step/landmark@v1
+        uses: misty-step/landmark@v0
         with:
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           node-version: "24"
           synthesis: "true"


### PR DESCRIPTION
Part of the fleet 0.x reset (Powder landmark-017). Landmark v0 line = pre-stable mode.

`GH_RELEASE_TOKEN` is expired and being retired; this workflow now releases with `${{ github.token }}` instead.

## Changes
- `.github/workflows/landmark-release.yml`: `misty-step/landmark@v1` -> `@v0`
- `.github/workflows/landmark-release.yml`: `github-token` now uses `${{ github.token }}` instead of `secrets.GH_RELEASE_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)