### PR TITLE
fix(skills): shape template pins aesthetic v0.24.0

### DIFF
--- a/skills/shape/templates/html-plan.html
+++ b/skills/shape/templates/html-plan.html
@@ -7,7 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&amp;family=Geist+Mono:wght@100..900&amp;display=swap">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v2.5.1/aesthetic.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/misty-step/aesthetic@v0.24.0/aesthetic.css">
   <style>
     :root {
       --ae-accent: #2643d0;


### PR DESCRIPTION
## Summary
- Re-pin the shape skill's `html-plan.html` template's aesthetic CSS link from `@v2.5.1` to `@v0.24.0`.
- This is a forward-looking template that generates future planning artifacts, so it upgrades to the current kit version (not just a version-reset identity swap).

Context: fleet-wide aesthetic version reset 2.x → 0.x semantics (Powder landmark-017). Left `.evidence/**` and `.harness-kit/traces/**` archival plan outputs untouched — they're already-rendered HTML relying on the jsdelivr permanent cache, not templates.

## Test plan
- [x] Confirmed only the template file references the old pin; archival evidence HTML intentionally left alone
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)