### PR TITLE
fix(skills): landmark@v0 pin + workflow-token release guidance

### DIFF
--- a/skills/.external/misty-landmark/SKILL.md
+++ b/skills/.external/misty-landmark/SKILL.md
@@ -25,9 +25,17 @@ agent-native contracts, or release-kit producer responsibilities.
 | Dry-run release analysis | `landmark run --provider local --dry-run` |
 | Install in a repo | `landmark setup` |
 | Fleet adoption | `fleet scan`, `fleet plan`, `fleet open-prs` |
-| GitHub Action use | `misty-step/landmark@v1` |
+| GitHub Action use | `misty-step/landmark@v0` |
 | Local development | `cargo run --locked -p landmark -- ...` |
 | Full repo gate | `bin/gate` |
+
+Landmark is pre-stable (0.x): repos below 1.0.0 stay on the `@v0` major-pin
+line until Landmark itself promotes to 1.0.0. See the landmark README's
+Versioning Philosophy section. Pass the Action's `github-token` input as
+`${{ github.token }}` — the default `GITHUB_TOKEN` — under a job (or
+workflow) `permissions` block granting `contents`/`issues`/`pull-requests`
+write; a PAT-backed secret is only needed when downstream automation must
+trigger further workflow runs.
 
 ## Operating Rules
 

--- a/skills/harness-engineering/templates/one-core-many-faces/.github/workflows/landmark-release.yml.tmpl
+++ b/skills/harness-engineering/templates/one-core-many-faces/.github/workflows/landmark-release.yml.tmpl
@@ -32,9 +32,9 @@ jobs:
           persist-credentials: false
 
       - name: Run Landmark
-        uses: misty-step/landmark@v1
+        uses: misty-step/landmark@v0
         with:
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           node-version: "24"
           synthesis: "true"


### PR DESCRIPTION
## Summary
- `skills/harness-engineering/templates/one-core-many-faces/.github/workflows/landmark-release.yml.tmpl`: this template's trigger is `workflow_run` (after `ci` completes) + `workflow_dispatch` — a general Landmark-owned-release workflow, not a `release: published`-only synthesis listener — so it stays (not deleted) and gets re-pinned `@v1` → `@v0`, with `github-token` switched from `${{ secrets.GH_RELEASE_TOKEN }}` to `${{ github.token }}`. It already carries a top-level `permissions: { contents: write, issues: write, pull-requests: write }` block, so no permissions change was needed.
- `skills/.external/misty-landmark/SKILL.md`: bumped the pin reference and added a short note on pre-stable mode + the default-token guidance.

## Important: this file is a vendored sync copy
`skills/.external/misty-landmark/SKILL.md` is pinned from `misty-step/landmark` at `393e15c2f816036c1edd0985696ba4d2a64772d4` per `registry.yaml` (`skill_name: landmark`, `skills_path: "."` — it mirrors landmark's own root `SKILL.md`, which [misty-step/landmark#207](https://github.com/misty-step/landmark/pull/207) already fixes at the source). This PR edits the vendored copy directly per the lane instructions, but per `registry.yaml`'s own doctrine ("Editing a vendored external makes it a fork — mark it here and stop syncing it"), this is a stopgap: once landmark#207 merges and the pin in `registry.yaml` is bumped, `sync-external` will re-pull the real fix from upstream. This PR is not the durable source of truth for that file.

## Test plan
- [x] Repo gate: `cargo run --locked -p harness-kit-checks -- check --repo .` — all 21 checks pass (`check: passed`), including `check-vendored-copies` and `check-template`.

Powder: landmark-017

🤖 Generated with [Claude Code](https://claude.com/claude-code)